### PR TITLE
Add init container to show 'Build successful' at end of 'logs' output

### DIFF
--- a/pkg/apis/build/v1alpha1/build_pod.go
+++ b/pkg/apis/build/v1alpha1/build_pod.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/knative/pkg/kmeta"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -278,6 +278,11 @@ func (b *Build) BuildPod(config BuildPodConfig, secrets []corev1.Secret, builder
 						layersVolume,
 						cacheVolume,
 					},
+					ImagePullPolicy: corev1.PullIfNotPresent,
+				},
+				{
+					Name:            "success",
+					Image:           config.NopImage,
 					ImagePullPolicy: corev1.PullIfNotPresent,
 				},
 			},

--- a/pkg/apis/build/v1alpha1/build_pod_test.go
+++ b/pkg/apis/build/v1alpha1/build_pod_test.go
@@ -148,6 +148,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 				"build",
 				"export",
 				"cache",
+				"success",
 			}))
 		})
 
@@ -434,7 +435,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			require.NoError(t, err)
 
 			for _, container := range pod.Spec.InitContainers {
-				if container.Name != "creds-init" && container.Name != "source-init" && container.Name != "prepare" {
+				if container.Name != "creds-init" && container.Name != "source-init" && container.Name != "prepare" && container.Name != "success" {
 					assert.Equal(t, builderImage, container.Image, fmt.Sprintf("image on container '%s'", container.Name))
 				}
 			}


### PR DESCRIPTION
Watching TGIK briefly I saw the "Oh I didn't know my build was completed" comment that I'd made to myself each time I run logs.

This PR adds an init container to each build pod so that `Build successful` is displayed at the end of each successful build's `logs` output.