### PR TITLE
Build pods invokes lifecycle binaries in /cnb/lifecycle/

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/sclevine/spec v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
+	github.com/vdemeester/k8s-pkg-credentialprovider v0.0.0-20200107171650-7c61ffa44238
 	go.opencensus.io v0.22.1 // indirect
 	go.uber.org/zap v1.14.1
 	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975

--- a/pkg/apis/build/v1alpha1/build_pod.go
+++ b/pkg/apis/build/v1alpha1/build_pod.go
@@ -182,7 +182,7 @@ func (b *Build) BuildPod(config BuildPodImages, secrets []corev1.Secret, bc Buil
 					corev1.Container{
 						Name:    "detect",
 						Image:   builderImage,
-						Command: []string{"/lifecycle/detector"},
+						Command: []string{"/cnb/lifecycle/detector"},
 						Args: []string{
 							"-app=/workspace",
 							"-group=/layers/group.toml",
@@ -200,7 +200,7 @@ func (b *Build) BuildPod(config BuildPodImages, secrets []corev1.Secret, bc Buil
 					corev1.Container{
 						Name:    "analyze",
 						Image:   builderImage,
-						Command: []string{"/lifecycle/analyzer"},
+						Command: []string{"/cnb/lifecycle/analyzer"},
 						Args: []string{
 							"-layers=/layers",
 							"-group=/layers/group.toml",
@@ -229,7 +229,7 @@ func (b *Build) BuildPod(config BuildPodImages, secrets []corev1.Secret, bc Buil
 					corev1.Container{
 						Name:    "restore",
 						Image:   builderImage,
-						Command: []string{"/lifecycle/restorer"},
+						Command: []string{"/cnb/lifecycle/restorer"},
 						Args: []string{
 							"-group=/layers/group.toml",
 							"-layers=/layers",
@@ -246,7 +246,7 @@ func (b *Build) BuildPod(config BuildPodImages, secrets []corev1.Secret, bc Buil
 					corev1.Container{
 						Name:    "build",
 						Image:   builderImage,
-						Command: []string{"/lifecycle/builder"},
+						Command: []string{"/cnb/lifecycle/builder"},
 						Args: []string{
 							"-layers=/layers",
 							"-app=/workspace",
@@ -266,7 +266,7 @@ func (b *Build) BuildPod(config BuildPodImages, secrets []corev1.Secret, bc Buil
 						corev1.Container{
 							Name:    "export",
 							Image:   builderImage,
-							Command: []string{"/lifecycle/exporter"},
+							Command: []string{"/cnb/lifecycle/exporter"},
 							Args: append([]string{
 								"-layers=/layers",
 								"-app=/workspace",
@@ -291,7 +291,7 @@ func (b *Build) BuildPod(config BuildPodImages, secrets []corev1.Secret, bc Buil
 						corev1.Container{
 							Name:    "export",
 							Image:   builderImage,
-							Command: []string{"/lifecycle/exporter"},
+							Command: []string{"/cnb/lifecycle/exporter"},
 							Args: append([]string{
 								"-layers=/layers",
 								"-app=/workspace",

--- a/pkg/apis/experimental/v1alpha1/stack_types.go
+++ b/pkg/apis/experimental/v1alpha1/stack_types.go
@@ -46,9 +46,9 @@ type ResolvedStack struct {
 	BuildImage StackStatusImage `json:"buildImage,omitempty"`
 	RunImage   StackStatusImage `json:"runImage,omitempty"`
 	// +listType
-	Mixins     []string         `json:"mixins,omitempty"`
-	UserID     int              `json:"userId,omitempty"`
-	GroupID    int              `json:"groupId,omitempty"`
+	Mixins  []string `json:"mixins,omitempty"`
+	UserID  int      `json:"userId,omitempty"`
+	GroupID int      `json:"groupId,omitempty"`
 }
 
 // +k8s:openapi-gen=true

--- a/pkg/cnb/builder_builder.go
+++ b/pkg/cnb/builder_builder.go
@@ -108,11 +108,6 @@ func (bb *builderBlder) WriteableImage() (v1.Image, error) {
 		return nil, err
 	}
 
-	compatLayer, err := bb.lifecycleCompatLayer()
-	if err != nil {
-		return nil, err
-	}
-
 	stackLayer, err := bb.stackLayer()
 	if err != nil {
 		return nil, err
@@ -128,7 +123,6 @@ func (bb *builderBlder) WriteableImage() (v1.Image, error) {
 			[]v1.Layer{
 				defaultLayer,
 				lifecycleLayer,
-				compatLayer,
 			},
 			buildpackLayers,
 			[]v1.Layer{
@@ -324,26 +318,6 @@ func (bb *builderBlder) rootOwnedDir(path string) *tar.Header {
 		Mode:     0755,
 		ModTime:  normalizedTime,
 	}
-}
-
-func (bb *builderBlder) lifecycleCompatLayer() (v1.Layer, error) {
-	b := &bytes.Buffer{}
-	tw := tar.NewWriter(b)
-
-	if err := tw.WriteHeader(&tar.Header{
-		Typeflag: tar.TypeSymlink,
-		Name:     lifecycleSymlinkDir,
-		Linkname: cnbLifecycleDir,
-		ModTime:  normalizedTime,
-		Mode:     0644,
-	}); err != nil {
-		return nil, errors.Wrapf(err, "creating %s dir in layer", lifecycleSymlinkDir)
-	}
-	if err := tw.Close(); err != nil {
-		return nil, err
-	}
-
-	return tarball.LayerFromReader(b)
 }
 
 func deterministicSortBySize(layers map[expv1alpha1.BuildpackInfo]buildpackLayer) []expv1alpha1.BuildpackInfo {

--- a/pkg/cnb/create_builder_test.go
+++ b/pkg/cnb/create_builder_test.go
@@ -256,13 +256,11 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 			buildpackLayerCount := 3
 			defaultDirectoryLayerCount := 1
 			stackTomlLayerCount := 1
-			lifecycleSymlinkLayerCount := 1
 			orderTomlLayerCount := 1
 			assert.Len(t, layers,
 				buildImageLayers+
 					defaultDirectoryLayerCount+
 					lifecycleImageLayers+
-					lifecycleSymlinkLayerCount+
 					stackTomlLayerCount+
 					buildpackLayerCount+
 					orderTomlLayerCount)
@@ -318,17 +316,6 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 				require.NoError(t, err)
 
 				assert.Equal(t, layers[index], lifecycleLayers[0])
-			})
-
-			layerTester.testNextLayer("Lifecycle Symlink", func(index int) {
-				assertLayerContents(t, layers[index], map[string]content{
-					"/lifecycle": {
-						linkname: "/cnb/lifecycle",
-						typeflag: tar.TypeSymlink,
-						mode:     0644,
-					},
-				})
-
 			})
 
 			layerTester.testNextLayer("Largest Buildpack Layer", func(index int) {


### PR DESCRIPTION
- remove creation of lifecycle compat layer from builder builder

closes #342

Signed-off-by: Ashwin Venkatesh <avenkatesh@pivotal.io>