### PR TITLE
Ignore non basic auth secret annotations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/buildpacks/imgutil v0.0.0-20200528211046-5c4cfa56bb24
 	github.com/buildpacks/lifecycle v0.8.0
 	github.com/docker/docker v17.12.0-ce-rc1.0.20190924003213-a8608b5b67c7+incompatible // indirect
+	github.com/go-git/go-git-fixtures v3.5.0+incompatible
+	github.com/go-git/go-git/v5 v5.1.0
 	github.com/go-openapi/spec v0.19.8
 	github.com/google/go-cmp v0.4.1
 	github.com/google/go-containerregistry v0.1.0
@@ -22,8 +24,6 @@ require (
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	gomodules.xyz/jsonpatch/v2 v2.1.0 // indirect
-	gopkg.in/src-d/go-git-fixtures.v3 v3.5.0
-	gopkg.in/src-d/go-git.v4 v4.13.1
 	k8s.io/api v0.17.5
 	k8s.io/apiextensions-apiserver v0.17.5 // indirect
 	k8s.io/apimachinery v0.17.5

--- a/go.sum
+++ b/go.sum
@@ -410,6 +410,16 @@ github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-critic/go-critic v0.4.1/go.mod h1:7/14rZGnZbY6E38VEGk2kVhoq6itzc1E68facVDK23g=
 github.com/go-critic/go-critic v0.4.3/go.mod h1:j4O3D4RoIwRqlZw5jJpx0BNfXWWbpcJoKu5cYSe4YmQ=
+github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
+github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
+github.com/go-git/go-billy/v5 v5.0.0 h1:7NQHvd9FVid8VL4qVUMm8XifBK+2xCoZ2lSk0agRrHM=
+github.com/go-git/go-billy/v5 v5.0.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
+github.com/go-git/go-git-fixtures v3.5.0+incompatible h1:llua7G/C+/wwz94Yqx+umpElARLsXBa/p2LPOkEuLn8=
+github.com/go-git/go-git-fixtures v3.5.0+incompatible/go.mod h1:wTsKs9W3ZWQhHoofLq4Mp0qIh6X2bhU4+yN2Df1jx/8=
+github.com/go-git/go-git-fixtures/v4 v4.0.1 h1:q+IFMfLx200Q3scvt2hN79JsEzy4AmBTp/pqnefH+Bc=
+github.com/go-git/go-git-fixtures/v4 v4.0.1/go.mod h1:m+ICp2rF3jDhFgEZ/8yziagdT1C+ZpZcrJjappBCDSw=
+github.com/go-git/go-git/v5 v5.1.0 h1:HxJn9g/E7eYvKW3Fm7Jt4ee8LXfPOm/H1cdDu8vEssk=
+github.com/go-git/go-git/v5 v5.1.0/go.mod h1:ZKfuPUoY1ZqIG4QG9BDBh3G4gLM5zvPuSJAozQrZuyM=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/pkg/apis/build/v1alpha1/build_pod_test.go
+++ b/pkg/apis/build/v1alpha1/build_pod_test.go
@@ -152,6 +152,15 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			},
 			Type: corev1.SecretTypeDockercfg,
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "secret-to-ignore",
+				Annotations: map[string]string{
+					v1alpha1.DOCKERSecretAnnotationPrefix: "ignoreme.com",
+				},
+			},
+			Type: corev1.SecretTypeBootstrapToken,
+		},
 	}
 
 	config := v1alpha1.BuildPodImages{

--- a/pkg/git/fetch.go
+++ b/pkg/git/fetch.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/BurntSushi/toml"
 
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/pkg/errors"
-	"gopkg.in/src-d/go-git.v4"
-	"gopkg.in/src-d/go-git.v4/config"
-	"gopkg.in/src-d/go-git.v4/plumbing"
-	"gopkg.in/src-d/go-git.v4/plumbing/transport"
 )
 
 type Fetcher struct {

--- a/pkg/git/fetch_test.go
+++ b/pkg/git/fetch_test.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/BurntSushi/toml"
 
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/sclevine/spec"
 	"github.com/stretchr/testify/require"
-	gogit "gopkg.in/src-d/go-git.v4"
-	"gopkg.in/src-d/go-git.v4/plumbing/transport"
 )
 
 func TestGitCheckout(t *testing.T) {

--- a/pkg/git/git_keychain.go
+++ b/pkg/git/git_keychain.go
@@ -5,11 +5,11 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	gitSsh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
-	"gopkg.in/src-d/go-git.v4/plumbing/transport"
-	"gopkg.in/src-d/go-git.v4/plumbing/transport/http"
-	gitSsh "gopkg.in/src-d/go-git.v4/plumbing/transport/ssh"
 
 	"github.com/pivotal/kpack/pkg/secret"
 )

--- a/pkg/git/git_keychain_test.go
+++ b/pkg/git/git_keychain_test.go
@@ -6,11 +6,11 @@ import (
 	"path"
 	"testing"
 
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/sclevine/spec"
 	"github.com/stretchr/testify/require"
 	ssh2 "golang.org/x/crypto/ssh"
-	"gopkg.in/src-d/go-git.v4/plumbing/transport/http"
-	"gopkg.in/src-d/go-git.v4/plumbing/transport/ssh"
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/pkg/git/k8s_git_keychain.go
+++ b/pkg/git/k8s_git_keychain.go
@@ -3,7 +3,7 @@ package git
 import (
 	"fmt"
 
-	"gopkg.in/src-d/go-git.v4/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	k8sclient "k8s.io/client-go/kubernetes"

--- a/pkg/git/k8s_git_keychain_test.go
+++ b/pkg/git/k8s_git_keychain_test.go
@@ -7,11 +7,11 @@ import (
 	"encoding/pem"
 	"testing"
 
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/sclevine/spec"
 	"github.com/stretchr/testify/require"
 	ssh2 "golang.org/x/crypto/ssh"
-	"gopkg.in/src-d/go-git.v4/plumbing/transport/http"
-	"gopkg.in/src-d/go-git.v4/plumbing/transport/ssh"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"

--- a/pkg/git/remote_git_resolver.go
+++ b/pkg/git/remote_git_resolver.go
@@ -1,11 +1,11 @@
 package git
 
 import (
-	"gopkg.in/src-d/go-git.v4"
-	"gopkg.in/src-d/go-git.v4/config"
-	"gopkg.in/src-d/go-git.v4/plumbing"
-	"gopkg.in/src-d/go-git.v4/plumbing/transport"
-	"gopkg.in/src-d/go-git.v4/storage/memory"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/storage/memory"
 
 	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )

--- a/pkg/git/remote_git_resolver_test.go
+++ b/pkg/git/remote_git_resolver_test.go
@@ -3,11 +3,11 @@ package git
 import (
 	"testing"
 
+	fixtures "github.com/go-git/go-git-fixtures"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/sclevine/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	fixtures "gopkg.in/src-d/go-git-fixtures.v3"
-	"gopkg.in/src-d/go-git.v4/plumbing/transport/http"
 
 	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )


### PR DESCRIPTION
Previously if a secret was annotated, kpack would assume it was a basic auth secret even if it was a dockerconfig secret which would prevent it from being used in a build.

Found by @jamespollard8