### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request: {}
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-go@v1
+      with:
+        go-version: '1.13'
+    - name: Run tests
+      run: make


### PR DESCRIPTION
This ports the Travis CI behavior to GitHub Actions. Actions are
currently in public beta, and is targeted to be GA in November.

Learn more at https://github.com/features/actions

Note: because this is the repos first action, you won't see it run in the pivotal/kpack repo until this PR is merged. You can see the output at https://github.com/scothis/kpack/commit/d65b0e5b857f9140b63dea1ce500abe9e7368dc8/checks?check_suite_id=261474152

Once you're happy with GitHub Actions, to disable Travis, delete the .travis.yml file.
