### PR TITLE
Provide image generation on builds

### DIFF
--- a/pkg/apis/build/v1alpha1/build.go
+++ b/pkg/apis/build/v1alpha1/build.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"strconv"
+
 	"github.com/google/go-containerregistry/pkg/name"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -43,6 +45,22 @@ func (b *Build) BuildRef() string {
 	}
 
 	return b.GetName()
+}
+
+func (b *Build) ImageGeneration() int64 {
+	if b == nil {
+		return 0
+	}
+	generation, ok := b.Labels[ImageGenerationLabel]
+	if !ok {
+		return 0
+	}
+	atoi, err := strconv.Atoi(generation)
+	if err != nil {
+		return 0
+	}
+
+	return int64(atoi)
 }
 
 func (b *Build) Stack() string {

--- a/pkg/apis/build/v1alpha1/image_builds.go
+++ b/pkg/apis/build/v1alpha1/image_builds.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	BuildNumberLabel = "image.build.pivotal.io/buildNumber"
-	ImageLabel       = "image.build.pivotal.io/image"
+	BuildNumberLabel     = "image.build.pivotal.io/buildNumber"
+	ImageLabel           = "image.build.pivotal.io/image"
+	ImageGenerationLabel = "image.build.pivotal.io/imageGeneration"
 
 	BuildReasonAnnotation = "image.build.pivotal.io/reason"
 	BuildNeededAnnotation = "image.build.pivotal.io/additionalBuildNeeded"
@@ -36,8 +37,9 @@ func (im *Image) Build(sourceResolver *SourceResolver, builder BuilderResource, 
 				*kmeta.NewControllerRef(im),
 			},
 			Labels: combine(im.Labels, map[string]string{
-				BuildNumberLabel: buildNumber,
-				ImageLabel:       im.Name,
+				BuildNumberLabel:     buildNumber,
+				ImageLabel:           im.Name,
+				ImageGenerationLabel: strconv.Itoa(int(im.Generation)),
 			}),
 			Annotations: combine(im.Annotations, map[string]string{
 				BuildReasonAnnotation: strings.Join(reasons, ","),

--- a/pkg/apis/build/v1alpha1/image_builds_test.go
+++ b/pkg/apis/build/v1alpha1/image_builds_test.go
@@ -130,10 +130,15 @@ func testImageBuilds(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal(t, map[string]string{"annotation-key": "annotation-value", "image.build.pivotal.io/reason": "CONFIG"}, build.Annotations)
 		})
 
-		it("sets builder to be the Builder's resolved latestImage", func() {
+		it("sets labels from image metadata and propagates image labels", func() {
+			image.Generation = 22
 			build := image.Build(sourceResolver, builder, latestBuild, []string{}, "some-cache-name", 27)
 
-			assert.Equal(t, map[string]string{"label-key": "label-value", "image.build.pivotal.io/buildNumber": "27", "image.build.pivotal.io/image": "image-name"}, build.Labels)
+			assert.Equal(t, map[string]string{
+				"label-key":                              "label-value",
+				"image.build.pivotal.io/buildNumber":     "27",
+				"image.build.pivotal.io/imageGeneration": "22",
+				"image.build.pivotal.io/image":           "image-name"}, build.Labels)
 		})
 
 		it("sets git url and git revision when image source is git", func() {

--- a/pkg/apis/build/v1alpha1/image_types.go
+++ b/pkg/apis/build/v1alpha1/image_types.go
@@ -75,12 +75,13 @@ type ImageBuild struct {
 
 // +k8s:openapi-gen=true
 type ImageStatus struct {
-	corev1alpha1.Status `json:",inline"`
-	LatestBuildRef      string `json:"latestBuildRef,omitempty"`
-	LatestImage         string `json:"latestImage,omitempty"`
-	LatestStack         string `json:"latestStack,omitempty"`
-	BuildCounter        int64  `json:"buildCounter,omitempty"`
-	BuildCacheName      string `json:"buildCacheName,omitempty"`
+	corev1alpha1.Status        `json:",inline"`
+	LatestBuildRef             string `json:"latestBuildRef,omitempty"`
+	LatestBuildImageGeneration int64  `json:"latestBuildImageGeneration,omitempty"`
+	LatestImage                string `json:"latestImage,omitempty"`
+	LatestStack                string `json:"latestStack,omitempty"`
+	BuildCounter               int64  `json:"buildCounter,omitempty"`
+	BuildCacheName             string `json:"buildCacheName,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/reconciler/image/image.go
+++ b/pkg/reconciler/image/image.go
@@ -97,7 +97,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	if k8serrors.IsNotFound(err) {
 		return nil
 	} else if err != nil {
-		return fmt.Errorf("failed attempting to fetch image with name %s: %s", imageName, err)
+		return err
 	}
 
 	image = image.DeepCopy()

--- a/pkg/reconciler/image/image_test.go
+++ b/pkg/reconciler/image/image_test.go
@@ -2,6 +2,7 @@ package image_test
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -46,7 +47,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 		key                            = "some-namespace/image-name"
 		someLabelKey                   = "some/label"
 		someValueToPassThrough         = "to-pass-through"
-		originalGeneration       int64 = 0
+		originalGeneration       int64 = 1
 	)
 	var (
 		fakeTracker = testhelpers.FakeTracker{}
@@ -81,8 +82,9 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 
 	image := &v1alpha1.Image{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      imageName,
-			Namespace: namespace,
+			Name:       imageName,
+			Namespace:  namespace,
+			Generation: originalGeneration,
 			Labels: map[string]string{
 				someLabelKey: someValueToPassThrough,
 			},
@@ -239,7 +241,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 
 	when("Reconcile", func() {
 		it("updates observed generation after processing an update", func() {
-			const updatedGeneration int64 = 1
+			const updatedGeneration int64 = 2
 			image.ObjectMeta.Generation = updatedGeneration
 
 			rt.Test(rtesting.TableRow{
@@ -743,9 +745,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel: "1",
-									v1alpha1.ImageLabel:       imageName,
-									someLabelKey:              someValueToPassThrough,
+									v1alpha1.BuildNumberLabel:     "1",
+									v1alpha1.ImageLabel:           imageName,
+									v1alpha1.ImageGenerationLabel: generation(image),
+									someLabelKey:                  someValueToPassThrough,
 								},
 								Annotations: map[string]string{
 									v1alpha1.BuildReasonAnnotation: v1alpha1.BuildReasonConfig,
@@ -775,10 +778,11 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								Status: v1alpha1.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
-										Conditions:         conditionReadyUnknown(),
+										Conditions:         conditionBuildExecuting("image-name-build-1-00001"),
 									},
-									LatestBuildRef: "image-name-build-1-00001", // GenerateNameReactor
-									BuildCounter:   1,
+									LatestBuildRef:             "image-name-build-1-00001", // GenerateNameReactor
+									LatestBuildImageGeneration: originalGeneration,
+									BuildCounter:               1,
 								},
 							},
 						},
@@ -811,9 +815,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel: "1",
-									v1alpha1.ImageLabel:       imageName,
-									someLabelKey:              someValueToPassThrough,
+									v1alpha1.BuildNumberLabel:     "1",
+									v1alpha1.ImageLabel:           imageName,
+									v1alpha1.ImageGenerationLabel: generation(image),
+									someLabelKey:                  someValueToPassThrough,
 								},
 								Annotations: map[string]string{
 									v1alpha1.BuildReasonAnnotation: v1alpha1.BuildReasonConfig,
@@ -842,10 +847,11 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								Status: v1alpha1.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
-										Conditions:         conditionReadyUnknown(),
+										Conditions:         conditionBuildExecuting("image-name-build-1-00001"),
 									},
-									LatestBuildRef: "image-name-build-1-00001", // GenerateNameReactor
-									BuildCounter:   1,
+									LatestBuildRef:             "image-name-build-1-00001", // GenerateNameReactor
+									LatestBuildImageGeneration: originalGeneration,
+									BuildCounter:               1,
 								},
 							},
 						},
@@ -878,9 +884,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel: "1",
-									v1alpha1.ImageLabel:       imageName,
-									someLabelKey:              someValueToPassThrough,
+									v1alpha1.BuildNumberLabel:     "1",
+									v1alpha1.ImageLabel:           imageName,
+									v1alpha1.ImageGenerationLabel: generation(image),
+									someLabelKey:                  someValueToPassThrough,
 								},
 								Annotations: map[string]string{
 									v1alpha1.BuildReasonAnnotation: v1alpha1.BuildReasonConfig,
@@ -909,10 +916,11 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								Status: v1alpha1.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
-										Conditions:         conditionReadyUnknown(),
+										Conditions:         conditionBuildExecuting("image-name-build-1-00001"),
 									},
-									LatestBuildRef: "image-name-build-1-00001", // GenerateNameReactor
-									BuildCounter:   1,
+									LatestBuildRef:             "image-name-build-1-00001", // GenerateNameReactor
+									LatestBuildImageGeneration: originalGeneration,
+									BuildCounter:               1,
 								},
 							},
 						},
@@ -946,9 +954,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel: "1",
-									v1alpha1.ImageLabel:       imageName,
-									someLabelKey:              someValueToPassThrough,
+									v1alpha1.BuildNumberLabel:     "1",
+									v1alpha1.ImageLabel:           imageName,
+									v1alpha1.ImageGenerationLabel: generation(image),
+									someLabelKey:                  someValueToPassThrough,
 								},
 								Annotations: map[string]string{
 									v1alpha1.BuildReasonAnnotation: v1alpha1.BuildReasonConfig,
@@ -977,10 +986,11 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								Status: v1alpha1.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
-										Conditions:         conditionReadyUnknown(),
+										Conditions:         conditionBuildExecuting("image-name-build-1-00001"),
 									},
-									LatestBuildRef: "image-name-build-1-00001", // GenerateNameReactor
-									BuildCounter:   1,
+									LatestBuildRef:             "image-name-build-1-00001", // GenerateNameReactor
+									LatestBuildImageGeneration: originalGeneration,
+									BuildCounter:               1,
 								},
 							},
 						},
@@ -1012,9 +1022,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel: "1",
-									v1alpha1.ImageLabel:       imageName,
-									someLabelKey:              someValueToPassThrough,
+									v1alpha1.BuildNumberLabel:     "1",
+									v1alpha1.ImageLabel:           imageName,
+									v1alpha1.ImageGenerationLabel: generation(image),
+									someLabelKey:                  someValueToPassThrough,
 								},
 								Annotations: map[string]string{
 									v1alpha1.BuildReasonAnnotation: v1alpha1.BuildReasonConfig,
@@ -1045,20 +1056,12 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								Status: v1alpha1.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
-										Conditions: corev1alpha1.Conditions{
-											{
-												Type:   corev1alpha1.ConditionReady,
-												Status: corev1.ConditionUnknown,
-											},
-											{
-												Type:   v1alpha1.ConditionBuilderReady,
-												Status: corev1.ConditionTrue,
-											},
-										},
+										Conditions:         conditionBuildExecuting("image-name-build-1-00001"),
 									},
-									LatestBuildRef: "image-name-build-1-00001", // GenerateNameReactor
-									BuildCounter:   1,
-									BuildCacheName: image.CacheName(),
+									LatestBuildRef:             "image-name-build-1-00001", // GenerateNameReactor
+									LatestBuildImageGeneration: originalGeneration,
+									BuildCounter:               1,
+									BuildCacheName:             image.CacheName(),
 								},
 							},
 						},
@@ -1130,9 +1133,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel: "2",
-									v1alpha1.ImageLabel:       imageName,
-									someLabelKey:              someValueToPassThrough,
+									v1alpha1.BuildNumberLabel:     "2",
+									v1alpha1.ImageLabel:           imageName,
+									someLabelKey:                  someValueToPassThrough,
+									v1alpha1.ImageGenerationLabel: generation(image),
 								},
 								Annotations: map[string]string{
 									v1alpha1.BuildReasonAnnotation: strings.Join([]string{v1alpha1.BuildReasonConfig, v1alpha1.BuildReasonCommit}, ","),
@@ -1166,11 +1170,12 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								Status: v1alpha1.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
-										Conditions:         conditionReadyUnknown(),
+										Conditions:         conditionBuildExecuting("image-name-build-2-00001"),
 									},
-									LatestBuildRef: "image-name-build-2-00001", // GenerateNameReactor
-									LatestImage:    image.Spec.Tag + "@sha256:just-built",
-									BuildCounter:   2,
+									LatestBuildRef:             "image-name-build-2-00001", // GenerateNameReactor
+									LatestBuildImageGeneration: originalGeneration,
+									LatestImage:                image.Spec.Tag + "@sha256:just-built",
+									BuildCounter:               2,
 								},
 							},
 						},
@@ -1253,9 +1258,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel: "2",
-									v1alpha1.ImageLabel:       imageName,
-									someLabelKey:              someValueToPassThrough,
+									v1alpha1.BuildNumberLabel:     "2",
+									v1alpha1.ImageLabel:           imageName,
+									v1alpha1.ImageGenerationLabel: generation(image),
+									someLabelKey:                  someValueToPassThrough,
 								},
 								Annotations: map[string]string{
 									v1alpha1.BuildReasonAnnotation: v1alpha1.BuildReasonCommit,
@@ -1289,11 +1295,12 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								Status: v1alpha1.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
-										Conditions:         conditionReadyUnknown(),
+										Conditions:         conditionBuildExecuting("image-name-build-2-00001"),
 									},
-									LatestBuildRef: "image-name-build-2-00001", // GenerateNameReactor
-									LatestImage:    image.Spec.Tag + "@sha256:just-built",
-									BuildCounter:   2,
+									LatestBuildRef:             "image-name-build-2-00001", // GenerateNameReactor
+									LatestBuildImageGeneration: originalGeneration,
+									LatestImage:                image.Spec.Tag + "@sha256:just-built",
+									BuildCounter:               2,
 								},
 							},
 						},
@@ -1401,9 +1408,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel: "2",
-									v1alpha1.ImageLabel:       imageName,
-									someLabelKey:              someValueToPassThrough,
+									v1alpha1.BuildNumberLabel:     "2",
+									v1alpha1.ImageLabel:           imageName,
+									v1alpha1.ImageGenerationLabel: generation(image),
+									someLabelKey:                  someValueToPassThrough,
 								},
 								Annotations: map[string]string{
 									v1alpha1.BuildReasonAnnotation: v1alpha1.BuildReasonBuildpack,
@@ -1436,11 +1444,12 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								Status: v1alpha1.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
-										Conditions:         conditionReadyUnknown(),
+										Conditions:         conditionBuildExecuting("image-name-build-2-00001"),
 									},
-									LatestBuildRef: "image-name-build-2-00001", // GenerateNameReactor
-									LatestImage:    image.Spec.Tag + "@sha256:just-built",
-									BuildCounter:   2,
+									LatestBuildRef:             "image-name-build-2-00001", // GenerateNameReactor
+									LatestBuildImageGeneration: originalGeneration,
+									LatestImage:                image.Spec.Tag + "@sha256:just-built",
+									BuildCounter:               2,
 								},
 							},
 						},
@@ -1511,9 +1520,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel: "3",
-									v1alpha1.ImageLabel:       imageName,
-									someLabelKey:              someValueToPassThrough,
+									v1alpha1.BuildNumberLabel:     "3",
+									v1alpha1.ImageLabel:           imageName,
+									v1alpha1.ImageGenerationLabel: generation(image),
+									someLabelKey:                  someValueToPassThrough,
 								},
 								Annotations: map[string]string{
 									v1alpha1.BuildReasonAnnotation: strings.Join([]string{v1alpha1.BuildReasonConfig, v1alpha1.BuildReasonCommit}, ","),
@@ -1547,10 +1557,11 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 								Status: v1alpha1.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
-										Conditions:         conditionReadyUnknown(),
+										Conditions:         conditionBuildExecuting("image-name-build-3-00001"),
 									},
-									LatestBuildRef: "image-name-build-3-00001", // GenerateNameReactor
-									BuildCounter:   3,
+									LatestBuildRef:             "image-name-build-3-00001", // GenerateNameReactor
+									LatestBuildImageGeneration: originalGeneration,
+									BuildCounter:               3,
 								},
 							},
 						},
@@ -1904,6 +1915,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 	})
 }
 
+func generation(i *v1alpha1.Image) string {
+	return strconv.Itoa(int(i.Generation))
+}
+
 func resolvedSourceResolver(image *v1alpha1.Image) *v1alpha1.SourceResolver {
 	sr := image.SourceResolver()
 	sr.ResolvedSource(v1alpha1.ResolvedSourceConfig{
@@ -2001,6 +2016,20 @@ func conditionReadyUnknown() corev1alpha1.Conditions {
 		{
 			Type:   corev1alpha1.ConditionReady,
 			Status: corev1.ConditionUnknown,
+		},
+		{
+			Type:   v1alpha1.ConditionBuilderReady,
+			Status: corev1.ConditionTrue,
+		},
+	}
+}
+
+func conditionBuildExecuting(buildName string) corev1alpha1.Conditions {
+	return corev1alpha1.Conditions{
+		{
+			Type:    corev1alpha1.ConditionReady,
+			Status:  corev1.ConditionUnknown,
+			Message: fmt.Sprintf("%s is executing", buildName),
 		},
 		{
 			Type:   v1alpha1.ConditionBuilderReady,


### PR DESCRIPTION
 - label builds with the image generation that scheduled the build
 - provide latestBuildImageGeneration on an image status
 - this should allow tooling to monitor an update to see if an build correlates with a specific image update
- Report "build-name" is executing when a image is Ready=Unknown