### PR TITLE
Fix the code coverage to exclude the deepcopy

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,3 @@
 ignore:
   - "**/zz_*_generated.go" # Ignore generated files.
+  - "**/zz_generated.deepcopy.go" # Ignore generated files.


### PR DESCRIPTION
The deepcopy file name format for k8s client is different.