### PR TITLE
Extract last build information from last build and not image status

### DIFF
--- a/pkg/apis/build/v1alpha1/build.go
+++ b/pkg/apis/build/v1alpha1/build.go
@@ -108,8 +108,5 @@ func (b *Build) ImagePullSecretsVolume() corev1.Volume {
 }
 
 func (b *Build) Rebasable(builderStack string) bool {
-	if b.Spec.LastBuild.StackID != "" {
-		return b.Annotations[BuildReasonAnnotation] == BuildReasonStack && b.Spec.LastBuild.StackID == builderStack
-	}
-	return b.Annotations[BuildReasonAnnotation] == BuildReasonStack
+	return b.Annotations[BuildReasonAnnotation] == BuildReasonStack && b.Spec.LastBuild.StackID == builderStack
 }

--- a/pkg/apis/build/v1alpha1/build_pod_test.go
+++ b/pkg/apis/build/v1alpha1/build_pod_test.go
@@ -71,7 +71,8 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			},
 			Resources: resources,
 			LastBuild: v1alpha1.LastBuild{
-				Image: previousAppImage,
+				Image:   previousAppImage,
+				StackID: "com.builder.stack.io",
 			},
 		},
 	}

--- a/pkg/apis/build/v1alpha1/image_builds.go
+++ b/pkg/apis/build/v1alpha1/image_builds.go
@@ -86,7 +86,7 @@ func lastBuildBuiltWithBuilderBuildpacks(builder BuilderResource, build *Build) 
 	return true
 }
 
-func (im *Image) build(sourceResolver *SourceResolver, builder BuilderResource, reasons []string, nextBuildNumber int64) *Build {
+func (im *Image) build(sourceResolver *SourceResolver, builder BuilderResource, latestBuild *Build, reasons []string, nextBuildNumber int64) *Build {
 	buildNumber := strconv.Itoa(int(nextBuildNumber))
 	return &Build{
 		ObjectMeta: metav1.ObjectMeta{
@@ -112,8 +112,8 @@ func (im *Image) build(sourceResolver *SourceResolver, builder BuilderResource, 
 			Source:         sourceResolver.SourceConfig(),
 			CacheName:      im.Status.BuildCacheName,
 			LastBuild: LastBuild{
-				Image:   im.Status.LatestImage,
-				StackID: im.Status.LatestStack,
+				Image:   latestBuild.BuiltImage(),
+				StackID: latestBuild.Stack(),
 			},
 		},
 	}

--- a/pkg/apis/build/v1alpha1/image_reconcile_build.go
+++ b/pkg/apis/build/v1alpha1/image_reconcile_build.go
@@ -23,7 +23,7 @@ func (im *Image) ReconcileBuild(latestBuild *Build, resolver *SourceResolver, bu
 		nextBuildNumber := currentBuildNumber + 1
 		return newBuild{
 			previousBuild: latestBuild,
-			build:         im.build(resolver, builder, reasons, nextBuildNumber),
+			build:         im.build(resolver, builder, latestBuild, reasons, nextBuildNumber),
 			buildCounter:  nextBuildNumber,
 			latestImage:   latestImage,
 		}, nil

--- a/pkg/reconciler/v1alpha1/image/image_test.go
+++ b/pkg/reconciler/v1alpha1/image/image_test.go
@@ -876,6 +876,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 										Revision: sourceResolver.Status.Source.Git.Revision,
 									},
 								},
+								LastBuild: v1alpha1.LastBuild{
+									Image:   "some/image@sha256:just-built",
+									StackID: "io.buildpacks.stacks.bionic",
+								},
 							},
 						},
 					},
@@ -988,6 +992,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 										URL:      sourceResolver.Status.Source.Git.URL,
 										Revision: sourceResolver.Status.Source.Git.Revision,
 									},
+								},
+								LastBuild: v1alpha1.LastBuild{
+									Image:   "some/image@sha256:just-built",
+									StackID: "io.buildpacks.stacks.bionic",
 								},
 							},
 						},
@@ -1131,6 +1139,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 										URL:      sourceResolver.Status.Source.Git.URL,
 										Revision: sourceResolver.Status.Source.Git.Revision,
 									},
+								},
+								LastBuild: v1alpha1.LastBuild{
+									Image:   "some/image@sha256:just-built",
+									StackID: "io.buildpacks.stacks.bionic",
 								},
 							},
 						},


### PR DESCRIPTION
- Rebasable verifies stack id always

Closes #214 