### PR TITLE
Ensure clientsets are configured just once for acceptance tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/prometheus/procfs v0.0.5 // indirect
 	github.com/sclevine/spec v1.4.0
 	github.com/spf13/pflag v1.0.5
-	github.com/stretchr/testify v1.4.0
+	github.com/stretchr/testify v1.5.1
 	go.opencensus.io v0.22.1 // indirect
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/multierr v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -383,6 +383,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/tj/assert v0.0.0-20171129193455-018094318fb0 h1:Rw8kxzWo1mr6FSaYXjQELRe88y2KdfynXdnK72rdjtA=
 github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
 github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eNAjXGDx2yma7uG2XoyRZTq1uv3M/o7imD0=

--- a/test/e2e.go
+++ b/test/e2e.go
@@ -31,22 +31,24 @@ func newClients(t *testing.T) (*clients, error) {
 		defaultKubeconfig = path.Join(usr.HomeDir, ".kube/config")
 	}
 
-	kubeconfig := flag.String("kubeconfig", defaultKubeconfig, "Path to a kubeconfig. Only required if out-of-cluster.")
-	masterURL := flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	setup.Do(func() {
+		kubeconfig := flag.String("kubeconfig", defaultKubeconfig, "Path to a kubeconfig. Only required if out-of-cluster.")
+		masterURL := flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 
-	flag.Parse()
+		flag.Parse()
 
-	clusterConfig, err = clientcmd.BuildConfigFromFlags(*masterURL, *kubeconfig)
-	require.NoError(t, err)
+		clusterConfig, err = clientcmd.BuildConfigFromFlags(*masterURL, *kubeconfig)
+		require.NoError(t, err)
 
-	client, err = versioned.NewForConfig(clusterConfig)
-	require.NoError(t, err)
+		client, err = versioned.NewForConfig(clusterConfig)
+		require.NoError(t, err)
 
-	k8sClient, err = kubernetes.NewForConfig(clusterConfig)
-	require.NoError(t, err)
+		k8sClient, err = kubernetes.NewForConfig(clusterConfig)
+		require.NoError(t, err)
 
-	dynamicClient, err = dynamic.NewForConfig(clusterConfig)
-	require.NoError(t, err)
+		dynamicClient, err = dynamic.NewForConfig(clusterConfig)
+		require.NoError(t, err)
+	})
 
 	return &clients{
 		client:        client,


### PR DESCRIPTION
The end to end tests are currently failing in the CI before the before block of the tests attempts to recreate the clients required by the tests. Use a sync.Once to ensure the before block does not fail. Also updated testify while we were at it.