### PR TITLE
Improve error message for prepare step

### DIFF
--- a/cmd/build-init/main.go
+++ b/cmd/build-init/main.go
@@ -80,22 +80,14 @@ func main() {
 		}
 	}
 
-	hasImageWriteAccess, err := dockercreds.HasWriteAccess(creds, *imageTag)
+	err = dockercreds.VerifyWriteAccess(creds, *imageTag)
 	if err != nil {
-		logger.Fatal(err)
+		logger.Fatal(errors.Wrapf(err, "Error verifying write access to %q", *imageTag))
 	}
 
-	if !hasImageWriteAccess {
-		logger.Fatalf("invalid credentials to build to %s", *imageTag)
-	}
-
-	hasRunImageReadAccess, err := dockercreds.HasReadAccess(creds, *runImage)
+	err = dockercreds.VerifyReadAccess(creds, *runImage)
 	if err != nil {
-		logger.Fatal(errors.Wrapf(err, "validating read access to run image"))
-	}
-
-	if !hasRunImageReadAccess {
-		logger.Fatalf("could not read run image: %s", *runImage)
+		logger.Fatal(errors.Wrapf(err, "Error verifying read access to run image %q", *runImage))
 	}
 
 	err = fetchSource(logger, creds)

--- a/cmd/build-init/main.go
+++ b/cmd/build-init/main.go
@@ -53,6 +53,7 @@ const (
 	builderPullSecretsDir = "/builderPullSecrets"
 	projectMetadataDir    = "/projectMetadata"
 )
+
 func main() {
 	flag.Parse()
 
@@ -164,4 +165,3 @@ func logLoadingSecrets(logger *log.Logger, secretsSlices ...[]string) {
 		}
 	}
 }
-

--- a/pkg/dockercreds/access_checker.go
+++ b/pkg/dockercreds/access_checker.go
@@ -39,6 +39,7 @@ func HasWriteAccess(keychain authn.Keychain, tag string) (bool, error) {
 			}
 		}
 
+		err = errors.Errorf("Error validating write permission to %s. %s", tag, err.Error())
 		return false, errors.WithStack(err)
 	}
 

--- a/pkg/dockercreds/access_checker_test.go
+++ b/pkg/dockercreds/access_checker_test.go
@@ -65,8 +65,6 @@ func testAccessChecker(t *testing.T, when spec.G, it spec.S) {
 				writer.WriteHeader(401)
 			})
 
-			tagName := fmt.Sprintf("%s/some/image:tag", server.URL[7:])
-
 			hasAccess, err := HasWriteAccess(testKeychain{}, tagName)
 			require.NoError(t, err)
 			assert.False(t, hasAccess)
@@ -83,8 +81,6 @@ func testAccessChecker(t *testing.T, when spec.G, it spec.S) {
 				writer.WriteHeader(401)
 			})
 
-			tagName := fmt.Sprintf("%s/some/image:tag", server.URL[7:])
-
 			hasAccess, err := HasWriteAccess(testKeychain{}, tagName)
 			require.NoError(t, err)
 			assert.False(t, hasAccess)
@@ -99,8 +95,6 @@ func testAccessChecker(t *testing.T, when spec.G, it spec.S) {
 				writer.WriteHeader(200)
 			})
 
-			tagName := fmt.Sprintf("%s/some/image:tag", server.URL[7:])
-
 			hasAccess, err := HasWriteAccess(testKeychain{}, tagName)
 			require.NoError(t, err)
 			assert.False(t, hasAccess)
@@ -111,10 +105,20 @@ func testAccessChecker(t *testing.T, when spec.G, it spec.S) {
 				writer.WriteHeader(404)
 			})
 
-			tagName := fmt.Sprintf("%s/some/image:tag", server.URL[7:])
+			hasAccess, err := HasWriteAccess(testKeychain{}, tagName)
+			require.Error(t, err)
+			assert.False(t, hasAccess)
+		})
+
+		it("wraps unhandled server errors with a reasonable error message", func() {
+			handler.HandleFunc("/v2/", func(writer http.ResponseWriter, request *http.Request) {
+				writer.WriteHeader(500)
+			})
 
 			hasAccess, err := HasWriteAccess(testKeychain{}, tagName)
 			require.Error(t, err)
+			expectedErrorMessage := fmt.Sprintf("Error validating write permission to %s. GET %s/v2/: unsupported status code 500", tagName, server.URL)
+			assert.Equal(t, expectedErrorMessage, err.Error())
 			assert.False(t, hasAccess)
 		})
 	})

--- a/pkg/dockercreds/access_checker_test.go
+++ b/pkg/dockercreds/access_checker_test.go
@@ -65,8 +65,7 @@ func testAccessChecker(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			err := VerifyWriteAccess(testKeychain{}, tagName)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "Unauthorized")
+			assert.EqualError(t, err, "UNAUTHORIZED")
 		})
 
 		it("errors when server responds with unauthorized but without a code such as on artifactory", func() {
@@ -81,8 +80,7 @@ func testAccessChecker(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			err := VerifyWriteAccess(testKeychain{}, tagName)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "Unauthorized")
+			assert.EqualError(t, err, "UNAUTHORIZED")
 		})
 
 		it("errors when does not have permission", func() {
@@ -141,7 +139,7 @@ func testAccessChecker(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			err := VerifyReadAccess(testKeychain{}, tagName)
-			assert.EqualError(t, err, fmt.Sprintf("GET %s/v2/some/image/manifests/tag: unsupported status code 401", server.URL))
+			assert.EqualError(t, err, "UNAUTHORIZED")
 		})
 
 		it("errors when cannot reach server", func() {


### PR DESCRIPTION
- wrap unhandled server errors returned by container registry with a more reasonable error message
- removed redundant code from test file

Before:
```
[prepare] GET https://dev.registry.pivotal.io/service/token?scope=repository%3Agarbage%3Apush%2Cpull&service=harbor-registry: unsupported status code 500
```
After:
```
[prepare] Error validating write permission to dev.registry.pivotal.io/garbage. GET https://dev.registry.pivotal.io/service/token?scope=repository%3Agarbage%3Apush%2Cpull&service=harbor-registry: unsupported status code 500
```

Signed-off-by: Sukhil Suresh <ssuresh@pivotal.io>