### PR TITLE
Preemptively load azurecredentialhelperfix package for real

### DIFF
--- a/pkg/dockercreds/k8sdockercreds/k8s_keychain.go
+++ b/pkg/dockercreds/k8sdockercreds/k8s_keychain.go
@@ -1,6 +1,8 @@
 package k8sdockercreds
 
 import (
+	_ "github.com/pivotal/kpack/pkg/dockercreds/k8sdockercreds/azurecredentialhelperfix"
+
 	"sort"
 
 	"github.com/google/go-containerregistry/pkg/authn"

--- a/pkg/dockercreds/k8sdockercreds/k8s_keychain_test.go
+++ b/pkg/dockercreds/k8sdockercreds/k8s_keychain_test.go
@@ -1,8 +1,6 @@
 package k8sdockercreds
 
 import (
-	_ "github.com/pivotal/kpack/pkg/dockercreds/k8sdockercreds/azurecredentialhelperfix"
-
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/authn"


### PR DESCRIPTION

 - Previously it was only getting loaded in tests preventing it from being picked up in the actual controller