### PR TITLE
Allow azure-container-registry-config to be set by environment variable

### DIFF
--- a/pkg/dockercreds/k8sdockercreds/azurecredentialhelperfix/setup.go
+++ b/pkg/dockercreds/k8sdockercreds/azurecredentialhelperfix/setup.go
@@ -1,0 +1,15 @@
+package setup
+
+import (
+	_ "k8s.io/kubernetes/pkg/credentialprovider/azure"
+
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+func init() {
+	//allow azure credential helper to be proccess its config before k8schain loads
+	//https://github.com/google/go-containerregistry/pull/652
+	pflag.Set("azure-container-registry-config", os.Getenv("AZURE_CONTAINER_REGISTRY_CONFIG"))
+}

--- a/pkg/dockercreds/k8sdockercreds/k8s_keychain_test.go
+++ b/pkg/dockercreds/k8sdockercreds/k8s_keychain_test.go
@@ -1,6 +1,8 @@
 package k8sdockercreds
 
 import (
+	_ "github.com/pivotal/kpack/pkg/dockercreds/k8sdockercreds/azurecredentialhelperfix"
+
 	"encoding/base64"
 	"fmt"
 	"testing"


### PR DESCRIPTION
- The k8schain processes the AzureCredentialProvider before it has time to process the azure-container-registry-config.
This allows the Azure provider to be configured before the k8schain is initialized.