### PR TITLE
Add ability to tag CustomBuilders with additional tags during creation

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -57,12 +57,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/buildpacks/imgutil v0.0.0-20191212154113-dc184e0d403b h1:SDsB0hJtURA+5i5vIjLntzRNPEqdoz6q+0MShCWdctw=
-github.com/buildpacks/imgutil v0.0.0-20191212154113-dc184e0d403b/go.mod h1:E3lXJcNXcRefJQAHW5rqboonet+jtOml4qImbJhYGAo=
 github.com/buildpacks/imgutil v0.0.0-20200115144305-2289fbc194a6 h1:faTLKnJXfBiK7jQlrCw64H1brZ/UABk5BGM5sTwTgdU=
 github.com/buildpacks/imgutil v0.0.0-20200115144305-2289fbc194a6/go.mod h1:E3lXJcNXcRefJQAHW5rqboonet+jtOml4qImbJhYGAo=
-github.com/buildpacks/lifecycle v0.5.1-0.20200110184618-3beb2de620e8 h1:v5wAh700qonBg+REbXUx4X/rBFn/pWsYOaMCHOqOvwo=
-github.com/buildpacks/lifecycle v0.5.1-0.20200110184618-3beb2de620e8/go.mod h1:ZIuIs9B6tjAW4dthhltKVyEUlhRfFWWix9eqoInMGX4=
 github.com/buildpacks/lifecycle v0.6.0 h1:GuFvJiTjiypP/MJoVJ8z9mUdYCjkgHWnHrPYIKuXnLs=
 github.com/buildpacks/lifecycle v0.6.0/go.mod h1:6QD+o2zODTKMFrm1GQBtM8TuLQ1ZQ6Wj9zLA1HU3rbI=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pivotal/kpack/pkg/registry"
@@ -20,10 +22,16 @@ func TestClient(t *testing.T) {
 }
 
 func testClient(t *testing.T, when spec.G, it spec.S) {
-	handler := http.NewServeMux()
-	server := httptest.NewServer(handler)
-	tagName := fmt.Sprintf("%s/some/image:tag", server.URL[7:])
-	subject := &registry.Client{}
+	const (
+		layerCount = 0
+	)
+
+	var (
+		handler = http.NewServeMux()
+		server  = httptest.NewServer(handler)
+		tagName = fmt.Sprintf("%s/some/image:tag", server.URL[7:])
+		subject = &registry.Client{}
+	)
 
 	when("Fetch", func() {
 		when("#Identifer", func() {
@@ -45,23 +53,47 @@ func testClient(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("Save", func() {
+
 		it("should save", func() {
-			image := randomImage(t)
+			image := randomImage(t, layerCount)
+			var (
+				numberOfLayerUploads       = 0
+				numberOfManifestsSaves     = 0
+				numberOfAdditionalTagSaves = 0
+			)
 
 			handler.HandleFunc("/v2/some/image/blobs/", func(writer http.ResponseWriter, request *http.Request) {
 				writer.WriteHeader(200)
+				numberOfLayerUploads++
 			})
 
 			handler.HandleFunc("/v2/some/image/manifests/tag", func(writer http.ResponseWriter, request *http.Request) {
 				if request.Method == "GET" {
 					writer.WriteHeader(404)
+					return
 				}
+
+				numberOfManifestsSaves++
 				writer.WriteHeader(201)
+			})
+
+			handler.HandleFunc("/v2/some/image/manifests/", func(writer http.ResponseWriter, request *http.Request) {
+				if request.Method == "GET" {
+					t.Errorf("unexpected %s to %s", request.Method, request.URL)
+					writer.WriteHeader(404)
+					return
+				}
+				assert.Regexp(t, regexp.MustCompile("/v2/some/image/manifests/\\d{14}"), request.RequestURI)
+				numberOfAdditionalTagSaves++
+
+				writer.WriteHeader(200)
 			})
 
 			handler.HandleFunc("/v2/", func(writer http.ResponseWriter, request *http.Request) {
 				if request.Method != "GET" {
-					t.Fatalf("unexpected %s to %s", request.Method, request.URL)
+					t.Errorf("unexpected %s to %s", request.Method, request.URL)
+					writer.WriteHeader(404)
+					return
 				}
 
 				writer.WriteHeader(200)
@@ -69,10 +101,15 @@ func testClient(t *testing.T, when spec.G, it spec.S) {
 
 			_, err := subject.Save(authn.DefaultKeychain, tagName, image)
 			require.NoError(t, err)
+
+			const configLayer = 1
+			assert.Equal(t, numberOfLayerUploads, layerCount+configLayer)
+			assert.Equal(t, numberOfManifestsSaves, 1)
+			assert.Equal(t, numberOfAdditionalTagSaves, 1)
 		})
 
 		it("does not save images if exisiting image already exisits", func() {
-			image := randomImage(t)
+			image := randomImage(t, layerCount)
 
 			handler.HandleFunc("/v2/some/image/manifests/tag", func(writer http.ResponseWriter, request *http.Request) {
 				configFile, err := image.RawManifest()
@@ -96,8 +133,8 @@ func testClient(t *testing.T, when spec.G, it spec.S) {
 	})
 }
 
-func randomImage(t *testing.T) v1.Image {
-	image, err := random.Image(5, 10)
+func randomImage(t *testing.T, layers int64) v1.Image {
+	image, err := random.Image(5, layers)
 	require.NoError(t, err)
 	return image
 }


### PR DESCRIPTION
- This prevents accidental GC of existing builder images on registries like Artifactory that clean up untagged images