### PR TITLE
Update the instructions to use basic git auth

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -104,8 +104,8 @@ metadata:
     build.pivotal.io/git: https://github.com
 type: kubernetes.io/basic-auth
 stringData:
-  username: <generated-token>
-  password: x-oauth-basic
+  username: <your-username>
+  password: <generated-token>
 ```
 
 ### Service Account


### PR DESCRIPTION
Switching the username and generated token placement in the docs, as the suggested way didnt work for us.