### PR TITLE
Update image status if builder is not ready

### DIFF
--- a/pkg/apis/build/v1alpha1/builder.go
+++ b/pkg/apis/build/v1alpha1/builder.go
@@ -42,3 +42,7 @@ func (b *Builder) HasSecret() bool {
 func (b *Builder) BuildpackMetadata() BuildpackMetadataList {
 	return b.Status.BuilderMetadata
 }
+
+func (b *Builder) GetName() string {
+	return b.ObjectMeta.Name
+}

--- a/pkg/apis/build/v1alpha1/cluster_builder.go
+++ b/pkg/apis/build/v1alpha1/cluster_builder.go
@@ -39,3 +39,7 @@ func (in *ClusterBuilder) Ready() bool {
 	return in.Status.GetCondition(duckv1alpha1.ConditionReady).IsTrue() &&
 		(in.Generation == in.Status.ObservedGeneration)
 }
+
+func (in *ClusterBuilder) GetName() string {
+	return in.ObjectMeta.Name
+}

--- a/pkg/apis/build/v1alpha1/image_builds.go
+++ b/pkg/apis/build/v1alpha1/image_builds.go
@@ -28,6 +28,7 @@ type AbstractBuilder interface {
 	ImageRef() BuilderImage
 	Ready() bool
 	BuildpackMetadata() BuildpackMetadataList
+	GetName() string
 }
 
 func (im *Image) buildNeeded(lastBuild *Build, sourceResolver *SourceResolver, builder AbstractBuilder) ([]string, bool) {

--- a/pkg/apis/build/v1alpha1/image_lifecycle.go
+++ b/pkg/apis/build/v1alpha1/image_lifecycle.go
@@ -22,14 +22,3 @@ func (im *Image) BuilderNotFound() duckv1alpha1.Conditions {
 		},
 	}
 }
-
-func (im *Image) BuilderNotReady() duckv1alpha1.Conditions {
-	return duckv1alpha1.Conditions{
-		{
-			Type:    duckv1alpha1.ConditionReady,
-			Status:  corev1.ConditionFalse,
-			Reason:  BuilderNotReady,
-			Message: fmt.Sprintf("Builder %s is not ready.", im.Spec.Builder.Name),
-		},
-	}
-}

--- a/pkg/apis/build/v1alpha1/image_lifecycle.go
+++ b/pkg/apis/build/v1alpha1/image_lifecycle.go
@@ -33,14 +33,3 @@ func (im *Image) BuilderNotReady() duckv1alpha1.Conditions {
 		},
 	}
 }
-
-func (b *Build) BuilderNotFound() duckv1alpha1.Conditions {
-	return duckv1alpha1.Conditions{
-		{
-			Type:    duckv1alpha1.ConditionSucceeded,
-			Status:  corev1.ConditionFalse,
-			Reason:  BuilderNotFound,
-			Message: fmt.Sprintf("Unable to find builder %s.", b.Spec.Builder.Image),
-		},
-	}
-}

--- a/pkg/apis/build/v1alpha1/image_lifecycle.go
+++ b/pkg/apis/build/v1alpha1/image_lifecycle.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	BuilderNotFound = "BuilderNotFound"
+	BuilderNotReady = "BuilderNotReady"
 )
 
 func (im *Image) BuilderNotFound() duckv1alpha1.Conditions {
@@ -18,6 +19,17 @@ func (im *Image) BuilderNotFound() duckv1alpha1.Conditions {
 			Status:  corev1.ConditionFalse,
 			Reason:  BuilderNotFound,
 			Message: fmt.Sprintf("Unable to find builder %s.", im.Spec.Builder.Name),
+		},
+	}
+}
+
+func (im *Image) BuilderNotReady() duckv1alpha1.Conditions {
+	return duckv1alpha1.Conditions{
+		{
+			Type:    duckv1alpha1.ConditionReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  BuilderNotReady,
+			Message: fmt.Sprintf("Builder %s is not ready.", im.Spec.Builder.Name),
 		},
 	}
 }

