### PR TITLE
Update acr fix to use new gggcr.k8schain import paths

### DIFF
--- a/pkg/dockercreds/k8sdockercreds/azurecredentialhelperfix/setup.go
+++ b/pkg/dockercreds/k8sdockercreds/azurecredentialhelperfix/setup.go
@@ -1,13 +1,13 @@
 package setup
 
 import (
+	_ "github.com/vdemeester/k8s-pkg-credentialprovider/azure"
+
 	"os"
 
 	"github.com/spf13/pflag"
 )
 
 func init() {
-	//allow azure credential helper to be proccess its config before k8schain loads
-	//https://github.com/google/go-containerregistry/pull/652
 	pflag.Set("azure-container-registry-config", os.Getenv("AZURE_CONTAINER_REGISTRY_CONFIG"))
 }


### PR DESCRIPTION
- The azure credential provider needs to be imported first to initialize the pflag.