### PR TITLE
Bump lifecycle to 0.9.2

### DIFF
--- a/hack/lifecycle/main.go
+++ b/hack/lifecycle/main.go
@@ -41,7 +41,7 @@ func main() {
 	flag.Parse()
 
 	image, err := lifecycleImage(
-		"https://github.com/buildpacks/lifecycle/releases/download/v0.9.1/lifecycle-v0.9.1+linux.x86-64.tgz",
+		"https://github.com/buildpacks/lifecycle/releases/download/v0.9.2/lifecycle-v0.9.2+linux.x86-64.tgz",
 		cnb.LifecycleMetadata{
 			LifecycleInfo: cnb.LifecycleInfo{
 				Version: "0.9.1",


### PR DESCRIPTION
- Avoid bumping go.mod lifecycle to avoid bumping google/go-container-registry to avoid bumping k8s/client-go to 1.18.*