### PR TITLE
Apply wait

### DIFF
--- a/cmd/logs/main.go
+++ b/cmd/logs/main.go
@@ -6,13 +6,13 @@ import (
 	"log"
 	"os"
 
-	"github.com/pivotal/kpack/pkg/logs"
-
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/pivotal/kpack/pkg/logs"
 )
 
 var (
@@ -36,7 +36,12 @@ func main() {
 		log.Fatalf("could not get kubernetes client: %s", err.Error())
 	}
 
-	err = logs.NewBuildLogsClient(k8sClient).Tail(context.Background(), os.Stdout, *image, *build, *namespace)
+	if (*build) == "" {
+		err = logs.NewBuildLogsClient(k8sClient).TailImage(context.Background(), os.Stdout, *image, *namespace)
+	} else {
+		err = logs.NewBuildLogsClient(k8sClient).Tail(context.Background(), os.Stdout, *image, *build, *namespace)
+	}
+
 	if err != nil {
 		log.Fatalf("error tailing logs %s", err)
 	}

--- a/pkg/logs/list_watch_build.go
+++ b/pkg/logs/list_watch_build.go
@@ -1,0 +1,29 @@
+package logs
+
+import (
+	"fmt"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/pivotal/kpack/pkg/client/clientset/versioned"
+)
+
+type listAndWatchBuild struct {
+	buildName   string
+	kpackClient versioned.Interface
+	namespace   string
+}
+
+func (l *listAndWatchBuild) List(options v1.ListOptions) (runtime.Object, error) {
+	options.FieldSelector = fmt.Sprintf("metadata.name=%s", l.buildName)
+
+	return l.kpackClient.BuildV1alpha1().Builds(l.namespace).List(options)
+}
+
+func (l *listAndWatchBuild) Watch(options v1.ListOptions) (watch.Interface, error) {
+	options.FieldSelector = fmt.Sprintf("metadata.name=%s", l.buildName)
+
+	return l.kpackClient.BuildV1alpha1().Builds(l.namespace).Watch(options)
+}

--- a/pkg/logs/wait_for_image.go
+++ b/pkg/logs/wait_for_image.go
@@ -1,0 +1,146 @@
+package logs
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	watchTools "k8s.io/client-go/tools/watch"
+
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
+	"github.com/pivotal/kpack/pkg/client/clientset/versioned"
+)
+
+type imageWaiter struct {
+	KpackClient versioned.Interface
+	logTailer   ImageLogTailer
+}
+
+type ImageLogTailer interface {
+	TailBuildName(ctx context.Context, writer io.Writer, buildName, namespace string) error
+}
+
+func NewImageWaiter(kpackClient versioned.Interface, logTailer ImageLogTailer) *imageWaiter {
+	return &imageWaiter{KpackClient: kpackClient, logTailer: logTailer}
+}
+
+func (w *imageWaiter) Wait(ctx context.Context, writer io.Writer, originalImage *v1alpha1.Image) (string, error) {
+	if done, err := imageUpdateHasResolved(originalImage.Generation)(watch.Event{Object: originalImage}); err != nil {
+		return "", err
+	} else if done {
+		return w.resultOfImageWait(ctx, writer, originalImage.Generation, originalImage)
+	}
+
+	event, err := watchTools.Until(ctx,
+		originalImage.ResourceVersion,
+		watchOnlyOneImage{kpackClient: w.KpackClient, image: originalImage},
+		filterErrors(imageUpdateHasResolved(originalImage.Generation)))
+	if err != nil {
+		return "", err
+	}
+
+	image, ok := event.Object.(*v1alpha1.Image)
+	if !ok {
+		return "", errors.New("unexpected object received")
+	}
+
+	return w.resultOfImageWait(ctx, writer, originalImage.Generation, image)
+}
+
+func (w *imageWaiter) resultOfImageWait(ctx context.Context, writer io.Writer, generation int64, image *v1alpha1.Image) (string, error) {
+	if image.Status.LatestBuildImageGeneration == generation {
+		return w.waitBuild(ctx, writer, image.Namespace, image.Status.LatestBuildRef)
+	}
+
+	if image.Status.GetCondition(corev1alpha1.ConditionReady).IsFalse() {
+		return "", errors.Errorf("update to image %s failed", image.Name)
+	}
+
+	return image.Status.LatestImage, nil
+}
+
+func imageUpdateHasResolved(generation int64) func(event watch.Event) (bool, error) {
+	return func(event watch.Event) (bool, error) {
+		image, ok := event.Object.(*v1alpha1.Image)
+		if !ok {
+			return false, errors.New("unexpected object received")
+		}
+
+		//space shuttle style
+		if image.Status.ObservedGeneration == generation {
+			if !image.Status.GetCondition(corev1alpha1.ConditionReady).IsUnknown() {
+				return true, nil // Ready=False or Ready=True
+			} else if image.Status.LatestBuildImageGeneration == generation {
+				return true, nil // Build scheduled
+			} else {
+				return false, nil // still waiting on build to be scheduled
+			}
+		} else if image.Status.ObservedGeneration > generation {
+			return false, errors.Errorf("image %s was updated before original update was processed", image.Name) // update skipped
+		} else {
+			return false, nil // still waiting on update
+		}
+	}
+}
+
+func filterErrors(condition watchTools.ConditionFunc) watchTools.ConditionFunc {
+	return func(event watch.Event) (bool, error) {
+		if event.Type == watch.Error {
+			return false, errors.Errorf("error on watch %+v", event.Object)
+		}
+
+		return condition(event)
+	}
+}
+
+type watchOnlyOneImage struct {
+	kpackClient versioned.Interface
+	image       *v1alpha1.Image
+}
+
+func (w watchOnlyOneImage) Watch(options v1.ListOptions) (watch.Interface, error) {
+	options.FieldSelector = fmt.Sprintf("metadata.name=%s", w.image.Name)
+	return w.kpackClient.BuildV1alpha1().Images(w.image.Namespace).Watch(options)
+}
+
+func (w *imageWaiter) waitBuild(ctx context.Context, writer io.Writer, namespace, buildName string) (string, error) {
+	doneChan := make(chan struct{})
+	defer func() { <-doneChan }()
+
+	go func() {
+		defer close(doneChan)
+		err := w.logTailer.TailBuildName(ctx, writer, namespace, buildName)
+		if err != nil {
+			fmt.Fprintf(writer, "error tailing logs %s", err)
+		}
+	}()
+
+	event, err := watchTools.ListWatchUntil(ctx,
+		&listAndWatchBuild{kpackClient: w.KpackClient, namespace: namespace, buildName: buildName},
+		filterErrors(func(event watch.Event) (bool, error) {
+			build, ok := event.Object.(*v1alpha1.Build)
+			if !ok {
+				return false, errors.New("unexpected object received")
+			}
+
+			return !build.Status.GetCondition(corev1alpha1.ConditionSucceeded).IsUnknown(), nil
+		}))
+	if err != nil {
+		return "", err
+	}
+
+	build, ok := event.Object.(*v1alpha1.Build)
+	if !ok {
+		return "", errors.New("unexpected object received")
+	}
+
+	if build.Status.GetCondition(corev1alpha1.ConditionSucceeded).IsFalse() {
+		return "", errors.Errorf("update to image failed")
+	}
+
+	return build.Status.LatestImage, nil
+}

