### PR TITLE
Update Documentation to prepare for 0.0.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Kubernetes Native Container Build Service
 
-kpack extends [Kubernetes](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) and utilizes kubernetes primitives to provide builds of OCI images as a platform implementation of [Cloud Native Buildpacks](https://buildpacks.io) (CNB).
+kpack extends [Kubernetes](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) and utilizes unprivileged kubernetes primitives to provide builds of OCI images as a platform implementation of [Cloud Native Buildpacks](https://buildpacks.io) (CNB).
 
 kpack provides a declarative image type that builds an image and schedules image rebuilds on relevant buildpack and source changes.
 
@@ -20,6 +20,8 @@ kpack also provides a build type to execute a single Cloud Native Buildpack imag
     - [Images](docs/image.md)
     - [Secrets](docs/secrets.md)
     - [Builders](docs/builders.md)
+    - [Builds](docs/build.md)
+    - [CustomBuilders](docs/custombuilders.md)
 
 - Tailing logs with the kpack [log utility](docs/logs.md)
  

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,122 @@
+# Builds
+
+A Build is a resource that schedules and run a single [Cloud Native Buildpacks](http://buildpacks.io) build.
+
+Unlike with the [Image resource](image.md), using Builds directly allows granular control of when builds execute. Each build resource is immutable and corresponds to a single build execution. You will need to create a new build for every build execution as builds will not rebuild on source code and buildpack updates. Additionally, you will need to manually specify the source, and the cache volume. 
+
+### Configuration
+
+```yaml
+apiVersion: build.pivotal.io/v1alpha1
+kind: Build
+metadata:
+  name: sample-build
+spec:
+  tags:
+  - sample/image
+  serviceAccount: service-account
+  builder:
+    image: cloudfoundry/cnb:bionic
+    imagePullSecrets: 
+    - name: builder-secret  
+  cacheName: persisent-volume-claim-name
+  source:
+    git:
+      url: https://github.com/buildpack/sample-java-app.git
+      revision: master
+  env:
+  - name: "JAVA_BP_ENV"
+    value: "value"
+  resources:
+    limits:
+      cpu: "0.25"
+      memory: "128M"
+    requests:
+      cpu: "0.5"
+      memory: "256M"
+```
+
+- `tags`: A list of docker tags to build. At least one tag is required.
+- `serviceAccount`: The Service Account name that will be used for credential lookup. Check out the [secrets documentation](secrets.md) for more information. 
+- `builder.image`: This is the tag to the [Cloud Native Buildpacks builder image](https://buildpacks.io/docs/using-pack/working-with-builders/) to use in the build. Unlike on the Image resource, this is an image not a reference to a Builder resource.    
+- `builder.imagePullSecrets`: An optional list of pull secrets if the builder is in a private registry. [To create this secret please reference this link](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials)
+- `source`: The source location that wil be the input to the build. See the [Source Configuration](#source-config) section below.
+- `cacheName`: Optional name of a persistent volume claim to used for a build cache across builds.
+- `env`: Optional list of build time environment variables.
+- `resources`: Optional configurable resource limits on `CPU` and `memory`.
+
+> Note: All fields on a build are immutable. Instead of updating a build, create a new one.
+ 
+##### <a id='source-config'></a>Source Configuration
+
+The `source` field is a composition of a source code location and a `subpath`. It can be configured in exactly one of the following ways:
+
+* Git
+
+    ```yaml
+    source:
+      git:
+        url: ""
+        revision: ""
+      subPath: ""
+    ```
+    - `git`: (Source Code is a git repository)
+        - `url`: The git repository url. For now, only https repositories are supported.
+        - `revision`: The git revision to use. This value may be a commit sha, branch name, or tag.
+    - `subPath`: A subdirectory within the source folder where application code resides. Can be ignored if the source code resides at the `root` level.
+
+* Blob
+
+    ```yaml
+    source:
+      blob:
+        url: ""
+      subPath: ""
+    ```
+    - `blob`: (Source Code is a blob/jar in a blobstore)
+        - `url`: The URL of the source code blob. This blob needs to either be publicly accessible or have the access token in the URL
+    - `subPath`: A subdirectory within the source folder where application code resides. Can be ignored if the source code resides at the `root` level.
+
+* Registry
+
+    ```yaml
+    source:
+      registry:
+        image: ""
+        imagePullSecrets:
+        - name: ""
+      subPath: ""
+    ```
+    - `registry` ( Source code is an OCI image in a registry that contains application source)
+        - `image`: Location of the source image
+        - `imagePullSecrets`: A list of `dockercfg` or `dockerconfigjson` secret names required if the source image is private
+    - `subPath`: A subdirectory within the source folder where application code resides. Can be ignored if the source code resides at the `root` level.
+
+
+
+#### Status
+
+When a build complete successfully its status will report the fully qualified built image reference.
+
+If you are using `kubectl` this information is available with `kubectl get <build-name>` or `kubectl describe <build-name>`. 
+
+```yaml
+status:
+  conditions:
+  - lastTransitionTime: "2020-01-17T16:16:36Z"
+    status: "True"
+    type: Succeeded
+  latestImage: index.docker.io/sample/image@sha256:d3eb15a6fd25cb79039594294419de2328f14b443fa0546fa9e16f5214d61686
+  ...
+``` 
+
+When a build fails its status will report the condition Succeeded=False. 
+
+```yaml
+status:
+  conditions:
+  - lastTransitionTime: "2020-01-17T16:13:48Z"
+    status: "False"
+    type: Succeeded
+  ...
+``` 

--- a/docs/custombuilders.md
+++ b/docs/custombuilders.md
@@ -1,0 +1,125 @@
+# Experimental Custom Builders
+
+kpack provides the experimental CustomBuilder and CustomClusterBuilder resources to define and create [Cloud Native Buildpacks builders](https://buildpacks.io/docs/using-pack/working-with-builders/) all within the kpack api. 
+This allows more granular control of the buildpacks and buildpack versions utilized without relying on pre-existing Builder resources. 
+
+Before creating CustomBuilders you will need to create the Stack and Store resources described below. 
+
+### <a id='store'></a>Store
+
+The Store is a cluster scoped resource resource is a repository for buildpacks that can be utilized by CustomBuilders. As an input the store takes a list of images that contain buildpacks.
+
+```yaml
+apiVersion: experimental.kpack.pivotal.io/v1alpha1
+kind: Store
+metadata:
+  name: sample-store
+spec:
+  sources:
+  - image: gcr.io/cf-build-service-public/node-engine-buildpackage@sha256:95ff756f0ef0e026440a8523f4bab02fd8b45dc1a8a3a7ba063cefdba5cb9493
+  - image: gcr.io/cf-build-service-public/npm-buildpackage@sha256:5058ceb9a562ec647ea5a41008b0d11e32a56e13e8c9ec20c4db63d220373e33
+  - image: cloudfoundry/cnb:bionic
+```
+
+* `sources`:  List of builder images or buildpackage images to make available in the store. Each image is an object with the key image.   
+ 
+For kpack to use an image in the store it, the OCI image label 'io.buildpacks.buildpack.layers' must contain buildpacks and buildpack metadata (this label is viewable via docker inspect).
+ 
+### <a id='store'></a>Stack
+
+The Stack is a cluster scoped resource that provides the configuration for a [Cloud Native Buildpack stack](https://buildpacks.io/docs/concepts/components/stack/) that is available to be used in a Custom Builder.   
+
+The [pack CLI](https://github.com/buildpacks/pack) command: `pack suggest-stacks` will display a list of recommended stacks that can be used. We recommend starting with the `io.buildpacks.stacks.bionic` stack. 
+
+```yaml
+apiVersion: experimental.kpack.pivotal.io/v1alpha1
+kind: Stack
+metadata:
+  name: bionic-stack
+spec:
+  id: "io.buildpacks.stacks.bionic"
+  buildImage:
+    image: "cloudfoundry/build@sha256:b30b850f5b4d2e11313f0ec152952eace285ce7a3bc203ca5cdcfa8e5bb232a6"
+  runImage:
+    image: "cloudfoundry/run@sha256:ba9998ae4bb32ab43a7966c537aa1be153092ab0c7536eeef63bcd6336cbd0db"
+```
+
+* `id`:  The 'id' of the stack
+* `buildImage.image`: The build image of stack.   
+* `runImage.image`: The run image of stack.
+
+> Note: The stack resource will not poll for updates. A CI/CD tool is needed to update the resource with new digests when new images are available.     
+
+### <a id='store'></a>Custom Builders
+
+The CustomBuilder uses a [Store](#store), a [Stack](#stack), and an order definition to construct a builder image.
+
+```yaml
+apiVersion: experimental.kpack.pivotal.io/v1alpha1
+kind: CustomBuilder
+metadata:
+  name: my-custom-builder
+spec:
+  tag: gcr.io/sample/custom-builder
+  serviceAccount: default
+  stack: bionic-stack
+  store: sample-store
+  order:
+  - group:
+    - id: org.cloudfoundry.node-engine
+    - id: org.cloudfoundry.yarn
+  - group:
+    - id: org.cloudfoundry.openjdk
+    - id: org.cloudfoundry.buildsystem
+      optional: true
+    - id: org.cloudfoundry.jvmapplication 
+```
+
+* `tag`: The tag to save the custom builder image. You must have access via the referenced service account.   
+* `serviceAccount`: A service account with credentials to write to the custom builder tag. 
+* `order`: The [builder order](https://buildpacks.io/docs/reference/builder-config/). 
+* `stack`: The name of the stack resource to use as the builder stack. All buildpacks in the order must be compatible with the stack.   
+* `store`: The name of the store resource to fetch buildpacks from.
+
+The custom builder can be referenced in an image configuration like this:
+
+```yaml
+builder:
+  name: my-custom-builder
+  kind: CustomBuilder
+```
+
+### <a id='store'></a>Custom Cluster Builders
+
+The CustomClusterBuilder resource is almost identical to a CustomBuilder but, it is a cluster scoped resource that can be referenced by an image in any namespace. Because CustomClusterBuilders are not in a namespace they cannot reference local service accounts. Instead the `serviceAccount` field is replaced with a `serviceAccountRef` field which is an object reference to a service account in any namespace.    
+
+```yaml
+apiVersion: experimental.kpack.pivotal.io/v1alpha1
+kind: CustomClusterBuilder
+metadata:
+  name: my-cluster-builder
+spec:
+  tag: sample/custom-builder
+  stack: bionic-stack
+  store: sample-store
+  serviceAccountRef:
+    name: default
+    namespace: default
+  order:
+  - group:
+    - id: org.cloudfoundry.node-engine
+    - id: org.cloudfoundry.yarn
+  - group:
+    - id: org.cloudfoundry.node-engine
+    - id: org.cloudfoundry.npm
+```
+
+* `serviceAccountRef`: An object reference to a service account in any namespace. The object reference must contain `name` and `namespace`.
+
+The custom cluster builder can be referenced in an image configuration like this:
+
+```yaml
+builder:
+  name: my-custom-builder
+  kind: CustomBuilder
+```

--- a/docs/image.md
+++ b/docs/image.md
@@ -41,6 +41,8 @@ The `builder` field describes the [builder resource](builders.md) that will buil
 
 > Note: This image can only reference builders defined in the same namespace. This is not true for ClusterBuilders because they are not namespace scoped.
 
+* Additionally, an image can be configured with the experimental CustomBuilder & CustomClusterBuilder resources. Check out the [experimental custom builder documentation](custombuilders.md) for more info.  
+
 ### <a id='source-config'></a>Source Configuration
 
 The `source` field is a composition of a source code location and a `subpath`. It can be configured in exactly one of the following ways:
@@ -81,7 +83,7 @@ The `source` field is a composition of a source code location and a `subpath`. I
         - name: ""
       subPath: ""
     ```
-    - `registry` ( Source code is an OCI image in a registry)
+    - `registry` ( Source code is an OCI image in a registry that contains application source)
         - `image`: Location of the source image
         - `imagePullSecrets`: A list of `dockercfg` or `dockerconfigjson` secret names required if the source image is private
     - `subPath`: A subdirectory within the source folder where application code resides. Can be ignored if the source code resides at the `root` level.
@@ -181,3 +183,30 @@ spec:
         cpu: 50m
         memory: 512M
 ```
+
+#### Status
+
+When an image has successfully built with its current configuration, its status will report the up to date fully qualified built image reference.
+
+If you are using `kubectl` this information is available with `kubectl get <image-name>` or `kubectl describe <image-name>`. 
+
+```yaml
+status:
+  conditions:
+  - lastTransitionTime: "2020-01-17T16:16:36Z"
+    status: "True"
+    type: Succeeded
+  latestImage: index.docker.io/sample/image@sha256:d3eb15a6fd25cb79039594294419de2328f14b443fa0546fa9e16f5214d61686
+  ...
+``` 
+
+When a build fails its status will report the condition Succeeded=False. 
+
+```yaml
+status:
+  conditions:
+  - lastTransitionTime: "2020-01-17T16:13:48Z"
+    status: "False"
+    type: Succeeded
+  ...
+``` 

--- a/docs/install.md
+++ b/docs/install.md
@@ -9,33 +9,17 @@
 
 ## Installing-kpack
 
-1. Download the most recent [github release](https://github.com/pivotal/kpack/releases).
+1. Download the most recent [github release](https://github.com/pivotal/kpack/releases). The release.yaml is an asset on the release. 
 
    ```bash
-   kubectl apply  --filename release.yaml
+   kubectl apply  --filename release-<version>.yaml
    ```
 
-1. Ensure that the kpack controller has a status of `Running` using  `kubectl get`.   
+1. Ensure that the kpack controller & webhook have a status of `Running` using  `kubectl get`.   
 
    ```bash
    kubectl get pods --namespace kpack --watch
    ```
-
-1. Check the logs to confirm the kpack controller started without error. You'll see something like this. If you see errors, please address them before continuing.
-
-    ```bash
-    kubectl -n kpack logs deployment/kpack-controller -f
-    2019-09-27T18:49:32.373Z	INFO	controller/controller.go:277	Starting controller and workers
-    2019-09-27T18:49:32.373Z	INFO	controller/controller.go:287	Started workers
-    2019-09-27T18:49:32.373Z	INFO	controller/controller.go:277	Starting controller and workers
-    2019-09-27T18:49:32.374Z	INFO	controller/controller.go:287	Started workers
-    2019-09-27T18:49:32.374Z	INFO	controller/controller.go:277	Starting controller and workers
-    2019-09-27T18:49:32.374Z	INFO	controller/controller.go:287	Started workers
-    2019-09-27T18:49:32.374Z	INFO	controller/controller.go:277	Starting controller and workers
-    2019-09-27T18:49:32.374Z	INFO	controller/controller.go:277	Starting controller and workers
-    2019-09-27T18:49:32.374Z	INFO	controller/controller.go:287	Started workers
-    2019-09-27T18:49:32.374Z	INFO	controller/controller.go:287	Started workers
-    ```
 
 1. Create a [ClusterBuilder](builders.md) resource. A ClusterBuilder is a reference to a [Cloud Native Buildpacks builder image](https://buildpacks.io/docs/using-pack/working-with-builders/). 
 The Builder image contains buildpacks that will be used to build images with kpack. We recommend starting with the [cloudfoundry/cnb:bionic](https://hub.docker.com/r/cloudfoundry/cnb) image which has support for Java, Node and Go.         
@@ -44,7 +28,7 @@ The Builder image contains buildpacks that will be used to build images with kpa
 apiVersion: build.pivotal.io/v1alpha1
 kind: ClusterBuilder
 metadata:
-  name: default-builder
+  name: default
 spec:
   image: cloudfoundry/cnb:bionic
 ```
@@ -52,78 +36,104 @@ spec:
 Apply the ClusterBuilder yaml to the cluster
 
 ```bash
-kubectl apply -f <name-of-cluster-builder-file.yaml>
+kubectl apply -f cluster-builder.yaml
 ```
 
 Ensure that kpack has processed the builder by running
 
 ```bash
-kubectl get clusterbuilder default-builder -o yaml
+kubectl describe clusterbuilder default
 ``` 
 
 You should see output similar to the following:
 
-```yaml
-apiVersion: build.pivotal.io/v1alpha1
-kind: ClusterBuilder
-metadata:
-  creationTimestamp: "2019-09-19T15:05:01Z"
-  generation: 1
-  name: default-builder
-  resourceVersion: "21823241"
-  selfLink: /apis/build.pivotal.io/v1alpha1/clusterbuilders/cluster-build-service-builder
-  uid: dabd3f65-daee-11e9-827a-42010a800176
-spec:
-  image: cloudfoundry/cnb:bionic
-status:
-  builderMetadata:
-  - key: org.cloudfoundry.nodejs
-    version: 0.0.2-RC3
-  - key: org.cloudfoundry.go-compiler
-    version: 0.0.24
-  - key: org.cloudfoundry.go-mod
-    version: 0.0.22
-  - key: org.cloudfoundry.dep
-    version: 0.0.21
-  - key: org.cloudfoundry.openjdk
-    version: 1.0.0-RC05
-  - key: org.cloudfoundry.buildsystem
-    version: 1.0.0-RC05
-  - key: org.cloudfoundry.jvmapplication
-    version: 1.0.0-RC05
-  - key: org.cloudfoundry.azureapplicationinsights
-    version: 1.0.0-RC05
-  - key: org.cloudfoundry.debug
-    version: 1.0.0-RC05
-  - key: org.cloudfoundry.googlestackdriver
-    version: 1.0.0-RC05
-  - key: org.cloudfoundry.jmx
-    version: 1.0.0-RC05
-  - key: org.cloudfoundry.procfile
-    version: 1.0.0-RC05
-  - key: org.cloudfoundry.archiveexpanding
-    version: 1.0.0-RC05
-  - key: org.cloudfoundry.tomcat
-    version: 1.0.0-RC05
-  - key: org.cloudfoundry.jdbc
-    version: 1.0.0-RC05
-  - key: org.cloudfoundry.springautoreconfiguration
-    version: 1.0.0-RC05
-  - key: org.cloudfoundry.springboot
-    version: 1.0.0-RC05
-  - key: org.cloudfoundry.distzip
-    version: 1.0.0-RC05
-  - key: org.cloudfoundry.node-engine
-    version: 0.0.49
-  - key: org.cloudfoundry.npm
-    version: 0.0.30
-  - key: org.cloudfoundry.yarn
-    version: 0.0.28
-  conditions:
-  - lastTransitionTime: null
-    status: "True"
-    type: Ready
-  latestImage: index.docker.io/cloudfoundry/cnb@sha256:e390f8c7ce696b222197a0e02687aeee6612a9815f78b6f5876de3cb3efd7ba3
-  observedGeneration: 1
+```text
+Name:         default
+Namespace:    
+Labels:       <none>
+Annotations:  kubectl.kubernetes.io/last-applied-configuration:
+                {"apiVersion":"build.pivotal.io/v1alpha1","kind":"ClusterBuilder","metadata":{"annotations":{},"name":"default"},"spec":{"image":"cloudfou...
+API Version:  build.pivotal.io/v1alpha1
+Kind:         ClusterBuilder
+Metadata:
+  Creation Timestamp:  2020-01-17T17:52:19Z
+  Generation:          1
+  Resource Version:    80893
+  Self Link:           /apis/build.pivotal.io/v1alpha1/clusterbuilders/default
+  UID:                 1af16b4f-3952-11ea-89bb-025000000001
+Spec:
+  Image:          cloudfoundry/cnb:bionic
+  Update Policy:  polling
+Status:
+  Builder Metadata:
+    Id:       org.cloudfoundry.debug
+    Version:  v1.1.17
+    Id:       org.cloudfoundry.dotnet-core
+    Version:  v0.0.4
+    Id:       org.cloudfoundry.go
+    Version:  v0.0.2
+    Id:       org.cloudfoundry.springautoreconfiguration
+    Version:  v1.0.159
+    Id:       org.cloudfoundry.buildsystem
+    Version:  v1.0.186
+    Id:       org.cloudfoundry.procfile
+    Version:  v1.0.62
+    Id:       org.cloudfoundry.nodejs
+    Version:  v1.0.0
+    Id:       org.cloudfoundry.distzip
+    Version:  v1.0.144
+    Id:       org.cloudfoundry.jdbc
+    Version:  v1.0.153
+    Id:       org.cloudfoundry.azureapplicationinsights
+    Version:  v1.0.151
+    Id:       org.cloudfoundry.springboot
+    Version:  v1.0.157
+    Id:       org.cloudfoundry.openjdk
+    Version:  v1.0.80
+    Id:       org.cloudfoundry.tomcat
+    Version:  v1.1.74
+    Id:       org.cloudfoundry.googlestackdriver
+    Version:  v1.0.96
+    Id:       org.cloudfoundry.jmx
+    Version:  v1.0.153
+    Id:       org.cloudfoundry.archiveexpanding
+    Version:  v1.0.102
+    Id:       org.cloudfoundry.jvmapplication
+    Version:  v1.0.113
+    Id:       org.cloudfoundry.dotnet-core-aspnet
+    Version:  0.0.97
+    Id:       org.cloudfoundry.dotnet-core-build
+    Version:  0.0.55
+    Id:       org.cloudfoundry.dotnet-core-conf
+    Version:  0.0.98
+    Id:       org.cloudfoundry.dotnet-core-runtime
+    Version:  0.0.106
+    Id:       org.cloudfoundry.dotnet-core-sdk
+    Version:  0.0.99
+    Id:       org.cloudfoundry.icu
+    Version:  0.0.25
+    Id:       org.cloudfoundry.node-engine
+    Version:  0.0.133
+    Id:       org.cloudfoundry.dep
+    Version:  0.0.64
+    Id:       org.cloudfoundry.go-compiler
+    Version:  0.0.55
+    Id:       org.cloudfoundry.go-mod
+    Version:  0.0.58
+    Id:       org.cloudfoundry.nodejs-compat
+    Version:  0.0.68
+    Id:       org.cloudfoundry.npm
+    Version:  0.0.83
+    Id:       org.cloudfoundry.yarn
+    Version:  0.0.94
+  Conditions:
+    Last Transition Time:  2020-01-17T17:52:19Z
+    Status:                True
+    Type:                  Ready
+  Latest Image:            index.docker.io/cloudfoundry/cnb@sha256:c983fb9602a7fb95b07d35ef432c04ad61ae8458263e7fb4ce62ca10de367c3b
+  Observed Generation:     1
+  Stack:
+    Id:         io.buildpacks.stacks.bionic
+    Run Image:  index.docker.io/cloudfoundry/run@sha256:ba9998ae4bb32ab43a7966c537aa1be153092ab0c7536eeef63bcd6336cbd0db
 ```
 

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -23,4 +23,4 @@ To tail logs from an image in a different namespace
 logs -image <image-name> -namespace <namespace>
 ```
 
-> The log utility will not exit when the build finishes.  
+> Note: The log utility will not exit when the build finishes.  

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -27,16 +27,16 @@ kind: Secret
 metadata:
   name: basic-docker-user-pass
   annotations:
-    build.pivotal.io/docker: index.docker.io
+    build.pivotal.io/docker: https://index.docker.io/v1/
 type: kubernetes.io/basic-auth
 stringData:
   username: <username>
   password: <password>
 ```
         
-> Note: The secret must be annotated with the registry prefix for its corresponding registry. For [dockerhub](https://hub.docker.com/) this should be `index.docker.io`. For GCR this should be `gcr.io`. 
+> Note: The secret must be annotated with the registry prefix for its corresponding registry. For [dockerhub](https://hub.docker.com/) this should be `https://index.docker.io/v1/`. For GCR this should be `gcr.io`. 
 
-### Git Registry Secrets
+### Git Secrets
 
 kubernetes.io/basic-auth secrets are used with a `build.pivotal.io/git` annotation that references a remote git location.      
 


### PR DESCRIPTION
 - De-emphasize git polling in tutorial
 - Use PetClinic instead of the buildpacks/samples app
 - Add standalone build documentation
 - Add Documentation on CustomBuilders and CustomClusterBuilders