--- a/pkg/apis/build/v1alpha1/image_lifecycle.go
+++ b/pkg/apis/build/v1alpha1/image_lifecycle.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	BuilderNotFound = "BuilderNotFound"
+	BuilderNotReady = "BuilderNotReady"
 )
 
 func (im *Image) BuilderNotFound() duckv1alpha1.Conditions {

--- a/pkg/apis/build/v1alpha1/image_lifecycle.go
+++ b/pkg/apis/build/v1alpha1/image_lifecycle.go
@@ -9,7 +9,6 @@ import (
 
 const (
 	BuilderNotFound = "BuilderNotFound"
-	BuilderNotReady = "BuilderNotReady"
 )
 
 func (im *Image) BuilderNotFound() duckv1alpha1.Conditions {

--- a/pkg/apis/build/v1alpha1/image_reconcile_build.go
+++ b/pkg/apis/build/v1alpha1/image_reconcile_build.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"fmt"
 	"strconv"
 
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
@@ -67,9 +68,10 @@ func (r upToDateBuild) conditions() duckv1alpha1.Conditions {
 	if !r.builder.Ready() {
 		return duckv1alpha1.Conditions{
 			{
-				Type:   duckv1alpha1.ConditionReady,
-				Status: corev1.ConditionFalse,
-				Reason: BuilderNotReady,
+				Type:    duckv1alpha1.ConditionReady,
+				Status:  corev1.ConditionFalse,
+				Reason:  BuilderNotReady,
+				Message: fmt.Sprintf("Builder %s is not ready", r.builder.GetName()),
 			},
 		}
 	}

--- a/pkg/apis/build/v1alpha1/image_reconcile_build.go
+++ b/pkg/apis/build/v1alpha1/image_reconcile_build.go
@@ -22,7 +22,6 @@ func (im *Image) ReconcileBuild(latestBuild *Build, resolver *SourceResolver, bu
 			build:         im.build(resolver, builder, reasons, nextBuildNumber),
 			buildCounter:  nextBuildNumber,
 			latestImage:   latestImage,
-			builder:       builder,
 		}, nil
 	}
 

--- a/pkg/apis/build/v1alpha1/image_reconcile_build.go
+++ b/pkg/apis/build/v1alpha1/image_reconcile_build.go
@@ -105,7 +105,6 @@ type newBuild struct {
 	buildCounter  int64
 	latestImage   string
 	previousBuild *Build
-	builder       AbstractBuilder
 }
 
 func (r newBuild) Apply(creator BuildCreator) (ReconciledBuild, error) {

--- a/pkg/apis/build/v1alpha1/image_types.go
+++ b/pkg/apis/build/v1alpha1/image_types.go
@@ -90,4 +90,4 @@ func (i *Image) NamespacedName() types.NamespacedName {
 	return types.NamespacedName{Namespace: i.Namespace, Name: i.Name}
 }
 
-const ConditionBuilderReady duckv1alpha1.ConditionType = "Builder Ready"
+const ConditionBuilderReady duckv1alpha1.ConditionType = "BuilderReady"

--- a/pkg/apis/build/v1alpha1/image_types.go
+++ b/pkg/apis/build/v1alpha1/image_types.go
@@ -89,3 +89,5 @@ func (*Image) GetGroupVersionKind() schema.GroupVersionKind {
 func (i *Image) NamespacedName() types.NamespacedName {
 	return types.NamespacedName{Namespace: i.Namespace, Name: i.Name}
 }
+
+const ConditionBuilderReady duckv1alpha1.ConditionType = "Builder Ready"

--- a/pkg/reconciler/v1alpha1/builder/builder.go
+++ b/pkg/reconciler/v1alpha1/builder/builder.go
@@ -122,8 +122,9 @@ func (c *Reconciler) reconcileBuilderStatus(builder *v1alpha1.Builder) reconcile
 				ObservedGeneration: builder.Generation,
 				Conditions: duckv1alpha1.Conditions{
 					{
-						Type:   duckv1alpha1.ConditionReady,
-						Status: corev1.ConditionFalse,
+						Type:    duckv1alpha1.ConditionReady,
+						Status:  corev1.ConditionFalse,
+						Message: err.Error(),
 					},
 				},
 			},
@@ -131,7 +132,6 @@ func (c *Reconciler) reconcileBuilderStatus(builder *v1alpha1.Builder) reconcile
 
 		return reconciledBuilderResult{
 			builder: builder,
-			err:     err,
 		}
 
 	}

--- a/pkg/reconciler/v1alpha1/builder/builder_test.go
+++ b/pkg/reconciler/v1alpha1/builder/builder_test.go
@@ -266,7 +266,7 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 				rt.Test(rtesting.TableRow{
 					Key:     key,
 					Objects: []runtime.Object{builder},
-					WantErr: true,
+					WantErr: false,
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
 							Object: &v1alpha1.Builder{
@@ -277,8 +277,9 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 										ObservedGeneration: 1,
 										Conditions: duckv1alpha1.Conditions{
 											{
-												Type:   duckv1alpha1.ConditionReady,
-												Status: corev1.ConditionFalse,
+												Type:    duckv1alpha1.ConditionReady,
+												Status:  corev1.ConditionFalse,
+												Message: "unavailable metadata",
 											},
 										},
 									},
@@ -288,7 +289,7 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 				})
 
-				assert.Zero(t, fakeEnqueuer.EnqueueCallCount())
+				assert.Equal(t, fakeEnqueuer.EnqueueCallCount(), 1)
 			})
 		})
 