--- a/pkg/logs/wait_for_image_test.go
+++ b/pkg/logs/wait_for_image_test.go
@@ -1,0 +1,294 @@
+package logs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strconv"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	clientgotesting "k8s.io/client-go/testing"
+
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
+	"github.com/pivotal/kpack/pkg/client/clientset/versioned/fake"
+)
+
+func TestWaitForImage(t *testing.T) {
+	spec.Run(t, "Wait for image", waitForImage)
+}
+
+func waitForImage(t *testing.T, when spec.G, it spec.S) {
+	var (
+		fakeLogTailer = &fakeLogTailer{}
+		out           = &bytes.Buffer{}
+
+		imageWatcher = &TestWatcher{
+			initialResourceVersion: 1,
+			events:                 make(chan watch.Event, 100),
+		}
+
+		nextBuild          = 11
+		generation   int64 = 2
+		imageToWatch       = &v1alpha1.Image{
+			ObjectMeta: v1.ObjectMeta{
+				Name:            "some-name",
+				Namespace:       "some-namespace",
+				ResourceVersion: "1",
+				Generation:      generation,
+			},
+			Status: v1alpha1.ImageStatus{
+				BuildCounter: int64(nextBuild - 1),
+			},
+		}
+		clientset   = fake.NewSimpleClientset()
+		imageWaiter = NewImageWaiter(clientset, fakeLogTailer)
+	)
+
+	it.Before(func() {
+		clientset.PrependWatchReactor("images", imageWatcher.watchReactor)
+	})
+
+	when("no change is needed to an image", func() {
+		it("returns the already built image", func() {
+			alreadyReadyImage := &v1alpha1.Image{
+				ObjectMeta: imageToWatch.ObjectMeta,
+				Status: v1alpha1.ImageStatus{
+					LatestImage:                "already/built@sha256:1213",
+					LatestBuildImageGeneration: imageToWatch.Generation - 1,
+					Status:                     conditionReady(corev1.ConditionTrue, imageToWatch.Generation),
+				},
+			}
+
+			result, err := imageWaiter.Wait(context.TODO(), out, alreadyReadyImage)
+			assert.NoError(t, err)
+			assert.Equal(t, "already/built@sha256:1213", result)
+		})
+
+		it("returns an error if no build has been created", func() {
+			alreadyReadyImage := &v1alpha1.Image{
+				ObjectMeta: imageToWatch.ObjectMeta,
+				Status: v1alpha1.ImageStatus{
+					Status: conditionReady(corev1.ConditionFalse, imageToWatch.Generation),
+				},
+			}
+
+			_, err := imageWaiter.Wait(context.TODO(), out, alreadyReadyImage)
+			assert.EqualError(t, err, "update to image some-name failed")
+		})
+	})
+
+	when("when a build is scheduled", func() {
+		it("returns built image from the build and tails build logs", func() {
+			_, err := clientset.BuildV1alpha1().Builds(imageToWatch.Namespace).Create(
+				&v1alpha1.Build{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "build-to-follow",
+						Namespace: imageToWatch.Namespace,
+					},
+					Status: v1alpha1.BuildStatus{
+						Status:      conditionSuccess(corev1.ConditionTrue),
+						LatestImage: "image/built-bybuild@sha256:123",
+					},
+				},
+			)
+			require.NoError(t, err)
+
+			scheduledBuildImage := &v1alpha1.Image{
+				ObjectMeta: imageToWatch.ObjectMeta,
+				Status: v1alpha1.ImageStatus{
+					LatestBuildRef:             "build-to-follow",
+					LatestBuildImageGeneration: imageToWatch.Generation,
+					Status:                     conditionReady(corev1.ConditionUnknown, imageToWatch.Generation),
+				},
+			}
+
+			result, err := imageWaiter.Wait(context.TODO(), out, scheduledBuildImage)
+			assert.NoError(t, err)
+			assert.Equal(t, "image/built-bybuild@sha256:123", result)
+
+			assert.Equal(t, imageToWatch.Namespace, fakeLogTailer.args[1])
+			assert.Equal(t, "build-to-follow", fakeLogTailer.args[2])
+		})
+
+		it("returns an err if resulting build fails", func() {
+			_, err := clientset.BuildV1alpha1().Builds(imageToWatch.Namespace).Create(
+				&v1alpha1.Build{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "build-to-follow",
+						Namespace: imageToWatch.Namespace,
+					},
+					Status: v1alpha1.BuildStatus{
+						Status: conditionSuccess(corev1.ConditionFalse),
+					},
+				},
+			)
+			require.NoError(t, err)
+
+			scheduledBuildImage := &v1alpha1.Image{
+				ObjectMeta: imageToWatch.ObjectMeta,
+				Status: v1alpha1.ImageStatus{
+					LatestBuildRef:             "build-to-follow",
+					LatestBuildImageGeneration: imageToWatch.Generation,
+					Status:                     conditionReady(corev1.ConditionUnknown, imageToWatch.Generation),
+				},
+			}
+
+			_, err = imageWaiter.Wait(context.TODO(), out, scheduledBuildImage)
+			assert.Error(t, err)
+
+			assert.Equal(t, imageToWatch.Namespace, fakeLogTailer.args[1])
+			assert.Equal(t, "build-to-follow", fakeLogTailer.args[2])
+		})
+
+		it("waits until resulting build is scheduled", func() {
+			image := &v1alpha1.Image{
+				ObjectMeta: imageToWatch.ObjectMeta,
+			}
+			imageWatcher.expectedImage = image
+
+			imageWatcher.addEvent(watch.Event{
+				Type: watch.Modified,
+				Object: &v1alpha1.Image{
+					ObjectMeta: image.ObjectMeta,
+					Status: v1alpha1.ImageStatus{
+						LatestBuildRef:             "build-to-follow",
+						LatestBuildImageGeneration: image.Generation,
+						Status:                     conditionReady(corev1.ConditionUnknown, image.Generation),
+					},
+				},
+			})
+			_, err := clientset.BuildV1alpha1().Builds(imageToWatch.Namespace).Create(
+				&v1alpha1.Build{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "build-to-follow",
+						Namespace: imageToWatch.Namespace,
+					},
+					Status: v1alpha1.BuildStatus{
+						Status:      conditionSuccess(corev1.ConditionTrue),
+						LatestImage: "image/built-bybuild@sha256:123",
+					},
+				},
+			)
+			require.NoError(t, err)
+
+			result, err := imageWaiter.Wait(context.TODO(), out, image)
+			assert.NoError(t, err)
+			assert.Equal(t, "image/built-bybuild@sha256:123", result)
+
+			assert.Equal(t, imageToWatch.Namespace, fakeLogTailer.args[1])
+			assert.Equal(t, "build-to-follow", fakeLogTailer.args[2])
+		})
+
+	})
+
+	when("an image update is skipped", func() {
+		it("an error is returned", func() {
+			image := &v1alpha1.Image{
+				ObjectMeta: imageToWatch.ObjectMeta,
+			}
+			imageWatcher.expectedImage = image
+
+			imageWatcher.addEvent(watch.Event{
+				Type: watch.Modified,
+				Object: &v1alpha1.Image{
+					ObjectMeta: image.ObjectMeta,
+					Status: v1alpha1.ImageStatus{
+						LatestBuildRef:             "build-to-follow",
+						LatestBuildImageGeneration: image.Generation + 1,
+						Status:                     conditionReady(corev1.ConditionUnknown, image.Generation+1),
+					},
+				},
+			})
+			_, err := imageWaiter.Wait(context.TODO(), out, image)
+			assert.EqualError(t, err, "image some-name was updated before original update was processed")
+		})
+	})
+}
+
+func conditionReady(status corev1.ConditionStatus, generation int64) corev1alpha1.Status {
+	return corev1alpha1.Status{
+		ObservedGeneration: generation,
+		Conditions: []corev1alpha1.Condition{
+			{
+				Type:   corev1alpha1.ConditionReady,
+				Status: status,
+			},
+		},
+	}
+}
+
+func conditionSuccess(status corev1.ConditionStatus) corev1alpha1.Status {
+	return corev1alpha1.Status{
+		Conditions: []corev1alpha1.Condition{
+			{
+				Type:   corev1alpha1.ConditionSucceeded,
+				Status: status,
+			},
+		},
+	}
+}
+
+type TestWatcher struct {
+	events                 chan watch.Event
+	initialResourceVersion int
+	expectedImage          *v1alpha1.Image
+}
+
+func (t *TestWatcher) addEvent(event watch.Event) {
+	t.initialResourceVersion++
+
+	image := event.Object.(*v1alpha1.Image)
+	image.ResourceVersion = strconv.Itoa(t.initialResourceVersion)
+	t.events <- event
+}
+
+func (t *TestWatcher) Stop() {
+}
+
+func (t *TestWatcher) ResultChan() <-chan watch.Event {
+	return t.events
+}
+
+func (t *TestWatcher) watchReactor(action clientgotesting.Action) (handled bool, ret watch.Interface, err error) {
+	namespace := action.GetNamespace()
+	if t.expectedImage == nil {
+		return false, nil, errors.New("test watcher must be configured with an expected image to be used")
+
+	}
+
+	if namespace != t.expectedImage.Namespace {
+		return false, nil, errors.New("unexpected namespace watch")
+	}
+
+	watchAction := action.(clientgotesting.WatchAction)
+	if watchAction.GetWatchRestrictions().ResourceVersion != t.expectedImage.ResourceVersion {
+		return false, nil, errors.New("expected watch on resource version")
+	}
+
+	match, found := watchAction.GetWatchRestrictions().Fields.RequiresExactMatch("metadata.name")
+	if !found {
+		return false, nil, errors.New("expected watch on name")
+	}
+	if match != t.expectedImage.Name {
+		return false, nil, errors.New("expected watch on name")
+	}
+
+	return true, t, nil
+}
+
+type fakeLogTailer struct {
+	args []interface{}
+}
+
+func (f *fakeLogTailer) TailBuildName(ctx context.Context, writer io.Writer, buildName, namespace string) error {
+	f.args = []interface{}{writer, buildName, namespace}
+	return nil
+}


### PR DESCRIPTION
- ImageWaiter is intended to be imported and used in kpack tooling
- Update Build logs to support tailing a build name
- Allow build logs to exit on build completion