### PR TITLE
Remove buildpackages from store sample

### DIFF
--- a/samples/experimental/store.yaml
+++ b/samples/experimental/store.yaml
@@ -4,6 +4,4 @@ metadata:
   name: sample-store
 spec:
   sources:
-  - image: gcr.io/cf-build-service-public/node-engine-buildpackage@sha256:95ff756f0ef0e026440a8523f4bab02fd8b45dc1a8a3a7ba063cefdba5cb9493
-  - image: gcr.io/cf-build-service-public/npm-buildpackage@sha256:5058ceb9a562ec647ea5a41008b0d11e32a56e13e8c9ec20c4db63d220373e33
   - image: cloudfoundry/cnb:bionic


### PR DESCRIPTION
The images that contain the `node` and `npm` buildpackages for the sample store are no longer available in gcr.
By removing them the experimental samples are back to a working state