--- a/pkg/reconciler/v1alpha1/clusterbuilder/clusterbuilder.go
+++ b/pkg/reconciler/v1alpha1/clusterbuilder/clusterbuilder.go
@@ -121,8 +121,9 @@ func (c *Reconciler) reconcileClusterBuilderStatus(builder *v1alpha1.ClusterBuil
 				ObservedGeneration: builder.Generation,
 				Conditions: duckv1alpha1.Conditions{
 					{
-						Type:   duckv1alpha1.ConditionReady,
-						Status: corev1.ConditionFalse,
+						Type:    duckv1alpha1.ConditionReady,
+						Status:  corev1.ConditionFalse,
+						Message: err.Error(),
 					},
 				},
 			},
@@ -130,7 +131,6 @@ func (c *Reconciler) reconcileClusterBuilderStatus(builder *v1alpha1.ClusterBuil
 
 		return reconciledClusterBuilderResult{
 			builder: builder,
-			err:     err,
 		}
 
 	}

--- a/pkg/reconciler/v1alpha1/clusterbuilder/clusterbuilder.go
+++ b/pkg/reconciler/v1alpha1/clusterbuilder/clusterbuilder.go
@@ -74,29 +74,20 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	}
 	builder = builder.DeepCopy()
 
-	reconciledResult := c.reconcileClusterBuilderStatus(builder)
+	builder = c.reconcileClusterBuilderStatus(builder)
 
-	err = c.updateClusterBuilderStatus(reconciledResult.builder)
+	err = c.updateClusterBuilderStatus(builder)
 	if err != nil {
 		return err
 	}
 
