### PR TITLE
Update cluster stack store docs

### DIFF
--- a/samples/experimental/clusterstack.yaml
+++ b/samples/experimental/clusterstack.yaml
@@ -1,5 +1,5 @@
 apiVersion: experimental.kpack.pivotal.io/v1alpha1
-kind: Stack
+kind: ClusterStack
 metadata:
   name: bionic-stack
 spec:

--- a/samples/experimental/clusterstore.yaml
+++ b/samples/experimental/clusterstore.yaml
@@ -1,7 +1,7 @@
 apiVersion: experimental.kpack.pivotal.io/v1alpha1
-kind: Store
+kind: ClusterStore
 metadata:
-  name: sample-store
+  name: sample-cluster-store
 spec:
   sources:
   - image: gcr.io/paketo-buildpacks/adopt-openjdk

--- a/samples/experimental/custom_builder.yaml
+++ b/samples/experimental/custom_builder.yaml
@@ -6,8 +6,12 @@ metadata:
 spec:
   serviceAccount: default
   tag: sample/custom-builder
-  stack: bionic-stack
-  store: sample-store
+  stack:
+    name: bionic-stack
+    kind: ClusterStack
+  store:
+    name: sample-cluster-store
+    kind: ClusterStore
   order:
   - group:
     - id: paketo-buildpacks/adopt-openjdk

--- a/samples/experimental/custom_cluster_builder.yaml
+++ b/samples/experimental/custom_cluster_builder.yaml
@@ -4,8 +4,12 @@ metadata:
   name: my-cluster-builder
 spec:
   tag: buildingbuilder/custom-builder
-  stack: bionic-stack
-  store: sample-store
+  stack:
+    name: bionic-stack
+    kind: ClusterStack
+  store:
+    name: sample-cluster-store
+    kind: ClusterStore
   serviceAccountRef:
     name: default
     namespace: default


### PR DESCRIPTION
Merge before next kpack release and after https://github.com/pivotal/kpack/pull/437.

This allows us to keep the docs in the kpack repo accurate until we want to update them and release the rename