### PR TITLE
Print a 'Build Successful' at the end of log output

### DIFF
--- a/pkg/apis/build/v1alpha1/build_pod.go
+++ b/pkg/apis/build/v1alpha1/build_pod.go
@@ -110,7 +110,7 @@ func (b *Build) BuildPod(config BuildPodConfig, secrets []corev1.Secret, builder
 			RestartPolicy: corev1.RestartPolicyNever,
 			Containers: []corev1.Container{
 				{
-					Name:            "nop",
+					Name:            "completion",
 					Image:           config.NopImage,
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Resources:       b.Spec.Resources,


### PR DESCRIPTION
- Include steps in cyan in log output to match pack output
- Improves output as proposed in: #149, #147