-	if reconciledResult.reEnqueue() {
+	if builder.Spec.UpdatePolicy != v1alpha1.External {
 		err = c.Enqueuer.Enqueue(builder)
 		if err != nil {
 			return err
 		}
 	}
-	return reconciledResult.err
-}
-
-type reconciledClusterBuilderResult struct {
-	builder *v1alpha1.ClusterBuilder
-	err     error
-}
-
-func (r reconciledClusterBuilderResult) reEnqueue() bool {
-	return r.builder.Spec.UpdatePolicy != v1alpha1.External && r.err == nil
+	return nil
 }
 
 func (c *Reconciler) updateClusterBuilderStatus(desired *v1alpha1.ClusterBuilder) error {
@@ -113,7 +104,7 @@ func (c *Reconciler) updateClusterBuilderStatus(desired *v1alpha1.ClusterBuilder
 	return err
 }
 
-func (c *Reconciler) reconcileClusterBuilderStatus(builder *v1alpha1.ClusterBuilder) reconciledClusterBuilderResult {
+func (c *Reconciler) reconcileClusterBuilderStatus(builder *v1alpha1.ClusterBuilder) *v1alpha1.ClusterBuilder {
 	builderImage, err := c.MetadataRetriever.GetBuilderImage(builder)
 	if err != nil {
 		builder.Status = v1alpha1.BuilderStatus{
@@ -128,11 +119,7 @@ func (c *Reconciler) reconcileClusterBuilderStatus(builder *v1alpha1.ClusterBuil
 				},
 			},
 		}
-
-		return reconciledClusterBuilderResult{
-			builder: builder,
-		}
-
+		return builder
 	}
 
 	builder.Status = v1alpha1.BuilderStatus{
@@ -149,9 +136,7 @@ func (c *Reconciler) reconcileClusterBuilderStatus(builder *v1alpha1.ClusterBuil
 		LatestImage:     builderImage.Identifier,
 	}
 
-	return reconciledClusterBuilderResult{
-		builder: builder,
-	}
+	return builder
 }
 
 func transform(in cnb.BuilderMetadata) v1alpha1.BuildpackMetadataList {

--- a/pkg/reconciler/v1alpha1/clusterbuilder/clusterbuilder_test.go
+++ b/pkg/reconciler/v1alpha1/clusterbuilder/clusterbuilder_test.go
@@ -265,7 +265,7 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 					rt.Test(rtesting.TableRow{
 						Key:     clusterBuilderKey,
 						Objects: []runtime.Object{clusterBuilder},
-						WantErr: true,
+						WantErr: false,
 						WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 							{
 								Object: &v1alpha1.ClusterBuilder{
@@ -276,8 +276,9 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 											ObservedGeneration: 1,
 											Conditions: duckv1alpha1.Conditions{
 												{
-													Type:   duckv1alpha1.ConditionReady,
-													Status: corev1.ConditionFalse,
+													Type:    duckv1alpha1.ConditionReady,
+													Status:  corev1.ConditionFalse,
+													Message: "unavailable metadata",
 												},
 											},
 										},
@@ -287,7 +288,7 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 						},
 					})
 
-					assert.Zero(t, fakeEnqueuer.EnqueueCallCount())
+					assert.Equal(t, fakeEnqueuer.EnqueueCallCount(), 1)
 				})
 			})
 		})

--- a/pkg/reconciler/v1alpha1/image/image.go
+++ b/pkg/reconciler/v1alpha1/image/image.go
@@ -133,12 +133,6 @@ func (c *Reconciler) reconcileImage(image *v1alpha1.Image) (*v1alpha1.Image, err
 		return image, nil
 	}
 
-	if !builder.Ready() {
-		image.Status.Conditions = image.BuilderNotReady()
-		image.Status.ObservedGeneration = image.Generation
-		return image, nil
-	}
-
 	err = c.Tracker.Track(builder, image.NamespacedName())
 	if err != nil {
 		return nil, err

--- a/pkg/reconciler/v1alpha1/image/image_test.go
+++ b/pkg/reconciler/v1alpha1/image/image_test.go
@@ -623,6 +623,27 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 						resolvedSourceResolver(image),
 					},
 					WantErr: false,
+					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
+						{
+							Object: &v1alpha1.Image{
+								ObjectMeta: image.ObjectMeta,
+								Spec:       image.Spec,
+								Status: v1alpha1.ImageStatus{
+									Status: duckv1alpha1.Status{
+										ObservedGeneration: originalGeneration,
+										Conditions: duckv1alpha1.Conditions{
+											{
+												Type:    duckv1alpha1.ConditionReady,
+												Status:  corev1.ConditionFalse,
+												Reason:  "BuilderNotReady",
+												Message: "Builder builder-name is not ready.",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				})
 			})
 

--- a/pkg/reconciler/v1alpha1/image/image_test.go
+++ b/pkg/reconciler/v1alpha1/image/image_test.go
@@ -633,10 +633,9 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 										ObservedGeneration: originalGeneration,
 										Conditions: duckv1alpha1.Conditions{
 											{
-												Type:    duckv1alpha1.ConditionReady,
-												Status:  corev1.ConditionFalse,
-												Reason:  "BuilderNotReady",
-												Message: "Builder builder-name is not ready.",
+												Type:   duckv1alpha1.ConditionReady,
+												Status: corev1.ConditionFalse,
+												Reason: "BuilderNotReady",
 											},
 										},
 									},

--- a/pkg/reconciler/v1alpha1/image/image_test.go
+++ b/pkg/reconciler/v1alpha1/image/image_test.go
@@ -633,9 +633,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 										ObservedGeneration: originalGeneration,
 										Conditions: duckv1alpha1.Conditions{
 											{
-												Type:   duckv1alpha1.ConditionReady,
-												Status: corev1.ConditionFalse,
-												Reason: "BuilderNotReady",
+												Type:    duckv1alpha1.ConditionReady,
+												Status:  corev1.ConditionFalse,
+												Reason:  "BuilderNotReady",
+												Message: "Builder builder-name is not ready",
 											},
 										},
 									},

