### PR TITLE
Move stack layer to be next to the order layer

### DIFF
--- a/pkg/cnb/builder_builder.go
+++ b/pkg/cnb/builder_builder.go
@@ -138,10 +138,10 @@ func (bb *BuilderBuilder) writeableImage() (v1.Image, error) {
 				defaultLayer,
 				lifecycleLayer,
 				compatLayer,
-				stackLayer,
 			},
 			buildpackLayers,
 			[]v1.Layer{
+				stackLayer,
 				orderLayer,
 			},
 		)...)

--- a/pkg/cnb/create_builder_test.go
+++ b/pkg/cnb/create_builder_test.go
@@ -295,6 +295,18 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 
 			})
 
+			layerTester.testNextLayer("Largest Buildpack Layer", func(index int) {
+				assert.Equal(t, layers[index], buildpack3Layer)
+			})
+
+			layerTester.testNextLayer("Middle Buildpack Layer", func(index int) {
+				assert.Equal(t, layers[index], buildpack2Layer)
+			})
+
+			layerTester.testNextLayer("Smallest Buildpack Layer", func(index int) {
+				assert.Equal(t, layers[index], buildpack1Layer)
+			})
+
 			layerTester.testNextLayer("stack Layer", func(index int) {
 				assertLayerContents(t, layers[index], map[string]content{
 					"/cnb/stack.toml": //language=toml
@@ -309,19 +321,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 				})
 			})
 
-			layerTester.testNextLayer("Largest Buildpack Layer", func(index int) {
-				assert.Equal(t, layers[index], buildpack3Layer)
-			})
-
-			layerTester.testNextLayer("Middle Buildpack Layer", func(index int) {
-				assert.Equal(t, layers[index], buildpack2Layer)
-			})
-
-			layerTester.testNextLayer("Smallest Buildpack Layer", func(index int) {
-				assert.Equal(t, layers[index], buildpack1Layer)
-			})
-
-			layerTester.testNextLayer("stack Layer", func(index int) {
+			layerTester.testNextLayer("order Layer", func(index int) {
 				assert.Equal(t, len(layers)-1, index)
 
 				assertLayerContents(t, layers[index], map[string]content{


### PR DESCRIPTION
The stack images are more likely to change than the buildpacks themselves. Moving the stack layer near the order layer and above the buildpack layers will ensure the fewest layers get pulled from upstream when a new builder is available (the docker daemon pulls all layers after the first changed layer)