### PR TITLE
Add each CRD to the 'kpack' category

### DIFF
--- a/config/build.yaml
+++ b/config/build.yaml
@@ -13,6 +13,8 @@ spec:
     - cnbbuild
     - cnbbuilds
     - bld
+    categories:
+    - kpack
   scope: Namespaced
   subresources:
     status: {}

--- a/config/builder.yaml
+++ b/config/builder.yaml
@@ -13,6 +13,8 @@ spec:
     - cnbbuilder
     - cnbbuilders
     - bldr
+    categories:
+    - kpack
   scope: Namespaced
   subresources:
     status: {}

--- a/config/clusterbuilder.yaml
+++ b/config/clusterbuilder.yaml
@@ -11,6 +11,8 @@ spec:
     plural: clusterbuilders
     shortNames:
     - clstbldr
+    categories:
+    - kpack
   scope: Cluster
   subresources:
     status: {}

--- a/config/image.yaml
+++ b/config/image.yaml
@@ -12,6 +12,8 @@ spec:
     shortNames:
     - cnbimage
     - cnbimages
+    categories:
+    - kpack
   scope: Namespaced
   subresources:
     status: {}

--- a/config/sourceresolver.yaml
+++ b/config/sourceresolver.yaml
@@ -9,6 +9,8 @@ spec:
     kind: SourceResolver
     singular: sourceresolver
     plural: sourceresolvers
+    categories:
+    - kpack
   scope: Namespaced
   subresources:
     status: {}


### PR DESCRIPTION
CRD categories make it easy to get groups of resources with kubectl.
Each CRD in this build.pivotal.io api group is now a member of the kpack
category.

Commands like `kubectl get kpack` will now return all kpack resources in
the default namespace.