### PR TITLE
Ensure that an image is provided to the analyze step

### DIFF
--- a/pkg/apis/build/v1alpha1/build_pod.go
+++ b/pkg/apis/build/v1alpha1/build_pod.go
@@ -207,7 +207,7 @@ func (b *Build) BuildPod(config BuildPodImages, secrets []corev1.Secret, bc Buil
 							"-analyzed=/layers/analyzed.toml",
 							"-cache-dir=/cache",
 							func() string {
-								if b.Spec.LastBuild != nil {
+								if b.Spec.LastBuild != nil && b.Spec.LastBuild.Image != "" {
 									return b.Spec.LastBuild.Image
 								}
 								return b.Tag()

--- a/pkg/apis/build/v1alpha1/build_pod_test.go
+++ b/pkg/apis/build/v1alpha1/build_pod_test.go
@@ -467,6 +467,15 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 				}, pod.Spec.InitContainers[2].Args)
 			})
 
+			it("configures analyze step with the current tag if previous build is corrupted", func() {
+				build.Spec.LastBuild = &v1alpha1.LastBuild{}
+
+				pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+				require.NoError(t, err)
+
+				assert.Contains(t, pod.Spec.InitContainers[2].Args, build.Tag())
+			})
+
 			it("configures restore step", func() {
 				pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
 				require.NoError(t, err)

--- a/pkg/apis/build/v1alpha1/image_builds.go
+++ b/pkg/apis/build/v1alpha1/image_builds.go
@@ -100,6 +100,10 @@ func lastBuild(latestBuild *Build) *LastBuild {
 		return nil
 	}
 
+	if latestBuild.IsFailure() {
+		return latestBuild.Spec.LastBuild
+	}
+
 	return &LastBuild{
 		Image:   latestBuild.BuiltImage(),
 		StackId: latestBuild.Stack(),


### PR DESCRIPTION
 - Check that build.lastBuild exists
 - Utilize last successful build to populate build.spec.lastBuild
 - Fixes https://github.com/pivotal/kpack/issues/339