### PR TITLE
Make image.cacheSize an immutable field

### DIFF
--- a/pkg/apis/build/v1alpha1/image_validation.go
+++ b/pkg/apis/build/v1alpha1/image_validation.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -26,46 +27,61 @@ func init() {
 	defaultCacheSize = resource.MustParse("2G")
 }
 
-func (s *Image) SetDefaults(ctx context.Context) {
-	if s.Spec.ServiceAccount == "" {
-		s.Spec.ServiceAccount = "default"
+func (i *Image) SetDefaults(ctx context.Context) {
+	if i.Spec.ServiceAccount == "" {
+		i.Spec.ServiceAccount = "default"
 	}
 
-	if s.Spec.ImageTaggingStrategy == "" {
-		s.Spec.ImageTaggingStrategy = BuildNumber
+	if i.Spec.ImageTaggingStrategy == "" {
+		i.Spec.ImageTaggingStrategy = BuildNumber
 	}
 
-	if s.Spec.FailedBuildHistoryLimit == nil {
-		s.Spec.FailedBuildHistoryLimit = &defaultFailedBuildHistoryLimit
+	if i.Spec.FailedBuildHistoryLimit == nil {
+		i.Spec.FailedBuildHistoryLimit = &defaultFailedBuildHistoryLimit
 	}
 
-	if s.Spec.SuccessBuildHistoryLimit == nil {
-		s.Spec.SuccessBuildHistoryLimit = &defaultSuccessfulBuildHistoryLimit
+	if i.Spec.SuccessBuildHistoryLimit == nil {
+		i.Spec.SuccessBuildHistoryLimit = &defaultSuccessfulBuildHistoryLimit
 	}
 
-	if s.Spec.CacheSize == nil && ctx.Value(HasDefaultStorageClass) != nil {
-		s.Spec.CacheSize = &defaultCacheSize
+	if i.Spec.CacheSize == nil && ctx.Value(HasDefaultStorageClass) != nil {
+		i.Spec.CacheSize = &defaultCacheSize
 	}
 }
 
-func (s *Image) Validate(ctx context.Context) *apis.FieldError {
-	return s.Spec.Validate(ctx).ViaField("spec")
+func (i *Image) Validate(ctx context.Context) *apis.FieldError {
+	return i.Spec.Validate(ctx).ViaField("spec")
 }
 
 func (is *ImageSpec) Validate(ctx context.Context) *apis.FieldError {
 	return is.validateTag(ctx).
 		Also(validateBuilder(is.Builder).ViaField("builder")).
 		Also(is.Source.Validate(ctx).ViaField("source")).
-		Also(is.Build.Validate(ctx).ViaField("build"))
+		Also(is.Build.Validate(ctx).ViaField("build")).
+		Also(is.validateCacheSize(ctx))
 }
 
-func (im *ImageSpec) validateTag(ctx context.Context) *apis.FieldError {
+func (is *ImageSpec) validateTag(ctx context.Context) *apis.FieldError {
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*Image)
-		return validate.ImmutableField(original.Spec.Tag, im.Tag, "tag")
+		return validate.ImmutableField(original.Spec.Tag, is.Tag, "tag")
 	}
 
-	return validate.Tag(im.Tag)
+	return validate.Tag(is.Tag)
+}
+
+func (is *ImageSpec) validateCacheSize(ctx context.Context) *apis.FieldError {
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*Image)
+		return validate.ImmutableField(
+			*original.Spec.CacheSize,
+			*is.CacheSize,
+			"cacheSize",
+			fmt.Sprintf("got: %v, want: %v", is.CacheSize, original.Spec.CacheSize),
+		)
+	}
+
+	return nil
 }
 
 func validateBuilder(builder v1.ObjectReference) *apis.FieldError {

--- a/pkg/apis/build/v1alpha1/image_validation_test.go
+++ b/pkg/apis/build/v1alpha1/image_validation_test.go
@@ -241,5 +241,13 @@ func testImageValidation(t *testing.T, when spec.G, it spec.S) {
 			err := image.Validate(apis.WithinUpdate(context.TODO(), original))
 			assert.EqualError(t, err, "Immutable field changed: spec.tag\ngot: something/different, want: some/image")
 		})
+
+		it("image.cacheSize has not changed", func() {
+			original := image.DeepCopy()
+			cacheSize := resource.MustParse("6G")
+			image.Spec.CacheSize = &cacheSize
+			err := image.Validate(apis.WithinUpdate(context.TODO(), original))
+			assert.EqualError(t, err, "Immutable field changed: spec.cacheSize\ngot: 6G, want: 5G")
+		})
 	})
 }

--- a/pkg/apis/validate/validation_helpers.go
+++ b/pkg/apis/validate/validation_helpers.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"knative.dev/pkg/apis"
@@ -21,12 +22,16 @@ func ListNotEmpty(value []string, field string) *apis.FieldError {
 	return nil
 }
 
-func ImmutableField(original, current interface{}, field string) *apis.FieldError {
+func ImmutableField(original, current interface{}, field string, errDetails ...string) *apis.FieldError {
 	if original != current {
+		details := fmt.Sprintf("got: %v, want: %v", current, original)
+		if len(errDetails) != 0 {
+			details = strings.Join(errDetails, "\n")
+		}
 		return &apis.FieldError{
 			Message: "Immutable field changed",
 			Paths:   []string{field},
-			Details: fmt.Sprintf("got: %v, want: %v", current, original),
+			Details: details,
 		}
 	}
 	return nil


### PR DESCRIPTION
- Extend ImmutableField method for optional error details
  Allows for comparison of non-stringable types