### PR TITLE
Keychain only matches on https://index.docker.io/v1/

### DIFF
--- a/pkg/dockercreds/match.go
+++ b/pkg/dockercreds/match.go
@@ -2,6 +2,9 @@ package dockercreds
 
 import (
 	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
 )
 
 var registryDomains = []string{
@@ -23,9 +26,16 @@ type RegistryMatcher struct {
 
 func (m RegistryMatcher) Match(reg string) bool {
 	for _, format := range registryDomains {
-		if fmt.Sprintf(format, reg) == m.Registry {
+		if fmt.Sprintf(format, registryString(reg)) == m.Registry {
 			return true
 		}
 	}
 	return false
+}
+
+func registryString(reg string) string {
+	if reg == name.DefaultRegistry {
+		return authn.DefaultAuthKey
+	}
+	return reg
 }

--- a/pkg/dockercreds/match_test.go
+++ b/pkg/dockercreds/match_test.go
@@ -36,12 +36,12 @@ func testRegistryMatch(t *testing.T, when spec.G, it spec.S) {
 			})
 		}
 
-		it("matches on dockerhub references", func() {
-			matcher := RegistryMatcher{Registry: "http://index.docker.io"}
+		it("only matches on fully qualified dockerhub references", func() {
+			matcher := RegistryMatcher{Registry: "https://index.docker.io/v1/"}
 			assert.True(t, matcher.Match("index.docker.io"))
 
 			matcher = RegistryMatcher{Registry: "index.docker.io"}
-			assert.True(t, matcher.Match("index.docker.io"))
+			assert.False(t, matcher.Match("index.docker.io"))
 		})
 	})
 }


### PR DESCRIPTION
 - authn.DefaultKeychain only matches https://index.docker.io/v1/
 - Lifecycle exporter uses authn.DefaultKeychain
 - Resolves https://github.com/pivotal/kpack/issues/290