### PR TITLE
omitempty possible empty fields

### DIFF
--- a/pkg/apis/build/v1alpha1/build.go
+++ b/pkg/apis/build/v1alpha1/build.go
@@ -108,5 +108,6 @@ func (b *Build) ImagePullSecretsVolume() corev1.Volume {
 }
 
 func (b *Build) Rebasable(builderStack string) bool {
-	return b.Annotations[BuildReasonAnnotation] == BuildReasonStack && b.Spec.LastBuild.StackID == builderStack
+	return b.Spec.LastBuild != nil &&
+		b.Annotations[BuildReasonAnnotation] == BuildReasonStack && b.Spec.LastBuild.StackID == builderStack
 }

--- a/pkg/apis/build/v1alpha1/build_pod_test.go
+++ b/pkg/apis/build/v1alpha1/build_pod_test.go
@@ -70,7 +70,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 				{Name: "keyB", Value: "valueB"},
 			},
 			Resources: resources,
-			LastBuild: v1alpha1.LastBuild{
+			LastBuild: &v1alpha1.LastBuild{
 				Image:   previousAppImage,
 				StackID: "com.builder.stack.io",
 			},

--- a/pkg/apis/build/v1alpha1/build_test.go
+++ b/pkg/apis/build/v1alpha1/build_test.go
@@ -1,0 +1,47 @@
+package v1alpha1_test
+
+import (
+	"testing"
+
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRebaseable(t *testing.T) {
+	build := &v1alpha1.Build{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				v1alpha1.BuildReasonAnnotation: v1alpha1.BuildReasonStack,
+			},
+		},
+	}
+	require.False(t, build.Rebasable("any.stack"))
+
+	build = &v1alpha1.Build{
+		Spec: v1alpha1.BuildSpec{
+			LastBuild: &v1alpha1.LastBuild{
+				Image:   "some/run",
+				StackID: "matching.stack",
+			},
+		},
+	}
+	require.False(t, build.Rebasable("matching.stack"))
+
+	build = &v1alpha1.Build{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				v1alpha1.BuildReasonAnnotation: v1alpha1.BuildReasonStack,
+			},
+		},
+		Spec: v1alpha1.BuildSpec{
+			LastBuild: &v1alpha1.LastBuild{
+				Image:   "some/run",
+				StackID: "matching.stack",
+			},
+		},
+		Status: v1alpha1.BuildStatus{},
+	}
+	require.True(t, build.Rebasable("matching.stack"))
+
+}

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -32,7 +32,7 @@ type Build struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   BuildSpec   `json:"spec"`
-	Status BuildStatus `json:"status"`
+	Status BuildStatus `json:"status,omitempty"`
 }
 
 var (
@@ -42,37 +42,37 @@ var (
 )
 
 type BuildBuilderSpec struct {
-	Image            string                        `json:"image"`
+	Image            string                        `json:"image,omitempty"`
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
 }
 
 type BuildSpec struct {
-	Tags           []string                    `json:"tags"`
-	Builder        BuildBuilderSpec            `json:"builder"`
-	ServiceAccount string                      `json:"serviceAccount"`
+	Tags           []string                    `json:"tags,omitempty"`
+	Builder        BuildBuilderSpec            `json:"builder,omitempty"`
+	ServiceAccount string                      `json:"serviceAccount,omitempty"`
 	Source         SourceConfig                `json:"source"`
-	CacheName      string                      `json:"cacheName"`
-	Env            []corev1.EnvVar             `json:"env"`
-	Resources      corev1.ResourceRequirements `json:"resources"`
-	LastBuild      LastBuild                   `json:"lastBuild"`
+	CacheName      string                      `json:"cacheName,omitempty"`
+	Env            []corev1.EnvVar             `json:"env,omitempty"`
+	Resources      corev1.ResourceRequirements `json:"resources,omitempty"`
+	LastBuild      *LastBuild                  `json:"lastBuild,omitempty"`
 }
 
 type LastBuild struct {
-	Image   string `json:"image"`
-	StackID string `json:"stackId"`
+	Image   string `json:"image,omitempty"`
+	StackID string `json:"stackId,omitempty"`
 }
 
 type BuildStack struct {
-	RunImage string `json:"runImage"`
-	ID       string `json:"id"`
+	RunImage string `json:"runImage,omitempty"`
+	ID       string `json:"id,omitempty"`
 }
 
 type BuildStatus struct {
 	duckv1alpha1.Status `json:",inline"`
-	BuildMetadata       BuildpackMetadataList   `json:"buildMetadata"`
-	Stack               BuildStack              `json:"stack"`
-	LatestImage         string                  `json:"latestImage"`
-	PodName             string                  `json:"podName"`
+	BuildMetadata       BuildpackMetadataList   `json:"buildMetadata,omitempty"`
+	Stack               BuildStack              `json:"stack,omitempty"`
+	LatestImage         string                  `json:"latestImage,omitempty"`
+	PodName             string                  `json:"podName,omitempty"`
 	StepStates          []corev1.ContainerState `json:"stepStates,omitempty"`
 	StepsCompleted      []string                `json:"stepsCompleted,omitempty"`
 }

--- a/pkg/apis/build/v1alpha1/build_validation.go
+++ b/pkg/apis/build/v1alpha1/build_validation.go
@@ -53,7 +53,7 @@ func (bbs *BuildBuilderSpec) Validate(ctx context.Context) *apis.FieldError {
 }
 
 func (lb *LastBuild) Validate(context context.Context) *apis.FieldError {
-	if lb.Image == "" {
+	if lb == nil || lb.Image == "" {
 		return nil
 	}
 

--- a/pkg/apis/build/v1alpha1/build_validation_test.go
+++ b/pkg/apis/build/v1alpha1/build_validation_test.go
@@ -140,7 +140,7 @@ func testBuildValidation(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("validates valid lastBuilt Image", func() {
-			build.Spec.LastBuild = LastBuild{Image: "invalid@@"}
+			build.Spec.LastBuild = &LastBuild{Image: "invalid@@"}
 
 			assertValidationError(build, apis.ErrInvalidValue(build.Spec.LastBuild.Image, "image").ViaField("spec", "lastBuild"))
 		})

--- a/pkg/apis/build/v1alpha1/builder_types.go
+++ b/pkg/apis/build/v1alpha1/builder_types.go
@@ -17,12 +17,12 @@ type Builder struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   BuilderWithSecretsSpec `json:"spec"`
-	Status BuilderStatus          `json:"status"`
+	Status BuilderStatus          `json:"status,omitempty"`
 }
 
 type BuilderSpec struct {
 	Image        string              `json:"image"`
-	UpdatePolicy BuilderUpdatePolicy `json:"updatePolicy"`
+	UpdatePolicy BuilderUpdatePolicy `json:"updatePolicy,omitempty"`
 }
 
 type BuilderWithSecretsSpec struct {
@@ -39,9 +39,9 @@ const (
 
 type BuilderStatus struct {
 	duckv1alpha1.Status `json:",inline"`
-	BuilderMetadata     BuildpackMetadataList `json:"builderMetadata"`
-	Stack               BuildStack            `json:"stack"`
-	LatestImage         string                `json:"latestImage"`
+	BuilderMetadata     BuildpackMetadataList `json:"builderMetadata,omitempty"`
+	Stack               BuildStack            `json:"stack,omitempty"`
+	LatestImage         string                `json:"latestImage,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/build/v1alpha1/cluster_builder_types.go
+++ b/pkg/apis/build/v1alpha1/cluster_builder_types.go
@@ -17,7 +17,7 @@ type ClusterBuilder struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   BuilderSpec   `json:"spec"`
-	Status BuilderStatus `json:"status"`
+	Status BuilderStatus `json:"status,omitempty"`
 }
 
 // +genclient:nonNamespaced

--- a/pkg/apis/build/v1alpha1/image_builds_test.go
+++ b/pkg/apis/build/v1alpha1/image_builds_test.go
@@ -29,18 +29,6 @@ func testImageBuilds(t *testing.T, when spec.G, it spec.S) {
 			Builder: ImageBuilder{
 				Name: "builder-name",
 			},
-			Build: ImageBuild{
-				Env: []v1.EnvVar{
-					{
-						Name:  "keyA",
-						Value: "ValueA",
-					},
-					{
-						Name:  "keyB",
-						Value: "ValueB",
-					},
-				},
-			},
 		},
 	}
 
@@ -95,16 +83,6 @@ func testImageBuilds(t *testing.T, when spec.G, it spec.S) {
 			Tags:           []string{"some/image"},
 			Builder:        builder.BuildBuilderSpec(),
 			ServiceAccount: "some/serviceaccount",
-			Env: []v1.EnvVar{
-				{
-					Name:  "keyA",
-					Value: "ValueA",
-				},
-				{
-					Name:  "keyB",
-					Value: "ValueB",
-				},
-			},
 		},
 		Status: BuildStatus{
 			Status: duckv1alpha1.Status{
@@ -305,8 +283,10 @@ func testImageBuilds(t *testing.T, when spec.G, it spec.S) {
 				build.Spec.Env = []v1.EnvVar{
 					{Name: "keyA", Value: "old"},
 				}
-				image.Spec.Build.Env = []v1.EnvVar{
-					{Name: "keyA", Value: "new"},
+				image.Spec.Build = &ImageBuild{
+					Env: []v1.EnvVar{
+						{Name: "keyA", Value: "new"},
+					},
 				}
 
 				reasons, needed, err := image.buildNeeded(build, sourceResolver, builder)
@@ -327,14 +307,16 @@ func testImageBuilds(t *testing.T, when spec.G, it spec.S) {
 					},
 				}
 
-				image.Spec.Build.Resources = v1.ResourceRequirements{
-					Limits: v1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("3"),
-						v1.ResourceMemory: resource.MustParse("512M"),
-					},
-					Requests: v1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("2"),
-						v1.ResourceMemory: resource.MustParse("256M"),
+				image.Spec.Build = &ImageBuild{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("3"),
+							v1.ResourceMemory: resource.MustParse("512M"),
+						},
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("2"),
+							v1.ResourceMemory: resource.MustParse("256M"),
+						},
 					},
 				}
 
@@ -588,6 +570,12 @@ func testImageBuilds(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("adds the env vars to the build spec", func() {
+			image.Spec.Build = &ImageBuild{
+				Env: []v1.EnvVar{
+					{Name: "keyA", Value: "new"},
+				},
+			}
+
 			expectedBuild := image.build(sourceResolver, builder, build, []string{BuildReasonConfig}, 1)
 
 			assert.Equal(t, image.Spec.Build.Env, expectedBuild.Spec.Env)
@@ -607,14 +595,16 @@ func testImageBuilds(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("adds build resources", func() {
-			image.Spec.Build.Resources = v1.ResourceRequirements{
-				Limits: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("2"),
-					v1.ResourceMemory: resource.MustParse("256M"),
-				},
-				Requests: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("1"),
-					v1.ResourceMemory: resource.MustParse("128M"),
+			image.Spec.Build = &ImageBuild{
+				Resources: v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("2"),
+						v1.ResourceMemory: resource.MustParse("256M"),
+					},
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("1"),
+						v1.ResourceMemory: resource.MustParse("128M"),
+					},
 				},
 			}
 

--- a/pkg/apis/build/v1alpha1/image_types.go
+++ b/pkg/apis/build/v1alpha1/image_types.go
@@ -33,19 +33,19 @@ type Image struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   ImageSpec   `json:"spec"`
-	Status ImageStatus `json:"status"`
+	Status ImageStatus `json:"status,omitempty"`
 }
 
 type ImageSpec struct {
 	Tag                      string               `json:"tag"`
-	Builder                  ImageBuilder         `json:"builder"`
-	ServiceAccount           string               `json:"serviceAccount"`
+	Builder                  ImageBuilder         `json:"builder,omitempty"`
+	ServiceAccount           string               `json:"serviceAccount,omitempty"`
 	Source                   SourceConfig         `json:"source"`
 	CacheSize                *resource.Quantity   `json:"cacheSize,omitempty"`
-	FailedBuildHistoryLimit  *int64               `json:"failedBuildHistoryLimit"`
-	SuccessBuildHistoryLimit *int64               `json:"successBuildHistoryLimit"`
-	ImageTaggingStrategy     ImageTaggingStrategy `json:"imageTaggingStrategy"`
-	Build                    ImageBuild           `json:"build"`
+	FailedBuildHistoryLimit  *int64               `json:"failedBuildHistoryLimit,omitempty"`
+	SuccessBuildHistoryLimit *int64               `json:"successBuildHistoryLimit,omitempty"`
+	ImageTaggingStrategy     ImageTaggingStrategy `json:"imageTaggingStrategy,omitempty"`
+	Build                    *ImageBuild          `json:"build,omitempty"`
 }
 
 type ImageBuilder struct {
@@ -61,17 +61,17 @@ const (
 )
 
 type ImageBuild struct {
-	Env       []corev1.EnvVar             `json:"env"`
-	Resources corev1.ResourceRequirements `json:"resources"`
+	Env       []corev1.EnvVar             `json:"env,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 type ImageStatus struct {
 	duckv1alpha1.Status `json:",inline"`
-	LatestBuildRef      string `json:"latestBuildRef"`
-	LatestImage         string `json:"latestImage"`
-	LatestStack         string `json:"latestStack"`
-	BuildCounter        int64  `json:"buildCounter"`
-	BuildCacheName      string `json:"buildCacheName"`
+	LatestBuildRef      string `json:"latestBuildRef,omitempty"`
+	LatestImage         string `json:"latestImage,omitempty"`
+	LatestStack         string `json:"latestStack,omitempty"`
+	BuildCounter        int64  `json:"buildCounter,omitempty"`
+	BuildCacheName      string `json:"buildCacheName,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/build/v1alpha1/image_validation_test.go
+++ b/pkg/apis/build/v1alpha1/image_validation_test.go
@@ -39,7 +39,7 @@ func testImageValidation(t *testing.T, when spec.G, it spec.S) {
 			FailedBuildHistoryLimit:  &limit,
 			SuccessBuildHistoryLimit: &limit,
 			ImageTaggingStrategy:     None,
-			Build: ImageBuild{
+			Build: &ImageBuild{
 				Env: []v1.EnvVar{
 					{
 						Name:  "keyA",

--- a/pkg/apis/build/v1alpha1/source_resolver_types.go
+++ b/pkg/apis/build/v1alpha1/source_resolver_types.go
@@ -13,17 +13,17 @@ type SourceResolver struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Spec              SourceResolverSpec   `json:"spec"`
-	Status            SourceResolverStatus `json:"status"`
+	Status            SourceResolverStatus `json:"status,omitempty"`
 }
 
 type SourceResolverSpec struct {
-	ServiceAccount string       `json:"serviceAccount"`
+	ServiceAccount string       `json:"serviceAccount,omitempty"`
 	Source         SourceConfig `json:"source"`
 }
 
 type SourceResolverStatus struct {
 	duckv1alpha1.Status `json:",inline"`
-	Source              ResolvedSourceConfig `json:"source"`
+	Source              ResolvedSourceConfig `json:"source,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/build/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/build/v1alpha1/zz_generated.deepcopy.go
@@ -176,7 +176,11 @@ func (in *BuildSpec) DeepCopyInto(out *BuildSpec) {
 		}
 	}
 	in.Resources.DeepCopyInto(&out.Resources)
-	out.LastBuild = in.LastBuild
+	if in.LastBuild != nil {
+		in, out := &in.LastBuild, &out.LastBuild
+		*out = new(LastBuild)
+		**out = **in
+	}
 	return
 }
 
@@ -614,7 +618,11 @@ func (in *ImageSpec) DeepCopyInto(out *ImageSpec) {
 		*out = new(int64)
 		**out = **in
 	}
-	in.Build.DeepCopyInto(&out.Build)
+	if in.Build != nil {
+		in, out := &in.Build, &out.Build
+		*out = new(ImageBuild)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/reconciler/v1alpha1/image/image_test.go
+++ b/pkg/reconciler/v1alpha1/image/image_test.go
@@ -103,7 +103,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 			FailedBuildHistoryLimit:  limit(10),
 			SuccessBuildHistoryLimit: limit(10),
 			ImageTaggingStrategy:     v1alpha1.None,
-			Build:                    v1alpha1.ImageBuild{},
+			Build:                    &v1alpha1.ImageBuild{},
 		},
 		Status: v1alpha1.ImageStatus{
 			Status: duckv1alpha1.Status{
@@ -876,7 +876,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 										Revision: sourceResolver.Status.Source.Git.Revision,
 									},
 								},
-								LastBuild: v1alpha1.LastBuild{
+								LastBuild: &v1alpha1.LastBuild{
 									Image:   "some/image@sha256:just-built",
 									StackID: "io.buildpacks.stacks.bionic",
 								},
@@ -993,7 +993,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 										Revision: sourceResolver.Status.Source.Git.Revision,
 									},
 								},
-								LastBuild: v1alpha1.LastBuild{
+								LastBuild: &v1alpha1.LastBuild{
 									Image:   "some/image@sha256:just-built",
 									StackID: "io.buildpacks.stacks.bionic",
 								},
@@ -1140,7 +1140,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 										Revision: sourceResolver.Status.Source.Git.Revision,
 									},
 								},
-								LastBuild: v1alpha1.LastBuild{
+								LastBuild: &v1alpha1.LastBuild{
 									Image:   "some/image@sha256:just-built",
 									StackID: "io.buildpacks.stacks.bionic",
 								},


### PR DESCRIPTION
-  This prevents kpack from serializing unnecessary fields creating
a less brittle api
- Allow build.spec.LastBuild to be nil
- Allow image.spec.build to be nil