### PR TITLE
Select buildpacks for builders by comparing semvers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0 // indirect
 	contrib.go.opencensus.io/exporter/stackdriver v0.12.2 // indirect
 	github.com/BurntSushi/toml v0.3.1
+	github.com/Masterminds/semver/v3 v3.0.3
 	github.com/aws/aws-sdk-go v1.25.1 // indirect
 	github.com/buildpacks/imgutil v0.0.0-20200115144305-2289fbc194a6
 	github.com/buildpacks/lifecycle v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,9 @@ github.com/Azure/go-autorest v11.1.2+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSW
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver/v3 v3.0.3 h1:znjIyLfpXEDQjOIEWh+ehwpTU14UzUPub3c3sm36u14=
+github.com/Masterminds/semver/v3 v3.0.3/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+qxleU=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46 h1:lsxEuwrXEAokXB9qhlbKWPpo3KMLZQ5WB5WLQRW1uq0=

--- a/pkg/cnb/store_buildpack_repository_test.go
+++ b/pkg/cnb/store_buildpack_repository_test.go
@@ -20,7 +20,7 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 		engineBuildpack := v1alpha1.StoreBuildpack{
 			BuildpackInfo: v1alpha1.BuildpackInfo{
 				Id:      "io.buildpack.engine",
-				Version: "v1",
+				Version: "1.0.0",
 			},
 			DiffId: "sha256:1bf8899667b8d1e6b124f663faca32903b470831e5e4e992644ac5c839ab3462",
 			Digest: "sha256:d345d1b12ae6b3f7cfc617f7adaebe06c32ce60b1aa30bb80fb622b65523de8f",
@@ -43,7 +43,7 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 		packageManagerBuildpack := v1alpha1.StoreBuildpack{
 			BuildpackInfo: v1alpha1.BuildpackInfo{
 				Id:      "io.buildpack.package-manager",
-				Version: "v1",
+				Version: "1.0.0",
 			},
 			DiffId: "sha256:2bf8899667b8d1e6b124f663faca32903b470831e5e4e992644ac5c839ab3462",
 			Digest: "sha256:7c1213a54d20137a7479e72150c058268a6604b98c011b4fc11ca45927923d7b",
@@ -66,7 +66,7 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 		metaBuildpack := v1alpha1.StoreBuildpack{
 			BuildpackInfo: v1alpha1.BuildpackInfo{
 				Id:      "io.buildpack.meta",
-				Version: "v1",
+				Version: "1.0.0",
 			},
 			DiffId: "sha256:3bf8899667b8d1e6b124f663faca32903b470831e5e4e992644ac5c839ab3462",
 			Digest: "sha256:07db84e57fdd7101104c2469984217696fdfe51591cb1edee2928514135920d6",
@@ -80,14 +80,14 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 						{
 							BuildpackInfo: v1alpha1.BuildpackInfo{
 								Id:      "io.buildpack.engine",
-								Version: "v1",
+								Version: "1.0.0",
 							},
 							Optional: false,
 						},
 						{
 							BuildpackInfo: v1alpha1.BuildpackInfo{
 								Id:      "io.buildpack.package-manager",
-								Version: "v1",
+								Version: "1.0.0",
 							},
 							Optional: true,
 						},
@@ -108,7 +108,7 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 		v8Buildpack := v1alpha1.StoreBuildpack{
 			BuildpackInfo: v1alpha1.BuildpackInfo{
 				Id:      "io.buildpack.multi",
-				Version: "v8",
+				Version: "8.0.0",
 			},
 			DiffId: "sha256:8bf8899667b8d1e6b124f663faca32903b470831e5e4e992644ac5c839ab3462",
 			Digest: "sha256:fc14806eb95d01b6338ba1b9fea605e84db7c8c09561ae360bad5b80b5d0d80b",
@@ -131,7 +131,7 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 		v9Buildpack := v1alpha1.StoreBuildpack{
 			BuildpackInfo: v1alpha1.BuildpackInfo{
 				Id:      "io.buildpack.multi",
-				Version: "v9",
+				Version: "9.0.0",
 			},
 			DiffId: "sha256:9bf8899667b8d1e6b124f663faca32903b470831e5e4e992644ac5c839ab3462",
 			Digest: "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
@@ -170,7 +170,7 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 		}
 
 		it("returns layer info from store image", func() {
-			info, err := storeBuildpackRepository.FindByIdAndVersion("io.buildpack.engine", "v1")
+			info, err := storeBuildpackRepository.FindByIdAndVersion("io.buildpack.engine", "1.0.0")
 			require.NoError(t, err)
 
 			expectedLayer, err := layerFromStoreBuildpack(nil, engineBuildpack)
@@ -178,14 +178,14 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 			require.Equal(t, info, RemoteBuildpackInfo{
 				BuildpackInfo: v1alpha1.BuildpackInfo{
 					Id:      "io.buildpack.engine",
-					Version: "v1",
+					Version: "1.0.0",
 				},
 				Layers: []buildpackLayer{
 					{
 						v1Layer: expectedLayer,
 						BuildpackInfo: v1alpha1.BuildpackInfo{
 							Id:      "io.buildpack.engine",
-							Version: "v1",
+							Version: "1.0.0",
 						},
 						BuildpackLayerInfo: BuildpackLayerInfo{
 							API:         "0.1",
@@ -204,7 +204,7 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
-		it("returns the alphabetical newest buildpack if version is unspecified", func() {
+		it("returns the semver newest buildpack if version is unspecified", func() {
 			info, err := storeBuildpackRepository.FindByIdAndVersion("io.buildpack.multi", "")
 			require.NoError(t, err)
 
@@ -214,14 +214,14 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 			require.Equal(t, info, RemoteBuildpackInfo{
 				BuildpackInfo: v1alpha1.BuildpackInfo{
 					Id:      "io.buildpack.multi",
-					Version: "v9",
+					Version: "9.0.0",
 				},
 				Layers: []buildpackLayer{
 					{
 						v1Layer: expectedLayer,
 						BuildpackInfo: v1alpha1.BuildpackInfo{
 							Id:      "io.buildpack.multi",
-							Version: "v9",
+							Version: "9.0.0",
 						},
 						BuildpackLayerInfo: BuildpackLayerInfo{
 							API:         "0.2",
@@ -240,8 +240,36 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
+		it("fails to find the buildpack if version is unspecified and not all buildpacks are semver conformant", func() {
+			storeBuildpackRepository.Store.Status.Buildpacks = append(storeBuildpackRepository.Store.Status.Buildpacks, v1alpha1.StoreBuildpack{
+				BuildpackInfo: v1alpha1.BuildpackInfo{
+					Id:      "io.buildpack.multi",
+					Version: "my-wacky-version",
+				},
+				DiffId: "sha256:9bf8899667b8d1e6b124f663faca32903b470831e5e4e992644ac5c839ab3462",
+				Digest: "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
+				Size:   10,
+				StoreImage: v1alpha1.StoreImage{
+					Image: "some.registry.io/build-package",
+				},
+				Order: nil,
+				API:   "0.2",
+				Stacks: []v1alpha1.BuildpackStack{
+					{
+						ID: "io.custom.stack",
+					},
+					{
+						ID: "io.stack.only.v9.works",
+					},
+				},
+			})
+
+			_, err := storeBuildpackRepository.FindByIdAndVersion("io.buildpack.multi", "")
+			require.Error(t, err, "cannot find buildpack 'io.buildpack.multi' with latest version due to invalid semver 'my-wacky-version'")
+		})
+
 		it("returns all buildpack layers in a meta buildpack", func() {
-			info, err := storeBuildpackRepository.FindByIdAndVersion("io.buildpack.meta", "v1")
+			info, err := storeBuildpackRepository.FindByIdAndVersion("io.buildpack.meta", "1.0.0")
 			require.NoError(t, err)
 
 			expectedEngineLayer, err := layerFromStoreBuildpack(nil, engineBuildpack)
@@ -256,14 +284,14 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 			require.Equal(t, RemoteBuildpackInfo{
 				BuildpackInfo: v1alpha1.BuildpackInfo{
 					Id:      "io.buildpack.meta",
-					Version: "v1",
+					Version: "1.0.0",
 				},
 				Layers: []buildpackLayer{
 					{
 						v1Layer: expectedEngineLayer,
 						BuildpackInfo: v1alpha1.BuildpackInfo{
 							Id:      "io.buildpack.engine",
-							Version: "v1",
+							Version: "1.0.0",
 						},
 						BuildpackLayerInfo: BuildpackLayerInfo{
 							API:         "0.1",
@@ -282,7 +310,7 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 						v1Layer: expectedPackageManagerLayer,
 						BuildpackInfo: v1alpha1.BuildpackInfo{
 							Id:      "io.buildpack.package-manager",
-							Version: "v1",
+							Version: "1.0.0",
 						},
 						BuildpackLayerInfo: BuildpackLayerInfo{
 							API:         "0.2",
@@ -301,7 +329,7 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 						v1Layer: expectedMetaLayer,
 						BuildpackInfo: v1alpha1.BuildpackInfo{
 							Id:      "io.buildpack.meta",
-							Version: "v1",
+							Version: "1.0.0",
 						},
 						BuildpackLayerInfo: BuildpackLayerInfo{
 							API:         "0.3",
@@ -312,14 +340,14 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 										{
 											BuildpackInfo: v1alpha1.BuildpackInfo{
 												Id:      "io.buildpack.engine",
-												Version: "v1",
+												Version: "1.0.0",
 											},
 											Optional: false,
 										},
 										{
 											BuildpackInfo: v1alpha1.BuildpackInfo{
 												Id:      "io.buildpack.package-manager",
-												Version: "v1",
+												Version: "1.0.0",
 											},
 											Optional: true,
 										},


### PR DESCRIPTION
When there are duplicates of a buildpack but one of those buildpacks does not have a semver compatible version, then the builder will not roll forward and the status will have a corresponding error message. 