### PR TITLE
Utilize updated buildpack metadata types

### DIFF
--- a/pkg/apis/experimental/v1alpha1/buildpack_types.go
+++ b/pkg/apis/experimental/v1alpha1/buildpack_types.go
@@ -25,3 +25,9 @@ type BuildpackInfo struct {
 func (b BuildpackInfo) String() string {
 	return fmt.Sprintf("%s@%s", b.Id, b.Version)
 }
+
+// +k8s:openapi-gen=true
+type BuildpackStack struct {
+	ID     string   `json:"id"`
+	Mixins []string `json:"mixins,omitempty"`
+}

--- a/pkg/apis/experimental/v1alpha1/buildpack_types.go
+++ b/pkg/apis/experimental/v1alpha1/buildpack_types.go
@@ -28,6 +28,8 @@ func (b BuildpackInfo) String() string {
 
 // +k8s:openapi-gen=true
 type BuildpackStack struct {
-	ID     string   `json:"id"`
+	ID string `json:"id"`
+
+	// +listType
 	Mixins []string `json:"mixins,omitempty"`
 }

--- a/pkg/apis/experimental/v1alpha1/store_types.go
+++ b/pkg/apis/experimental/v1alpha1/store_types.go
@@ -45,13 +45,15 @@ type StoreStatus struct {
 type StoreBuildpack struct {
 	BuildpackInfo `json:",inline"`
 	StoreImage    StoreImage `json:"storeImage,omitempty"`
+	API           string     `json:"api,omitempty"`
+	DiffId        string     `json:"diffId,omitempty"`
+	Digest        string     `json:"digest,omitempty"`
+	Size          int64      `json:"size,omitempty"`
+
 	// +listType
-	API    string           `json:"api,omitempty"`
-	Order  []OrderEntry     `json:"order,omitempty"`
+	Order []OrderEntry `json:"order,omitempty"`
+	// +listType
 	Stacks []BuildpackStack `json:"stacks,omitempty"`
-	DiffId string           `json:"diffId,omitempty"`
-	Digest string           `json:"digest,omitempty"`
-	Size   int64            `json:"size,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/experimental/v1alpha1/store_types.go
+++ b/pkg/apis/experimental/v1alpha1/store_types.go
@@ -46,10 +46,12 @@ type StoreBuildpack struct {
 	BuildpackInfo `json:",inline"`
 	StoreImage    StoreImage `json:"storeImage,omitempty"`
 	// +listType
-	Order  []OrderEntry `json:"order,omitempty"`
-	DiffId string       `json:"diffId,omitempty"`
-	Digest string       `json:"digest,omitempty"`
-	Size   int64        `json:"size,omitempty"`
+	API    string           `json:"api,omitempty"`
+	Order  []OrderEntry     `json:"order,omitempty"`
+	Stacks []BuildpackStack `json:"stacks,omitempty"`
+	DiffId string           `json:"diffId,omitempty"`
+	Digest string           `json:"digest,omitempty"`
+	Size   int64            `json:"size,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/cnb/builder_builder.go
+++ b/pkg/cnb/builder_builder.go
@@ -100,10 +100,7 @@ func (bb *BuilderBuilder) writeableImage() (v1.Image, error) {
 
 	for _, key := range buildpacks {
 		layer := bb.buildpackLayers[key]
-		if err := buildpackLayerMetadata.add(layer); err != nil {
-			return nil, err
-		}
-
+		buildpackLayerMetadata.add(layer)
 		buildpackLayers = append(buildpackLayers, layer.v1Layer)
 	}
 

--- a/pkg/cnb/builder_layers.go
+++ b/pkg/cnb/builder_layers.go
@@ -1,18 +1,6 @@
 package cnb
 
-import (
-	"github.com/pkg/errors"
-
-	expv1alpha1 "github.com/pivotal/kpack/pkg/apis/experimental/v1alpha1"
-)
-
 type BuildpackLayerMetadata map[string]map[string]BuildpackLayerInfo
-
-type BuildpackLayerInfo struct {
-	LayerDigest string            `json:"layerDigest"`
-	LayerDiffID string            `json:"layerDiffID"`
-	Order       expv1alpha1.Order `json:"order,omitempty"`
-}
 
 func (l BuildpackLayerMetadata) add(layer buildpackLayer) error {
 	_, ok := l[layer.BuildpackInfo.Id]
@@ -20,21 +8,6 @@ func (l BuildpackLayerMetadata) add(layer buildpackLayer) error {
 		l[layer.BuildpackInfo.Id] = map[string]BuildpackLayerInfo{}
 	}
 
-	diffId, err := layer.v1Layer.DiffID()
-	if err != nil {
-		return errors.Wrapf(err, "fetching %s@%s layer diff id", layer.BuildpackInfo.Id, layer.BuildpackInfo.Version)
-	}
-
-	digest, err := layer.v1Layer.Digest()
-	if err != nil {
-		return errors.Wrapf(err, "fetching %s@%s layer digest", layer.BuildpackInfo.Id, layer.BuildpackInfo.Version)
-	}
-
-	l[layer.BuildpackInfo.Id][layer.BuildpackInfo.Version] = BuildpackLayerInfo{
-		LayerDigest: digest.String(),
-		LayerDiffID: diffId.String(),
-		Order:       layer.Order,
-	}
-
+	l[layer.BuildpackInfo.Id][layer.BuildpackInfo.Version] = layer.BuildpackLayerInfo
 	return nil
 }

--- a/pkg/cnb/builder_layers.go
+++ b/pkg/cnb/builder_layers.go
@@ -2,12 +2,11 @@ package cnb
 
 type BuildpackLayerMetadata map[string]map[string]BuildpackLayerInfo
 
-func (l BuildpackLayerMetadata) add(layer buildpackLayer) error {
+func (l BuildpackLayerMetadata) add(layer buildpackLayer) {
 	_, ok := l[layer.BuildpackInfo.Id]
 	if !ok {
 		l[layer.BuildpackInfo.Id] = map[string]BuildpackLayerInfo{}
 	}
 
 	l[layer.BuildpackInfo.Id][layer.BuildpackInfo.Version] = layer.BuildpackLayerInfo
-	return nil
 }

--- a/pkg/cnb/buildpack_metadata.go
+++ b/pkg/cnb/buildpack_metadata.go
@@ -2,6 +2,7 @@ package cnb
 
 import (
 	"github.com/pivotal/kpack/pkg/apis/experimental/v1alpha1"
+	expv1alpha1 "github.com/pivotal/kpack/pkg/apis/experimental/v1alpha1"
 )
 
 const (
@@ -10,6 +11,18 @@ const (
 	buildpackMetadataLabel = "io.buildpacks.builder.metadata"
 	lifecycleMetadataLabel = "io.buildpacks.lifecycle.metadata"
 )
+
+type BuildpackLayerInfo struct {
+	API         string                       `json:"api"`
+	LayerDiffID string                       `json:"layerDiffID"`
+	Order       expv1alpha1.Order            `json:"order,omitempty"`
+	Stacks      []expv1alpha1.BuildpackStack `json:"stacks,omitempty"`
+}
+
+type Stack struct {
+	ID     string   `json:"id"`
+	Mixins []string `json:"mixins,omitempty"`
+}
 
 type BuilderImageMetadata struct {
 	Description string                   `json:"description"`
@@ -33,11 +46,6 @@ type CreatorMetadata struct {
 	Version string `json:"version"`
 }
 
-type Stack struct {
-	RunImage string
-	ID       string
-}
-
 type LifecycleMetadata struct {
 	LifecycleInfo
 	API LifecycleAPI `json:"api,omitempty"`
@@ -55,4 +63,9 @@ type LifecycleInfo struct {
 type LifecycleAPI struct {
 	BuildpackVersion string `toml:"buildpack" json:"buildpack,omitempty"`
 	PlatformVersion  string `toml:"platform" json:"platform,omitempty"`
+}
+
+type BuiltImageStack struct {
+	RunImage string
+	ID       string
 }

--- a/pkg/cnb/cnb_metadata.go
+++ b/pkg/cnb/cnb_metadata.go
@@ -116,7 +116,7 @@ type BuiltImage struct {
 	Identifier        string
 	CompletedAt       time.Time
 	BuildpackMetadata []lifecycle.Buildpack
-	Stack             Stack
+	Stack             BuiltImageStack
 }
 
 func readBuiltImage(appImage ggcrv1.Image, appImageId string) (BuiltImage, error) {
@@ -156,7 +156,7 @@ func readBuiltImage(appImage ggcrv1.Image, appImageId string) (BuiltImage, error
 		Identifier:        appImageId,
 		CompletedAt:       imageCreatedAt,
 		BuildpackMetadata: buildMetadata.Buildpacks,
-		Stack: Stack{
+		Stack: BuiltImageStack{
 			RunImage: baseImageRef.Context().String() + "@" + runImageRef.Identifier(),
 			ID:       stackId,
 		},

--- a/pkg/cnb/create_builder.go
+++ b/pkg/cnb/create_builder.go
@@ -69,6 +69,17 @@ func (r *RemoteBuilderCreator) CreateBuilder(keychain authn.Keychain, buildpackR
 			RunImage: stack.Status.RunImage.LatestImage,
 			ID:       stack.Spec.Id,
 		},
-		Buildpacks: builderBuilder.buildpacks(),
+		Buildpacks: buildpackMetadata(builderBuilder.buildpacks()),
 	}, nil
+}
+
+func buildpackMetadata(buildpacks []expv1alpha1.BuildpackInfo) v1alpha1.BuildpackMetadataList {
+	m := make(v1alpha1.BuildpackMetadataList, 0, len(buildpacks))
+	for _, b := range buildpacks {
+		m = append(m, v1alpha1.BuildpackMetadata{
+			Id:      b.Id,
+			Version: b.Version,
+		})
+	}
+	return m
 }

--- a/pkg/cnb/create_builder_test.go
+++ b/pkg/cnb/create_builder_test.go
@@ -120,6 +120,15 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 				Id:      "io.buildpack.1",
 				Version: "v1",
 			},
+			BuildpackLayerInfo: BuildpackLayerInfo{
+				API:         "0.2",
+				LayerDiffID: buildpack1Layer.diffID,
+				Stacks: []expv1alpha1.BuildpackStack{
+					{
+						ID: "io.buildpacks.stacks.cflinuxfs3",
+					},
+				},
+			},
 		},
 	})
 
@@ -130,6 +139,15 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 				Id:      "io.buildpack.3",
 				Version: "v2",
 			},
+			BuildpackLayerInfo: BuildpackLayerInfo{
+				API:         "0.2",
+				LayerDiffID: buildpack3Layer.diffID,
+				Stacks: []expv1alpha1.BuildpackStack{
+					{
+						ID: "io.buildpacks.stacks.cflinuxfs3",
+					},
+				},
+			},
 		},
 		{
 			v1Layer: buildpack2Layer,
@@ -137,16 +155,28 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 				Id:      "io.buildpack.2",
 				Version: "v1",
 			},
-			Order: expv1alpha1.Order{
-				{
-					Group: []expv1alpha1.BuildpackRef{
-						{
-							BuildpackInfo: expv1alpha1.BuildpackInfo{
-								Id:      "io.buildpack.3",
-								Version: "v2",
+			BuildpackLayerInfo: BuildpackLayerInfo{
+				API:         "0.2",
+				LayerDiffID: buildpack2Layer.diffID,
+				Order: expv1alpha1.Order{
+					{
+						Group: []expv1alpha1.BuildpackRef{
+							{
+								BuildpackInfo: expv1alpha1.BuildpackInfo{
+									Id:      "io.buildpack.3",
+									Version: "v2",
+								},
+								Optional: false,
 							},
-							Optional: false,
 						},
+					},
+				},
+				Stacks: []expv1alpha1.BuildpackStack{
+					{
+						ID: "io.buildpacks.stacks.cflinuxfs3",
+					},
+					{
+						ID: "io.some.other.stack",
 					},
 				},
 			},
@@ -392,13 +422,18 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 				`{
   "io.buildpack.1": {
     "v1": {
-      "layerDigest": "sha256:1bd8899667b8d1e6b124f663faca32903b470831e5e4e99265c839ab34628838",
-      "layerDiffID": "sha256:1bf8899667b8d1e6b124f663faca32903b470831e5e4e992644ac5c839ab3462"
+      "api": "0.2",
+      "layerDiffID": "sha256:1bf8899667b8d1e6b124f663faca32903b470831e5e4e992644ac5c839ab3462",
+      "stacks": [
+        {
+          "id": "io.buildpacks.stacks.cflinuxfs3"
+        }
+      ]
     }
   },
   "io.buildpack.2": {
     "v1": {
-      "layerDigest": "sha256:2bd8899667b8d1e6b124f663faca32903b470831e5e4e99265c839ab34628838",
+      "api": "0.2",
       "layerDiffID": "sha256:2bf8899667b8d1e6b124f663faca32903b470831e5e4e992644ac5c839ab3462",
       "order": [
         {
@@ -409,17 +444,29 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
             }
           ]
         }
+      ],
+      "stacks": [
+        {
+          "id": "io.buildpacks.stacks.cflinuxfs3"
+        },
+        {
+          "id": "io.some.other.stack"
+        }
       ]
     }
   },
   "io.buildpack.3": {
     "v2": {
-      "layerDigest": "sha256:3bd8899667b8d1e6b124f663faca32903b470831e5e4e99265c839ab34628838",
-      "layerDiffID": "sha256:3bf8899667b8d1e6b124f663faca32903b470831e5e4e992644ac5c839ab3462"
+      "api": "0.2",
+      "layerDiffID": "sha256:3bf8899667b8d1e6b124f663faca32903b470831e5e4e992644ac5c839ab3462",
+      "stacks": [
+        {
+          "id": "io.buildpacks.stacks.cflinuxfs3"
+        }
+      ]
     }
   }
-}
-`, buildpackLayers)
+}`, buildpackLayers)
 
 		})
 

--- a/pkg/cnb/remote_buildpack_metadata.go
+++ b/pkg/cnb/remote_buildpack_metadata.go
@@ -27,7 +27,7 @@ type RemoteBuildpackRef struct {
 }
 
 type buildpackLayer struct {
-	v1Layer       v1.Layer
-	BuildpackInfo v1alpha1.BuildpackInfo
-	Order         v1alpha1.Order
+	v1Layer            v1.Layer
+	BuildpackInfo      v1alpha1.BuildpackInfo
+	BuildpackLayerInfo BuildpackLayerInfo
 }

--- a/pkg/cnb/remote_store_reader.go
+++ b/pkg/cnb/remote_store_reader.go
@@ -58,11 +58,13 @@ func (r *RemoteStoreReader) Read(keychain authn.Keychain, storeImages []v1alpha1
 				order := metadata.Order
 				storeBP := v1alpha1.StoreBuildpack{
 					BuildpackInfo: info,
-					DiffId:        metadata.LayerDiffID,
 					StoreImage:    storeImage,
 					Order:         order,
+					DiffId:        metadata.LayerDiffID,
 					Digest:        digest.String(),
 					Size:          size,
+					API:           metadata.API,
+					Stacks:        metadata.Stacks,
 				}
 				buildpacks = append(buildpacks, storeBP)
 			}

--- a/pkg/cnb/remote_store_reader_test.go
+++ b/pkg/cnb/remote_store_reader_test.go
@@ -80,15 +80,51 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
             }
           ]
         }
+      ],
+      "api": "0.2",
+      "stacks": [
+        {
+          "id": "org.some.stack",
+          "mixins": [
+            "meta:mixin"
+          ]
+        },
+        {
+          "id": "org.meta.only.stack"
+        }
       ]
     }
   },
   "org.buildpack.multi": {
     "0.0.1": {
-      "layerDiffID": "sha256:114e397795eceac649afc159afb229211a9ad97b908f7ace225736b8774d9b00"
+      "layerDiffID": "sha256:114e397795eceac649afc159afb229211a9ad97b908f7ace225736b8774d9b00",
+      "api": "0.2",
+      "stacks": [
+        {
+          "id": "org.some.stack",
+          "mixins": [
+            "multi:mixin"
+          ]
+        },
+        {
+          "id": "org.multi.only.stack"
+        }
+      ]
     },
     "0.0.2": {
-      "layerDiffID": "sha256:fcc1dd482e41209737dadce3afd276a93d10d974c174fb72adddd3925b2f31d5"
+      "layerDiffID": "sha256:fcc1dd482e41209737dadce3afd276a93d10d974c174fb72adddd3925b2f31d5",
+      "api": "0.2",
+      "stacks": [
+        {
+          "id": "org.some.stack",
+          "mixins": [
+            "multi:mixin"
+          ]
+        },
+        {
+          "id": "org.multi.only.stack"
+        }
+      ]
     }
   }
 }
@@ -114,7 +150,19 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 				`{
   "org.buildpack.simple": {
     "0.0.1": {
-      "layerDiffID": "sha256:1fe2cf74b742ec16c76b9e996c247c78aa41905fe86b744db998094b4bcaf38a"
+      "layerDiffID": "sha256:1fe2cf74b742ec16c76b9e996c247c78aa41905fe86b744db998094b4bcaf38a",
+      "api": "0.2",
+      "stacks": [
+        {
+          "id": "org.some.stack",
+          "mixins": [
+            "simple:mixin"
+          ]
+        },
+        {
+          "id": "org.simple.only.stack"
+        }
+      ]
     }
   }
 }
@@ -145,6 +193,16 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 				StoreImage: v1alpha1.StoreImage{
 					Image: buildpackageA,
 				},
+				API: "0.2",
+				Stacks: []v1alpha1.BuildpackStack{
+					{
+						ID:     "org.some.stack",
+						Mixins: []string{"multi:mixin"},
+					},
+					{
+						ID: "org.multi.only.stack",
+					},
+				},
 				DiffId: "sha256:114e397795eceac649afc159afb229211a9ad97b908f7ace225736b8774d9b00",
 				Digest: "sha256:52f341c7c36e21e5c344856dd61bc8c2d1188647f259eaba6d375e37c9aed08e",
 				Size:   20,
@@ -154,12 +212,22 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 					Id:      "org.buildpack.multi",
 					Version: "0.0.2",
 				},
-				DiffId: "sha256:fcc1dd482e41209737dadce3afd276a93d10d974c174fb72adddd3925b2f31d5",
-				Digest: "sha256:d345d1b12ae6b3f7cfc617f7adaebe06c32ce60b1aa30bb80fb622b65523de8f",
-				Size:   30,
 				StoreImage: v1alpha1.StoreImage{
 					Image: buildpackageA,
 				},
+				API: "0.2",
+				Stacks: []v1alpha1.BuildpackStack{
+					{
+						ID:     "org.some.stack",
+						Mixins: []string{"multi:mixin"},
+					},
+					{
+						ID: "org.multi.only.stack",
+					},
+				},
+				DiffId: "sha256:fcc1dd482e41209737dadce3afd276a93d10d974c174fb72adddd3925b2f31d5",
+				Digest: "sha256:d345d1b12ae6b3f7cfc617f7adaebe06c32ce60b1aa30bb80fb622b65523de8f",
+				Size:   30,
 			})
 			require.Contains(t, storeBuildpacks,
 				v1alpha1.StoreBuildpack{
@@ -167,12 +235,10 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 						Id:      "org.buildpack.meta",
 						Version: "0.0.2",
 					},
-					DiffId: "sha256:1c6d357a885d873824545b40e1ccc9fd228c2dd38ba0acb9649955daf2941f94",
-					Digest: "sha256:c375a5c675104fe85cbd3042f5cfa6b1e56573c6d4e5d11224a62598532f3cc1",
-					Size:   10,
 					StoreImage: v1alpha1.StoreImage{
 						Image: buildpackageA,
 					},
+					API: "0.2",
 					Order: []v1alpha1.OrderEntry{
 						{
 							Group: []v1alpha1.BuildpackRef{
@@ -195,6 +261,18 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 							},
 						},
 					},
+					Stacks: []v1alpha1.BuildpackStack{
+						{
+							ID:     "org.some.stack",
+							Mixins: []string{"meta:mixin"},
+						},
+						{
+							ID: "org.meta.only.stack",
+						},
+					},
+					DiffId: "sha256:1c6d357a885d873824545b40e1ccc9fd228c2dd38ba0acb9649955daf2941f94",
+					Digest: "sha256:c375a5c675104fe85cbd3042f5cfa6b1e56573c6d4e5d11224a62598532f3cc1",
+					Size:   10,
 				})
 
 			require.Contains(t, storeBuildpacks, v1alpha1.StoreBuildpack{
@@ -205,6 +283,16 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 				DiffId: "sha256:1fe2cf74b742ec16c76b9e996c247c78aa41905fe86b744db998094b4bcaf38a",
 				Digest: "sha256:6aa3691a73805f608e5fce69fb6bc89aec8362f58a6b4be2682515e9cfa3cc1a",
 				Size:   40,
+				API:    "0.2",
+				Stacks: []v1alpha1.BuildpackStack{
+					{
+						ID:     "org.some.stack",
+						Mixins: []string{"simple:mixin"},
+					},
+					{
+						ID: "org.simple.only.stack",
+					},
+				},
 				StoreImage: v1alpha1.StoreImage{
 					Image: buildpackageB,
 				},

--- a/pkg/cnb/store_buildpack_repository.go
+++ b/pkg/cnb/store_buildpack_repository.go
@@ -41,7 +41,12 @@ func (s *StoreBuildpackRepository) FindByIdAndVersion(id, version string) (Remot
 		Layers: append(layers, buildpackLayer{
 			v1Layer:       layer,
 			BuildpackInfo: info,
-			Order:         storeBuildpack.Order,
+			BuildpackLayerInfo: BuildpackLayerInfo{
+				LayerDiffID: storeBuildpack.DiffId,
+				Order:       storeBuildpack.Order,
+				API:         storeBuildpack.API,
+				Stacks:      storeBuildpack.Stacks,
+			},
 		}),
 	}, nil
 }

--- a/pkg/reconciler/v1alpha1/build/build_test.go
+++ b/pkg/reconciler/v1alpha1/build/build_test.go
@@ -384,7 +384,7 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 					ID:      "io.buildpack.executed",
 					Version: "1.1",
 				}},
-				Stack: cnb.Stack{
+				Stack: cnb.BuiltImageStack{
 					RunImage: "somerun/123@sha256:12334563ad",
 					ID:       "io.buildpacks.stacks.bionic",
 				},


### PR DESCRIPTION
 - Only write diffID in the layers metadata
 - Write buildpack stack & api in layers metadata