### PR TITLE
Prevent duplicate entries in .docker/config.json

### DIFF
--- a/cmd/build-init/main.go
+++ b/cmd/build-init/main.go
@@ -55,7 +55,7 @@ func main() {
 	}
 
 	remoteImageFactory := &registry.ImageFactory{
-		KeychainFactory: defaultKeychainFactory{},
+		KeychainFactory: keychainFactory{builderCreds},
 	}
 
 	filePermissionSetup := &cnb.FilePermissionSetup{
@@ -76,11 +76,12 @@ func main() {
 	}
 }
 
-type defaultKeychainFactory struct {
+type keychainFactory struct {
+	keychain authn.Keychain
 }
 
-func (defaultKeychainFactory) KeychainForImageRef(registry.ImageRef) authn.Keychain {
-	return authn.DefaultKeychain
+func (k keychainFactory) KeychainForImageRef(registry.ImageRef) authn.Keychain {
+	return k.keychain
 }
 
 type realOs struct {
@@ -88,16 +89,4 @@ type realOs struct {
 
 func (realOs) Chown(volume string, uid, gid int) error {
 	return os.Chown(volume, uid, gid)
-}
-
-func fileExists(file string, logger *log.Logger) bool {
-	_, err := os.Stat(file)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false
-		}
-		logger.Fatal(err.Error())
-	}
-
-	return true
 }

--- a/pkg/dockercreds/docker_creds.go
+++ b/pkg/dockercreds/docker_creds.go
@@ -14,10 +14,8 @@ import (
 type DockerCreds map[string]entry
 
 func (c DockerCreds) Resolve(reg name.Registry) (authn.Authenticator, error) {
-	registryMatcher := RegistryMatcher{}
-
 	for registry, entry := range c {
-		if registryMatcher.Match(reg.RegistryStr(), registry) {
+		if RegistryMatch(reg.RegistryStr(), registry) {
 			if entry.Auth != "" {
 				return Auth(entry.Auth), nil
 			} else if entry.Username != "" {
@@ -82,7 +80,7 @@ func (c DockerCreds) contains(reg string) (bool, error) {
 	}
 
 	for existingRegistry := range c {
-		if (RegistryMatcher{}.Match(u.Host, existingRegistry)) {
+		if RegistryMatch(u.Host, existingRegistry) {
 			return true, nil
 		}
 	}

--- a/pkg/dockercreds/docker_creds.go
+++ b/pkg/dockercreds/docker_creds.go
@@ -2,11 +2,13 @@ package dockercreds
 
 import (
 	"encoding/json"
-	"github.com/pkg/errors"
 	"io/ioutil"
+	"net/url"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/pkg/errors"
 )
 
 type DockerCreds map[string]entry
@@ -36,7 +38,11 @@ func (c DockerCreds) AppendToDockerConfig(path string) error {
 		return err
 	}
 
-	appendedCreds := c.append(existingCreds)
+	appendedCreds, err := existingCreds.append(c)
+	if err != nil {
+		return err
+	}
+
 	configJson := dockerConfigJson{
 		Auths: appendedCreds,
 	}
@@ -47,15 +53,41 @@ func (c DockerCreds) AppendToDockerConfig(path string) error {
 	return ioutil.WriteFile(path, configJsonBytes, 0600)
 }
 
-func (c DockerCreds) append(a DockerCreds) DockerCreds {
+func (c DockerCreds) append(a DockerCreds) (DockerCreds, error) {
 	if c == nil {
-		return a
+		return a, nil
+	} else if a == nil {
+		return c, nil
 	}
 
 	for k, v := range a {
-		c[k] = v
+		if contains, err := c.contains(k); err != nil {
+			return nil, err
+		} else if !contains {
+			c[k] = v
+		}
 	}
-	return c
+
+	return c, nil
+}
+
+func (c DockerCreds) contains(reg string) (bool, error) {
+	if !strings.HasPrefix(reg, "http://") && !strings.HasPrefix(reg, "https://") {
+		reg = "//" + reg
+	}
+
+	u, err := url.Parse(reg)
+	if err != nil {
+		return false, err
+	}
+
+	for existingRegistry := range c {
+		if (RegistryMatcher{}.Match(u.Host, existingRegistry)) {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 type entry struct {

--- a/pkg/dockercreds/match.go
+++ b/pkg/dockercreds/match.go
@@ -17,10 +17,7 @@ var registryDomains = []string{
 	"http://%s/v2/",
 }
 
-type RegistryMatcher struct {
-}
-
-func (r RegistryMatcher) Match(parsedRegistry, registry string) bool {
+func RegistryMatch(parsedRegistry, registry string) bool {
 	for _, format := range registryDomains {
 		if fmt.Sprintf(format, parsedRegistry) == registry {
 			return true

--- a/pkg/dockercreds/match_test.go
+++ b/pkg/dockercreds/match_test.go
@@ -12,7 +12,7 @@ func TestMatch(t *testing.T) {
 }
 
 func testRegistryMatch(t *testing.T, when spec.G, it spec.S) {
-	when("#Match", func() {
+	when("#RegistryMatch", func() {
 		for _, regFormat := range []string{
 			// Allow naked domains
 			"reg.io",
@@ -26,17 +26,17 @@ func testRegistryMatch(t *testing.T, when spec.G, it spec.S) {
 			"http://reg.io/v2/",
 		} {
 			it("matches format "+regFormat, func() {
-				assert.True(t, RegistryMatcher{}.Match("reg.io", regFormat))
+				assert.True(t, RegistryMatch("reg.io", regFormat))
 			})
 
 			it("does not match other registries with "+regFormat, func() {
-				assert.False(t, RegistryMatcher{}.Match("gcr.io", regFormat))
+				assert.False(t, RegistryMatch("gcr.io", regFormat))
 			})
 		}
 
 		it("matches on dockerhub references", func() {
-			assert.True(t, RegistryMatcher{}.Match("index.docker.io", "http://index.docker.io"))
-			assert.True(t, RegistryMatcher{}.Match("index.docker.io", "index.docker.io"))
+			assert.True(t, RegistryMatch("index.docker.io", "http://index.docker.io"))
+			assert.True(t, RegistryMatch("index.docker.io", "index.docker.io"))
 		})
 	})
 }

--- a/pkg/dockercreds/parse_pull_secrets.go
+++ b/pkg/dockercreds/parse_pull_secrets.go
@@ -18,7 +18,7 @@ func ParseDockerPullSecrets(path string) (DockerCreds, error) {
 		return nil, err
 	}
 
-	return dockerCfg.append(dockerJson), nil
+	return dockerCfg.append(dockerJson)
 }
 
 func parseDockerCfg(path string) (DockerCreds, error) {
@@ -44,7 +44,10 @@ func parseDockerCfg(path string) (DockerCreds, error) {
 }
 
 func parseDockerConfigJson(path string) (DockerCreds, error) {
-	var config dockerConfigJson
+	config := dockerConfigJson{
+		Auths: map[string]entry{},
+	}
+
 	configjsonExists, err := fileExists(path)
 	if err != nil {
 		return nil, err

--- a/pkg/git/k8s_git_keychain.go
+++ b/pkg/git/k8s_git_keychain.go
@@ -19,7 +19,7 @@ func newK8sGitKeychain(k8sClient k8sclient.Interface) *k8sGitKeychain {
 	return &k8sGitKeychain{secretManager: secret.SecretManager{
 		Client:        k8sClient,
 		AnnotationKey: v1alpha1.GITSecretAnnotationPrefix,
-		Matcher:       gitUrlMatcher{},
+		Matcher:       gitUrlMatch,
 	}}
 }
 
@@ -40,9 +40,6 @@ func (k *k8sGitKeychain) Resolve(namespace, serviceAccount string, git v1alpha1.
 
 }
 
-type gitUrlMatcher struct {
-}
-
 var matchingDomains = []string{
 	// Allow naked domains
 	"%s",
@@ -51,7 +48,7 @@ var matchingDomains = []string{
 	"http://%s",
 }
 
-func (gitUrlMatcher) Match(urlMatch, annotatedUrl string) bool {
+func gitUrlMatch(urlMatch, annotatedUrl string) bool {
 	parseURL, err := url.Parse(urlMatch)
 	if err != nil {
 		return false

--- a/pkg/secret/secret_manager.go
+++ b/pkg/secret/secret_manager.go
@@ -17,9 +17,7 @@ type SecretManager struct {
 	Matcher       Matcher
 }
 
-type Matcher interface {
-	Match(url, annotatedUrl string) bool
-}
+type Matcher func(url, annotatedUrl string) bool
 
 func (m *SecretManager) SecretForServiceAccountAndURL(serviceAccount, namespace string, url string) (*URLAndUser, error) {
 	sa, err := m.Client.CoreV1().ServiceAccounts(namespace).Get(serviceAccount, meta_v1.GetOptions{})
@@ -43,7 +41,7 @@ func (m *SecretManager) secretForServiceAccount(account *v1.ServiceAccount, url 
 			return nil, err
 		}
 
-		if m.Matcher.Match(url, secret.ObjectMeta.Annotations[m.AnnotationKey]) {
+		if m.Matcher(url, secret.ObjectMeta.Annotations[m.AnnotationKey]) {
 			return secret, nil
 		}
 
@@ -81,7 +79,7 @@ func (m *SecretManager) SecretForImagePull(namespace, secretName, registryName s
 	}
 
 	for registry, registryAuth := range config.Auths {
-		if m.Matcher.Match(registryName, registry) {
+		if m.Matcher(registryName, registry) {
 			return registryAuth.Auth, nil
 		}
 	}

--- a/pkg/secret/secret_manager_test.go
+++ b/pkg/secret/secret_manager_test.go
@@ -27,7 +27,7 @@ func testSecretManager(t *testing.T, when spec.G, it spec.S) {
 
 		subject = secret.SecretManager{
 			Client:  fakeClient,
-			Matcher: fakeMatcher{},
+			Matcher: fakeMatch,
 		}
 	)
 
@@ -100,9 +100,6 @@ func testSecretManager(t *testing.T, when spec.G, it spec.S) {
 	})
 }
 
-type fakeMatcher struct {
-}
-
-func (fakeMatcher) Match(url, annotatedUrl string) bool {
+func fakeMatch(url, annotatedUrl string) bool {
 	return strings.Contains(annotatedUrl, url)
 }

--- a/pkg/secret/secrets_keychain.go
+++ b/pkg/secret/secrets_keychain.go
@@ -19,7 +19,7 @@ func NewSecretKeychainFactory(client k8sclient.Interface) *SecretKeychainFactory
 		secretManager: &SecretManager{
 			Client:        client,
 			AnnotationKey: v1alpha1.DOCKERSecretAnnotationPrefix,
-			Matcher:       dockercreds.RegistryMatcher{},
+			Matcher:       dockercreds.RegistryMatch,
 		},
 	}
 }


### PR DESCRIPTION
- build-init does not write the same registry to .docker/config.json if it already exists in a different format
- Use builderPullSecrets when fetching builder metadata in build-init

Signed-off-by: Joao Pereira <jdealmeidapereira@pivotal.io>