### PR TITLE
Ensure all buildpacks in store status are deterministic

### DIFF
--- a/pkg/cnb/remote_store_reader.go
+++ b/pkg/cnb/remote_store_reader.go
@@ -86,6 +86,10 @@ func (r *RemoteStoreReader) Read(keychain authn.Keychain, storeImages []v1alpha1
 	}
 
 	sort.Slice(buildpacks, func(i, j int) bool {
+		if buildpacks[i].String() == buildpacks[j].String() {
+			return buildpacks[i].StoreImage.Image < buildpacks[j].StoreImage.Image
+		}
+
 		return buildpacks[i].String() < buildpacks[j].String()
 	})
 


### PR DESCRIPTION
 - The same buildpack can show up in multiple build packages