--- a/pkg/reconciler/v1alpha1/image/image_test.go
+++ b/pkg/reconciler/v1alpha1/image/image_test.go
@@ -105,7 +105,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 		Status: v1alpha1.ImageStatus{
 			Status: duckv1alpha1.Status{
 				ObservedGeneration: originalGeneration,
-				Conditions:         conditionUnknown(),
+				Conditions:         conditionReadyUnknown(),
 			},
 		},
 	}
@@ -186,7 +186,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 							Status: v1alpha1.ImageStatus{
 								Status: duckv1alpha1.Status{
 									ObservedGeneration: updatedGeneration,
-									Conditions:         conditionUnknown(),
+									Conditions:         conditionReadyUnknown(),
 								},
 							},
 						},
@@ -431,7 +431,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									BuildCacheName: image.CacheName(),
 									Status: duckv1alpha1.Status{
 										ObservedGeneration: originalGeneration,
-										Conditions:         conditionUnknown(),
+										Conditions:         conditionReadyUnknown(),
 									},
 								},
 							},
@@ -591,7 +591,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								Status: v1alpha1.ImageStatus{
 									Status: duckv1alpha1.Status{
 										ObservedGeneration: originalGeneration,
-										Conditions:         conditionUnknown(),
+										Conditions:         conditionReadyUnknown(),
 									},
 								},
 							},
@@ -633,9 +633,13 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 										ObservedGeneration: originalGeneration,
 										Conditions: duckv1alpha1.Conditions{
 											{
-												Type:    duckv1alpha1.ConditionReady,
+												Type:   duckv1alpha1.ConditionReady,
+												Status: corev1.ConditionUnknown,
+											},
+											{
+												Type:    v1alpha1.ConditionBuilderReady,
 												Status:  corev1.ConditionFalse,
-												Reason:  "BuilderNotReady",
+												Reason:  v1alpha1.BuilderNotReady,
 												Message: "Builder builder-name is not ready",
 											},
 										},
@@ -695,7 +699,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								Status: v1alpha1.ImageStatus{
 									Status: duckv1alpha1.Status{
 										ObservedGeneration: originalGeneration,
-										Conditions:         conditionUnknown(),
+										Conditions:         conditionReadyUnknown(),
 									},
 									LatestBuildRef: "image-name-build-1-00001", // GenerateNameReactor
 									BuildCounter:   1,
@@ -764,6 +768,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 											{
 												Type:   duckv1alpha1.ConditionReady,
 												Status: corev1.ConditionUnknown,
+											},
+											{
+												Type:   v1alpha1.ConditionBuilderReady,
+												Status: corev1.ConditionTrue,
 											},
 										},
 									},
