### PR TITLE
Add buildpack homepage to custombuilder metadata

### DIFF
--- a/pkg/apis/experimental/v1alpha1/store_types.go
+++ b/pkg/apis/experimental/v1alpha1/store_types.go
@@ -45,11 +45,12 @@ type StoreStatus struct {
 type StoreBuildpack struct {
 	BuildpackInfo `json:",inline"`
 	StoreImage    StoreImage `json:"storeImage,omitempty"`
-	API           string     `json:"api,omitempty"`
 	DiffId        string     `json:"diffId,omitempty"`
 	Digest        string     `json:"digest,omitempty"`
 	Size          int64      `json:"size,omitempty"`
 
+	API      string `json:"api,omitempty"`
+	Homepage string `json:"homepage,omitempty"`
 	// +listType
 	Order []OrderEntry `json:"order,omitempty"`
 	// +listType

--- a/pkg/cnb/buildpack_metadata.go
+++ b/pkg/cnb/buildpack_metadata.go
@@ -17,6 +17,12 @@ type BuildpackLayerInfo struct {
 	LayerDiffID string                       `json:"layerDiffID"`
 	Order       expv1alpha1.Order            `json:"order,omitempty"`
 	Stacks      []expv1alpha1.BuildpackStack `json:"stacks,omitempty"`
+	Homepage    string                       `json:"homepage,omitempty"`
+}
+
+type DescriptiveBuildpackInfo struct {
+	v1alpha1.BuildpackInfo
+	Homepage string `json:"homepage,omitempty"`
 }
 
 type Stack struct {
@@ -25,11 +31,11 @@ type Stack struct {
 }
 
 type BuilderImageMetadata struct {
-	Description string                   `json:"description"`
-	Stack       StackMetadata            `json:"stack"`
-	Lifecycle   LifecycleMetadata        `json:"lifecycle"`
-	CreatedBy   CreatorMetadata          `json:"createdBy"`
-	Buildpacks  []v1alpha1.BuildpackInfo `json:"buildpacks"`
+	Description string                     `json:"description"`
+	Stack       StackMetadata              `json:"stack"`
+	Lifecycle   LifecycleMetadata          `json:"lifecycle"`
+	CreatedBy   CreatorMetadata            `json:"createdBy"`
+	Buildpacks  []DescriptiveBuildpackInfo `json:"buildpacks"`
 }
 
 type StackMetadata struct {

--- a/pkg/cnb/cnb_metadata.go
+++ b/pkg/cnb/cnb_metadata.go
@@ -12,7 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
-	expv1alpha1 "github.com/pivotal/kpack/pkg/apis/experimental/v1alpha1"
 	"github.com/pivotal/kpack/pkg/registry"
 	"github.com/pivotal/kpack/pkg/registry/imagehelpers"
 )
@@ -84,7 +83,7 @@ func (r *RemoteMetadataRetriever) GetBuilderImage(builder FetchableBuilder) (v1a
 	}, nil
 }
 
-func transform(infos []expv1alpha1.BuildpackInfo) v1alpha1.BuildpackMetadataList {
+func transform(infos []DescriptiveBuildpackInfo) v1alpha1.BuildpackMetadataList {
 	buildpacks := make(v1alpha1.BuildpackMetadataList, 0, len(infos))
 	for _, buildpack := range infos {
 		buildpacks = append(buildpacks, v1alpha1.BuildpackMetadata{

--- a/pkg/cnb/create_builder.go
+++ b/pkg/cnb/create_builder.go
@@ -75,7 +75,7 @@ func (r *RemoteBuilderCreator) CreateBuilder(keychain authn.Keychain, buildpackR
 	}, nil
 }
 
-func buildpackMetadata(buildpacks []expv1alpha1.BuildpackInfo) v1alpha1.BuildpackMetadataList {
+func buildpackMetadata(buildpacks []DescriptiveBuildpackInfo) v1alpha1.BuildpackMetadataList {
 	m := make(v1alpha1.BuildpackMetadataList, 0, len(buildpacks))
 	for _, b := range buildpacks {
 		m = append(m, v1alpha1.BuildpackMetadata{

--- a/pkg/cnb/create_builder_test.go
+++ b/pkg/cnb/create_builder_test.go
@@ -131,9 +131,12 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 	buildpackRepository.AddBP("io.buildpack.1", "v1", []buildpackLayer{
 		{
 			v1Layer: buildpack1Layer,
-			BuildpackInfo: expv1alpha1.BuildpackInfo{
-				Id:      "io.buildpack.1",
-				Version: "v1",
+			BuildpackInfo: DescriptiveBuildpackInfo{
+				BuildpackInfo: expv1alpha1.BuildpackInfo{
+					Id:      "io.buildpack.1",
+					Version: "v1",
+				},
+				Homepage: "buildpack.1.com",
 			},
 			BuildpackLayerInfo: BuildpackLayerInfo{
 				API:         "0.2",
@@ -151,9 +154,12 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 	buildpackRepository.AddBP("io.buildpack.2", "v2", []buildpackLayer{
 		{
 			v1Layer: buildpack3Layer,
-			BuildpackInfo: expv1alpha1.BuildpackInfo{
-				Id:      "io.buildpack.3",
-				Version: "v2",
+			BuildpackInfo: DescriptiveBuildpackInfo{
+				BuildpackInfo: expv1alpha1.BuildpackInfo{
+					Id:      "io.buildpack.3",
+					Version: "v3",
+				},
+				Homepage: "buildpack.3.com",
 			},
 			BuildpackLayerInfo: BuildpackLayerInfo{
 				API:         "0.2",
@@ -170,9 +176,12 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 		},
 		{
 			v1Layer: buildpack2Layer,
-			BuildpackInfo: expv1alpha1.BuildpackInfo{
-				Id:      "io.buildpack.2",
-				Version: "v1",
+			BuildpackInfo: DescriptiveBuildpackInfo{
+				BuildpackInfo: expv1alpha1.BuildpackInfo{
+					Id:      "io.buildpack.2",
+					Version: "v2",
+				},
+				Homepage: "buildpack.2.com",
 			},
 			BuildpackLayerInfo: BuildpackLayerInfo{
 				API:         "0.2",
@@ -235,8 +244,8 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 
 			assert.Len(t, builderRecord.Buildpacks, 3)
 			assert.Contains(t, builderRecord.Buildpacks, v1alpha1.BuildpackMetadata{Id: "io.buildpack.1", Version: "v1"})
-			assert.Contains(t, builderRecord.Buildpacks, v1alpha1.BuildpackMetadata{Id: "io.buildpack.2", Version: "v1"})
-			assert.Contains(t, builderRecord.Buildpacks, v1alpha1.BuildpackMetadata{Id: "io.buildpack.3", Version: "v2"})
+			assert.Contains(t, builderRecord.Buildpacks, v1alpha1.BuildpackMetadata{Id: "io.buildpack.2", Version: "v2"})
+			assert.Contains(t, builderRecord.Buildpacks, v1alpha1.BuildpackMetadata{Id: "io.buildpack.3", Version: "v3"})
 			assert.Equal(t, v1alpha1.BuildStack{RunImage: runImage, ID: stackID}, builderRecord.Stack)
 
 			assert.Len(t, registryClient.SavedImages(), 1)
@@ -396,15 +405,18 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
   "buildpacks": [
     {
       "id": "io.buildpack.3",
-      "version": "v2"
+      "version": "v3",
+	  "homepage": "buildpack.3.com"
     },
     {
       "id": "io.buildpack.2",
-      "version": "v1"
+      "version": "v2",
+	  "homepage": "buildpack.2.com"
     },
     {
       "id": "io.buildpack.1",
-      "version": "v1"
+      "version": "v1",
+	  "homepage": "buildpack.1.com"
     }
   ]
 }`, buildpackMetadata)
@@ -426,7 +438,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
     }
   },
   "io.buildpack.2": {
-    "v1": {
+    "v2": {
       "api": "0.2",
       "layerDiffID": "sha256:2bf8899667b8d1e6b124f663faca32903b470831e5e4e992644ac5c839ab3462",
       "order": [
@@ -442,7 +454,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
     }
   },
   "io.buildpack.3": {
-    "v2": {
+    "v3": {
       "api": "0.2",
       "layerDiffID": "sha256:3bf8899667b8d1e6b124f663faca32903b470831e5e4e992644ac5c839ab3462",
       "stacks": [
@@ -477,9 +489,12 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 				buildpackRepository.AddBP("io.buildpack.unsupported.stack", "v4", []buildpackLayer{
 					{
 						v1Layer: buildpack1Layer,
-						BuildpackInfo: expv1alpha1.BuildpackInfo{
-							Id:      "io.buildpack.unsupported.stack",
-							Version: "v4",
+						BuildpackInfo: DescriptiveBuildpackInfo{
+							BuildpackInfo: expv1alpha1.BuildpackInfo{
+								Id:      "io.buildpack.unsupported.stack",
+								Version: "v4",
+							},
+							Homepage: "buildpack.4.com",
 						},
 						BuildpackLayerInfo: BuildpackLayerInfo{
 							API:         "0.2",
@@ -514,9 +529,12 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 				buildpackRepository.AddBP("io.buildpack.unsupported.mixin", "v4", []buildpackLayer{
 					{
 						v1Layer: buildpack1Layer,
-						BuildpackInfo: expv1alpha1.BuildpackInfo{
-							Id:      "io.buildpack.unsupported.mixin",
-							Version: "v4",
+						BuildpackInfo: DescriptiveBuildpackInfo{
+							BuildpackInfo: expv1alpha1.BuildpackInfo{
+								Id:      "io.buildpack.unsupported.mixin",
+								Version: "v4",
+							},
+							Homepage: "buildpack.1.com",
 						},
 						BuildpackLayerInfo: BuildpackLayerInfo{
 							API:         "0.2",
@@ -552,9 +570,12 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 				buildpackRepository.AddBP("io.buildpack.unsupported.buildpack.api", "v4", []buildpackLayer{
 					{
 						v1Layer: buildpack1Layer,
-						BuildpackInfo: expv1alpha1.BuildpackInfo{
-							Id:      "io.buildpack.unsupported.buildpack.api",
-							Version: "v4",
+						BuildpackInfo: DescriptiveBuildpackInfo{
+							BuildpackInfo: expv1alpha1.BuildpackInfo{
+								Id:      "io.buildpack.unsupported.buildpack.api",
+								Version: "v4",
+							},
+							Homepage: "buildpack.4.com",
 						},
 						BuildpackLayerInfo: BuildpackLayerInfo{
 							API:         "0.3",
@@ -601,12 +622,18 @@ func (f *fakeBuildpackRepository) FindByIdAndVersion(id, version string) (Remote
 	}
 
 	return RemoteBuildpackInfo{
-		BuildpackInfo: expv1alpha1.BuildpackInfo{
-			Id:      id,
-			Version: version,
-		},
-		Layers: layers,
+		BuildpackInfo: buildpackInfoInLayers(layers, id, version),
+		Layers:        layers,
 	}, nil
+}
+
+func buildpackInfoInLayers(buildpackLayers []buildpackLayer, id, version string) DescriptiveBuildpackInfo {
+	for _, b := range buildpackLayers {
+		if b.BuildpackInfo.Id == id && b.BuildpackInfo.Version == version {
+			return b.BuildpackInfo
+		}
+	}
+	panic("unexpected missing buildpack info")
 }
 
 func (f *fakeBuildpackRepository) AddBP(id, version string, layers []buildpackLayer) {

--- a/pkg/cnb/remote_buildpack_metadata.go
+++ b/pkg/cnb/remote_buildpack_metadata.go
@@ -2,32 +2,37 @@ package cnb
 
 import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-
 	"github.com/pivotal/kpack/pkg/apis/experimental/v1alpha1"
 )
 
 type RemoteBuildpackInfo struct {
-	BuildpackInfo v1alpha1.BuildpackInfo
+	BuildpackInfo DescriptiveBuildpackInfo
 	Layers        []buildpackLayer
 }
 
 func (i RemoteBuildpackInfo) Optional(optional bool) RemoteBuildpackRef {
 	return RemoteBuildpackRef{
-		BuildpackRef: v1alpha1.BuildpackRef{
-			BuildpackInfo: i.BuildpackInfo,
-			Optional:      optional,
-		},
-		Layers: i.Layers,
+		DescriptiveBuildpackInfo: i.BuildpackInfo,
+		Optional:                 optional,
+		Layers:                   i.Layers,
 	}
 }
 
 type RemoteBuildpackRef struct {
-	BuildpackRef v1alpha1.BuildpackRef
-	Layers       []buildpackLayer
+	DescriptiveBuildpackInfo DescriptiveBuildpackInfo
+	Optional                 bool
+	Layers                   []buildpackLayer
+}
+
+func (r RemoteBuildpackRef) buildpackRef() v1alpha1.BuildpackRef {
+	return v1alpha1.BuildpackRef{
+		BuildpackInfo: r.DescriptiveBuildpackInfo.BuildpackInfo,
+		Optional:      r.Optional,
+	}
 }
 
 type buildpackLayer struct {
 	v1Layer            v1.Layer
-	BuildpackInfo      v1alpha1.BuildpackInfo
+	BuildpackInfo      DescriptiveBuildpackInfo
 	BuildpackLayerInfo BuildpackLayerInfo
 }

--- a/pkg/cnb/remote_store_reader.go
+++ b/pkg/cnb/remote_store_reader.go
@@ -64,12 +64,14 @@ func (r *RemoteStoreReader) Read(storeImages []v1alpha1.StoreImage) ([]v1alpha1.
 					c <- v1alpha1.StoreBuildpack{
 						BuildpackInfo: info,
 						StoreImage:    storeImage,
-						Order:         metadata.Order,
-						DiffId:        metadata.LayerDiffID,
 						Digest:        digest.String(),
+						DiffId:        metadata.LayerDiffID,
 						Size:          size,
-						API:           metadata.API,
-						Stacks:        metadata.Stacks,
+
+						Order:    metadata.Order,
+						Homepage: metadata.Homepage,
+						API:      metadata.API,
+						Stacks:   metadata.Stacks,
 					}
 				}
 			}

--- a/pkg/cnb/remote_store_reader_test.go
+++ b/pkg/cnb/remote_store_reader_test.go
@@ -82,6 +82,7 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
         }
       ],
       "api": "0.2",
+      "homepage": "buildpack.meta.com",
       "stacks": [
         {
           "id": "org.some.stack",
@@ -99,6 +100,7 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
     "0.0.1": {
       "layerDiffID": "sha256:114e397795eceac649afc159afb229211a9ad97b908f7ace225736b8774d9b00",
       "api": "0.2",
+      "homepage": "buildpack.multi.com/v1",
       "stacks": [
         {
           "id": "org.some.stack",
@@ -114,6 +116,7 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
     "0.0.2": {
       "layerDiffID": "sha256:fcc1dd482e41209737dadce3afd276a93d10d974c174fb72adddd3925b2f31d5",
       "api": "0.2",
+      "homepage": "buildpack.multi.com/v2",
       "stacks": [
         {
           "id": "org.some.stack",
@@ -152,6 +155,7 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
     "0.0.1": {
       "layerDiffID": "sha256:1fe2cf74b742ec16c76b9e996c247c78aa41905fe86b744db998094b4bcaf38a",
       "api": "0.2",
+      "homepage": "buildpack.simple.com",
       "stacks": [
         {
           "id": "org.some.stack",
@@ -193,7 +197,8 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 				StoreImage: v1alpha1.StoreImage{
 					Image: buildpackageA,
 				},
-				API: "0.2",
+				API:      "0.2",
+				Homepage: "buildpack.multi.com/v1",
 				Stacks: []v1alpha1.BuildpackStack{
 					{
 						ID:     "org.some.stack",
@@ -215,7 +220,8 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 				StoreImage: v1alpha1.StoreImage{
 					Image: buildpackageA,
 				},
-				API: "0.2",
+				API:      "0.2",
+				Homepage: "buildpack.multi.com/v2",
 				Stacks: []v1alpha1.BuildpackStack{
 					{
 						ID:     "org.some.stack",
@@ -229,6 +235,7 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 				Digest: "sha256:d345d1b12ae6b3f7cfc617f7adaebe06c32ce60b1aa30bb80fb622b65523de8f",
 				Size:   30,
 			})
+
 			require.Contains(t, storeBuildpacks,
 				v1alpha1.StoreBuildpack{
 					BuildpackInfo: v1alpha1.BuildpackInfo{
@@ -238,7 +245,8 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 					StoreImage: v1alpha1.StoreImage{
 						Image: buildpackageA,
 					},
-					API: "0.2",
+					API:      "0.2",
+					Homepage: "buildpack.meta.com",
 					Order: []v1alpha1.OrderEntry{
 						{
 							Group: []v1alpha1.BuildpackRef{
@@ -280,10 +288,11 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 					Id:      "org.buildpack.simple",
 					Version: "0.0.1",
 				},
-				DiffId: "sha256:1fe2cf74b742ec16c76b9e996c247c78aa41905fe86b744db998094b4bcaf38a",
-				Digest: "sha256:6aa3691a73805f608e5fce69fb6bc89aec8362f58a6b4be2682515e9cfa3cc1a",
-				Size:   40,
-				API:    "0.2",
+				DiffId:   "sha256:1fe2cf74b742ec16c76b9e996c247c78aa41905fe86b744db998094b4bcaf38a",
+				Digest:   "sha256:6aa3691a73805f608e5fce69fb6bc89aec8362f58a6b4be2682515e9cfa3cc1a",
+				Size:     40,
+				API:      "0.2",
+				Homepage: "buildpack.simple.com",
 				Stacks: []v1alpha1.BuildpackStack{
 					{
 						ID:     "org.some.stack",
@@ -344,6 +353,7 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
    "0.0.1": {
      "layerDiffID": "sha256:1fe2cf74b742ec16c76b9e996c247c78aa41905fe86b744db998094b4bcaf38a",
      "api": "0.2",
+	 "homepage": "builpack.simple.com",
      "stacks": [
        {
          "id": "org.some.stack",

--- a/pkg/cnb/store_buildpack_repository.go
+++ b/pkg/cnb/store_buildpack_repository.go
@@ -32,9 +32,12 @@ func (s *StoreBuildpackRepository) FindByIdAndVersion(id, version string) (Remot
 		return RemoteBuildpackInfo{}, err
 	}
 
-	info := v1alpha1.BuildpackInfo{
-		Id:      storeBuildpack.Id,
-		Version: storeBuildpack.Version,
+	info := DescriptiveBuildpackInfo{
+		BuildpackInfo: v1alpha1.BuildpackInfo{
+			Id:      storeBuildpack.Id,
+			Version: storeBuildpack.Version,
+		},
+		Homepage: storeBuildpack.Homepage,
 	}
 
 	return RemoteBuildpackInfo{
@@ -47,6 +50,7 @@ func (s *StoreBuildpackRepository) FindByIdAndVersion(id, version string) (Remot
 				Order:       storeBuildpack.Order,
 				API:         storeBuildpack.API,
 				Stacks:      storeBuildpack.Stacks,
+				Homepage:    storeBuildpack.Homepage,
 			},
 		}),
 	}, nil

--- a/pkg/cnb/store_buildpack_repository_test.go
+++ b/pkg/cnb/store_buildpack_repository_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 func TestBuildpackRepository(t *testing.T) {
-	spec.Run(t, "TestBuildpackRepository", testBuildpackRetriever)
+	spec.Run(t, "TestBuildpackRepository", testBuildpackRepository)
 }
 
-func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
+func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 	when("FindByIdAndVersion", func() {
 		engineBuildpack := v1alpha1.StoreBuildpack{
 			BuildpackInfo: v1alpha1.BuildpackInfo{
@@ -28,8 +28,9 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 			StoreImage: v1alpha1.StoreImage{
 				Image: "some.registry.io/build-package",
 			},
-			Order: nil,
-			API:   "0.1",
+			Order:    nil,
+			Homepage: "buildpack.engine.com",
+			API:      "0.1",
 			Stacks: []v1alpha1.BuildpackStack{
 				{
 					ID: "io.custom.stack",
@@ -51,8 +52,9 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 			StoreImage: v1alpha1.StoreImage{
 				Image: "some.registry.io/build-package",
 			},
-			Order: nil,
-			API:   "0.2",
+			Order:    nil,
+			Homepage: "buildpack.package-manager.com",
+			API:      "0.2",
 			Stacks: []v1alpha1.BuildpackStack{
 				{
 					ID: "io.custom.stack",
@@ -94,7 +96,8 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			},
-			API: "0.3",
+			Homepage: "buildpack.meta.com",
+			API:      "0.3",
 			Stacks: []v1alpha1.BuildpackStack{
 				{
 					ID: "io.custom.stack",
@@ -116,8 +119,9 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 			StoreImage: v1alpha1.StoreImage{
 				Image: "some.registry.io/build-package",
 			},
-			Order: nil,
-			API:   "0.2",
+			Order:    nil,
+			Homepage: "buildpack.multi.com",
+			API:      "0.2",
 			Stacks: []v1alpha1.BuildpackStack{
 				{
 					ID: "io.custom.stack",
@@ -139,8 +143,9 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 			StoreImage: v1alpha1.StoreImage{
 				Image: "some.registry.io/build-package",
 			},
-			Order: nil,
-			API:   "0.2",
+			Order:    nil,
+			Homepage: "buildpack.multi.com",
+			API:      "0.2",
 			Stacks: []v1alpha1.BuildpackStack{
 				{
 					ID: "io.custom.stack",
@@ -176,20 +181,27 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 			expectedLayer, err := layerFromStoreBuildpack(nil, engineBuildpack)
 
 			require.Equal(t, info, RemoteBuildpackInfo{
-				BuildpackInfo: v1alpha1.BuildpackInfo{
-					Id:      "io.buildpack.engine",
-					Version: "1.0.0",
+				BuildpackInfo: DescriptiveBuildpackInfo{
+					BuildpackInfo: v1alpha1.BuildpackInfo{
+						Id:      "io.buildpack.engine",
+						Version: "1.0.0",
+					},
+					Homepage: "buildpack.engine.com",
 				},
 				Layers: []buildpackLayer{
 					{
 						v1Layer: expectedLayer,
-						BuildpackInfo: v1alpha1.BuildpackInfo{
-							Id:      "io.buildpack.engine",
-							Version: "1.0.0",
+						BuildpackInfo: DescriptiveBuildpackInfo{
+							BuildpackInfo: v1alpha1.BuildpackInfo{
+								Id:      "io.buildpack.engine",
+								Version: "1.0.0",
+							},
+							Homepage: "buildpack.engine.com",
 						},
 						BuildpackLayerInfo: BuildpackLayerInfo{
 							API:         "0.1",
 							LayerDiffID: diffID(t, expectedLayer),
+							Homepage:    "buildpack.engine.com",
 							Stacks: []v1alpha1.BuildpackStack{
 								{
 									ID: "io.custom.stack",
@@ -212,20 +224,27 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 			require.NoError(t, err)
 
 			require.Equal(t, info, RemoteBuildpackInfo{
-				BuildpackInfo: v1alpha1.BuildpackInfo{
-					Id:      "io.buildpack.multi",
-					Version: "9.0.0",
+				BuildpackInfo: DescriptiveBuildpackInfo{
+					BuildpackInfo: v1alpha1.BuildpackInfo{
+						Id:      "io.buildpack.multi",
+						Version: "9.0.0",
+					},
+					Homepage: "buildpack.multi.com",
 				},
 				Layers: []buildpackLayer{
 					{
 						v1Layer: expectedLayer,
-						BuildpackInfo: v1alpha1.BuildpackInfo{
-							Id:      "io.buildpack.multi",
-							Version: "9.0.0",
+						BuildpackInfo: DescriptiveBuildpackInfo{
+							BuildpackInfo: v1alpha1.BuildpackInfo{
+								Id:      "io.buildpack.multi",
+								Version: "9.0.0",
+							},
+							Homepage: "buildpack.multi.com",
 						},
 						BuildpackLayerInfo: BuildpackLayerInfo{
 							API:         "0.2",
 							LayerDiffID: diffID(t, expectedLayer),
+							Homepage:    "buildpack.multi.com",
 							Stacks: []v1alpha1.BuildpackStack{
 								{
 									ID: "io.custom.stack",
@@ -282,16 +301,22 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 			require.NoError(t, err)
 
 			require.Equal(t, RemoteBuildpackInfo{
-				BuildpackInfo: v1alpha1.BuildpackInfo{
-					Id:      "io.buildpack.meta",
-					Version: "1.0.0",
+				BuildpackInfo: DescriptiveBuildpackInfo{
+					BuildpackInfo: v1alpha1.BuildpackInfo{
+						Id:      "io.buildpack.meta",
+						Version: "1.0.0",
+					},
+					Homepage: "buildpack.meta.com",
 				},
 				Layers: []buildpackLayer{
 					{
 						v1Layer: expectedEngineLayer,
-						BuildpackInfo: v1alpha1.BuildpackInfo{
-							Id:      "io.buildpack.engine",
-							Version: "1.0.0",
+						BuildpackInfo: DescriptiveBuildpackInfo{
+							BuildpackInfo: v1alpha1.BuildpackInfo{
+								Id:      "io.buildpack.engine",
+								Version: "1.0.0",
+							},
+							Homepage: "buildpack.engine.com",
 						},
 						BuildpackLayerInfo: BuildpackLayerInfo{
 							API:         "0.1",
@@ -304,17 +329,22 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 									ID: "io.stack.only.engine.works",
 								},
 							},
+							Homepage: "buildpack.engine.com",
 						},
 					},
 					{
 						v1Layer: expectedPackageManagerLayer,
-						BuildpackInfo: v1alpha1.BuildpackInfo{
-							Id:      "io.buildpack.package-manager",
-							Version: "1.0.0",
+						BuildpackInfo: DescriptiveBuildpackInfo{
+							BuildpackInfo: v1alpha1.BuildpackInfo{
+								Id:      "io.buildpack.package-manager",
+								Version: "1.0.0",
+							},
+							Homepage: "buildpack.package-manager.com",
 						},
 						BuildpackLayerInfo: BuildpackLayerInfo{
 							API:         "0.2",
 							LayerDiffID: diffID(t, expectedPackageManagerLayer),
+							Homepage:    "buildpack.package-manager.com",
 							Stacks: []v1alpha1.BuildpackStack{
 								{
 									ID: "io.custom.stack",
@@ -327,13 +357,17 @@ func testBuildpackRetriever(t *testing.T, when spec.G, it spec.S) {
 					},
 					{
 						v1Layer: expectedMetaLayer,
-						BuildpackInfo: v1alpha1.BuildpackInfo{
-							Id:      "io.buildpack.meta",
-							Version: "1.0.0",
+						BuildpackInfo: DescriptiveBuildpackInfo{
+							BuildpackInfo: v1alpha1.BuildpackInfo{
+								Id:      "io.buildpack.meta",
+								Version: "1.0.0",
+							},
+							Homepage: "buildpack.meta.com",
 						},
 						BuildpackLayerInfo: BuildpackLayerInfo{
 							API:         "0.3",
 							LayerDiffID: diffID(t, expectedMetaLayer),
+							Homepage:    "buildpack.meta.com",
 							Order: v1alpha1.Order{
 								{
 									Group: []v1alpha1.BuildpackRef{

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -44,10 +44,10 @@ func testClient(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("includes digest if repoName already has a digest", func() {
-				_, imageId, err := subject.Fetch(authn.DefaultKeychain, "gcr.io/paketo-buildpacks/builder@sha256:fc6c76f22d6d9d2afd654625b63607453cf3ccb65af485905ddfccd812e9eb97")
+				_, imageId, err := subject.Fetch(authn.DefaultKeychain, "gcr.io/paketo-buildpacks/builder@sha256:31e8de150acb4f204cc26cf8cbca93bd6fd78d5cdad8fc41f0f6b51a9606f08e")
 				require.NoError(t, err)
 
-				require.Equal(t, imageId, "gcr.io/paketo-buildpacks/builder@sha256:fc6c76f22d6d9d2afd654625b63607453cf3ccb65af485905ddfccd812e9eb97")
+				require.Equal(t, imageId, "gcr.io/paketo-buildpacks/builder@sha256:31e8de150acb4f204cc26cf8cbca93bd6fd78d5cdad8fc41f0f6b51a9606f08e")
 			})
 		})
 	})


### PR DESCRIPTION
- Implements https://github.com/buildpacks/rfcs/pull/55
- Expose buildpack homepage in the store.status
- Represent BuildpackInfo w/ homepage as DescriptiveBuildpackInfo