### PR TITLE
Implements RFC0013 for generating app source project metadata

### DIFF
--- a/cmd/build-init/main.go
+++ b/cmd/build-init/main.go
@@ -45,6 +45,7 @@ const (
 	buildSecretsDir       = "/var/build-secrets"
 	imagePullSecretsDir   = "/imagePullSecrets"
 	builderPullSecretsDir = "/builderPullSecrets"
+	layersDir             = "/alt-layers"
 )
 
 func main() {
@@ -114,7 +115,7 @@ func fetchSource(logger *log.Logger, serviceAccountCreds dockercreds.DockerCreds
 			Logger:   logger,
 			Keychain: gitKeychain,
 		}
-		return fetcher.Fetch(appDir, *gitURL, *gitRevision)
+		return fetcher.Fetch(appDir, *gitURL, *gitRevision, layersDir)
 	case *blobURL != "":
 		fetcher := blob.Fetcher{
 			Logger: logger,

--- a/pkg/apis/build/v1alpha1/build_pod.go
+++ b/pkg/apis/build/v1alpha1/build_pod.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/kmeta"
 )
 
@@ -65,6 +65,10 @@ var (
 	layersVolume = corev1.VolumeMount{
 		Name:      layersDirName,
 		MountPath: "/layers",
+	}
+	alternativeLayersVolumeMount = corev1.VolumeMount{
+		Name:      layersDirName,
+		MountPath: "/alt-layers",
 	}
 	homeEnv = corev1.EnvVar{
 		Name:  "HOME",
@@ -170,6 +174,7 @@ func (b *Build) BuildPod(config BuildPodImages, secrets []corev1.Secret, bc Buil
 							platformVolume,
 							sourceVolume,
 							homeVolume,
+							alternativeLayersVolumeMount,
 						),
 					},
 				)


### PR DESCRIPTION
- when fetching the git repository it creates as for https://github.com/buildpacks/lifecycle/pull/230 a project-metadata.toml file containing information about the git repository
- the layers volume need to be mounted on a different path because if mounted on `/layers` because the `prepare` container is built itself using `pack` and already contains a `/layers` directory. The specific failure is the launcher failing to read some expected file.
 - this change can work independently from https://github.com/buildpacks/lifecycle/pull/230

Example of generated toml file

```toml
[source]
type = "git"

  [source.version]
  commit = "3b5a3...698317"

  [source.metadata]
  repository = "https://github.com/carlo-colombo/java-maven.git"
  revision = "3b5a3d...698317"
```