@@ -863,7 +871,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								Status: v1alpha1.ImageStatus{
 									Status: duckv1alpha1.Status{
 										ObservedGeneration: originalGeneration,
-										Conditions:         conditionUnknown(),
+										Conditions:         conditionReadyUnknown(),
 									},
 									LatestBuildRef: "image-name-build-2-00001", // GenerateNameReactor
 									LatestImage:    image.Spec.Tag + "@sha256:just-built",
@@ -972,7 +980,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								Status: v1alpha1.ImageStatus{
 									Status: duckv1alpha1.Status{
 										ObservedGeneration: originalGeneration,
-										Conditions:         conditionUnknown(),
+										Conditions:         conditionReadyUnknown(),
 									},
 									LatestBuildRef: "image-name-build-2-00001", // GenerateNameReactor
 									LatestImage:    image.Spec.Tag + "@sha256:just-built",
@@ -1107,7 +1115,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								Status: v1alpha1.ImageStatus{
 									Status: duckv1alpha1.Status{
 										ObservedGeneration: originalGeneration,
-										Conditions:         conditionUnknown(),
+										Conditions:         conditionReadyUnknown(),
 									},
 									LatestBuildRef: "image-name-build-2-00001", // GenerateNameReactor
 									LatestImage:    image.Spec.Tag + "@sha256:just-built",
@@ -1214,6 +1222,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 											Type:   duckv1alpha1.ConditionSucceeded,
 											Status: corev1.ConditionTrue,
 										},
+										{
+											Type:   v1alpha1.ConditionBuilderReady,
+											Status: corev1.ConditionTrue,
+										},
 									},
 								},
 							},
@@ -1313,6 +1325,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 										Conditions: duckv1alpha1.Conditions{
 											{
 												Type:   duckv1alpha1.ConditionReady,
+												Status: corev1.ConditionTrue,
+											},
+											{
+												Type:   v1alpha1.ConditionBuilderReady,
 												Status: corev1.ConditionTrue,
 											},
 										},
@@ -1417,11 +1433,15 @@ func limit(limit int64) *int64 {
 	return &limit
 }
 
-func conditionUnknown() duckv1alpha1.Conditions {
+func conditionReadyUnknown() duckv1alpha1.Conditions {
 	return duckv1alpha1.Conditions{
 		{
 			Type:   duckv1alpha1.ConditionReady,
 			Status: corev1.ConditionUnknown,
+		},
+		{
+			Type:   v1alpha1.ConditionBuilderReady,
+			Status: corev1.ConditionTrue,
 		},
 	}
 }
@@ -1432,6 +1452,10 @@ func conditionReady() duckv1alpha1.Conditions {
 			Type:   duckv1alpha1.ConditionReady,
 			Status: corev1.ConditionTrue,
 		},
+		{
+			Type:   v1alpha1.ConditionBuilderReady,
+			Status: corev1.ConditionTrue,
+		},
 	}
 }
 
@@ -1440,6 +1464,10 @@ func conditionNotReady() duckv1alpha1.Conditions {
 		{
 			Type:   duckv1alpha1.ConditionReady,
 			Status: corev1.ConditionFalse,
+		},
+		{
+			Type:   v1alpha1.ConditionBuilderReady,
+			Status: corev1.ConditionTrue,
 		},
 	}
 }

--- a/test/execute_build_test.go
+++ b/test/execute_build_test.go
@@ -114,8 +114,7 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 
 			_, err = clients.client.BuildV1alpha1().ClusterBuilders().Create(&v1alpha1.ClusterBuilder{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterBuilderName,
-					Namespace: testNamespace,
+					Name: clusterBuilderName,
 				},
 				Spec: v1alpha1.BuilderSpec{
 					Image: builderImage,
@@ -188,6 +187,8 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 					Name: clusterBuilderName,
 				},
 			}
+
+			time.Sleep(10 * time.Second)
 
 			for imageName, imageSource := range imageConfigs {
 				imageTag := cfg.newImageTag()

--- a/test/execute_build_test.go
+++ b/test/execute_build_test.go
@@ -188,8 +188,6 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 				},
 			}
 
-			time.Sleep(10 * time.Second)
-
 			for imageName, imageSource := range imageConfigs {
 				imageTag := cfg.newImageTag()
 				_, err = clients.client.BuildV1alpha1().Images(testNamespace).Create(&v1alpha1.Image{


### PR DESCRIPTION
Update image status to `builderNotReady` if the builder is not ready.

Additionally, if the builder metadata is not available (because of incorrect credentials on a private builder), this does not try to constantly re-enqueue the builder/clusterbuilder resource

Additionally added a sleep in our tests as we now wait for the builders to be ready for images to get scheduled.