### PR TITLE
Utilize cloudfoundry/cnb:tiny for kpack images

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -3,7 +3,7 @@
 function pack_build() {
     image=$1
     target=$2
-    builder="cloudfoundry/cnb:bionic"
+    builder="cloudfoundry/cnb:tiny"
 
     pack build ${image} --builder ${builder} -e BP_GO_TARGETS=${target} --publish
 


### PR DESCRIPTION
The `org.cloudfoundry.stacks.tiny` has a noticeably smaller footprint. 
 - completion image ~ 46mb vs previously ~ 81mb

The image has more frequent updates to the `cloudfoundry/go-*` buildpacks