### PR TITLE
Fix build trigger timestamp

### DIFF
--- a/pkg/buildchange/change_processor_test.go
+++ b/pkg/buildchange/change_processor_test.go
@@ -43,21 +43,9 @@ func testChangeProcessor(t *testing.T, when spec.G, it spec.S) {
 
 	when("single change processed", func() {
 		when("TRIGGER", func() {
-			when("date string is given in unsupported format", func() {
-				change := buildchange.NewTriggerChange("bad date string")
-				expectedErrorStr := `error determining if build is required for reason 'TRIGGER': parsing time "bad date string" as "2006-01-02 15:04:05.000000 -0700 MST m=+0.000000000": cannot parse "bad date string" as "2006"`
-
-				it("errors for Summarize", func() {
-					_, err := cp.Process(change).Summarize()
-					assert.Error(t, err)
-					assert.Equal(t, expectedErrorStr, err.Error())
-				})
-			})
-
-			when("date string is given in supported format", func() {
-				change := buildchange.NewTriggerChange("2020-11-20 15:38:15.794105 -0500 EST m=+0.022963826")
-				expectedReasonsStr := "TRIGGER"
-				expectedChangesStr := testhelpers.CompactJSON(`
+			change := buildchange.NewTriggerChange("Fri, 20 Nov 2020 15:38:15 -0500")
+			expectedReasonsStr := "TRIGGER"
+			expectedChangesStr := testhelpers.CompactJSON(`
 [
   {
     "reason": "TRIGGER",
@@ -66,17 +54,16 @@ func testChangeProcessor(t *testing.T, when spec.G, it spec.S) {
   }
 ]`)
 
-				it("returns the correct ChangeSummary and does not error", func() {
-					summary, err := cp.Process(change).Summarize()
-					assert.NoError(t, err)
-					assert.True(t, summary.HasChanges)
-					assert.Equal(t, expectedReasonsStr, summary.ReasonsStr)
-					assert.Equal(t, expectedChangesStr, summary.ChangesStr)
+			it("returns the correct ChangeSummary and does not error", func() {
+				summary, err := cp.Process(change).Summarize()
+				assert.NoError(t, err)
+				assert.True(t, summary.HasChanges)
+				assert.Equal(t, expectedReasonsStr, summary.ReasonsStr)
+				assert.Equal(t, expectedChangesStr, summary.ChangesStr)
 
-					var changes []buildchange.GenericChange
-					err = json.Unmarshal([]byte(summary.ChangesStr), &changes)
-					assert.NoError(t, err)
-				})
+				var changes []buildchange.GenericChange
+				err = json.Unmarshal([]byte(summary.ChangesStr), &changes)
+				assert.NoError(t, err)
 			})
 		})
 
@@ -409,7 +396,7 @@ func testChangeProcessor(t *testing.T, when spec.G, it spec.S) {
 		when("they are all valid", func() {
 			commitChange := buildchange.NewCommitChange("old-revision", "new-revision")
 
-			triggerChange := buildchange.NewTriggerChange("2020-11-20 15:38:15.794105 -0500 EST m=+0.022963826")
+			triggerChange := buildchange.NewTriggerChange("Fri, 20 Nov 2020 15:38:15 -0500")
 
 			oldRunImageRef := "gcr.io/some-project/repo/run@sha256:87302783be0a0cab9fde5b68c9954b7e9150ca0d514ba542e9810c3c6f2984ad"
 			newRunImageRef := "gcr.io/some-project/repo/run@sha256:87302783be0a0cab9fde5b68c9954b7e9150ca0d514ba542e9810c3c6f2984ae"
@@ -606,21 +593,8 @@ func testChangeProcessor(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
-		when("they are all invalid", func() {
-			triggerChange := buildchange.NewTriggerChange("bad date string")
-			stackChange := buildchange.NewStackChange("invalid-oldRunImageRef", "invalid-newRunImageRef")
-			expectedErrorStr := `error determining if build is required for reason 'TRIGGER': parsing time "bad date string" as "2006-01-02 15:04:05.000000 -0700 MST m=+0.000000000": cannot parse "bad date string" as "2006"
-error determining if build is required for reason 'STACK': could not parse reference: invalid-oldRunImageRef; could not parse reference: invalid-newRunImageRef`
-
-			it("errors for Summarize", func() {
-				_, err := cp.Process(triggerChange).Process(stackChange).Summarize()
-				assert.Error(t, err)
-				assert.Equal(t, expectedErrorStr, err.Error())
-			})
-		})
-
 		when("some are invalid", func() {
-			triggerChange := buildchange.NewTriggerChange("2020-11-20 15:38:15.794105 -0500 EST m=+0.022963826")
+			triggerChange := buildchange.NewTriggerChange("Fri, 20 Nov 2020 15:38:15 -0500")
 			stackChange := buildchange.NewStackChange("invalid-oldRunImageRef", "invalid-newRunImageRef")
 			expectedErrorStr := `error determining if build is required for reason 'STACK': could not parse reference: invalid-oldRunImageRef; could not parse reference: invalid-newRunImageRef`
 

--- a/pkg/buildchange/trigger_change.go
+++ b/pkg/buildchange/trigger_change.go
@@ -2,38 +2,27 @@ package buildchange
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
-// kp-cli uses time.Now().String() which looks like this
-const expectedTimeLayout = "2006-01-02 15:04:05.000000 -0700 MST m=+0.000000000"
-
 func NewTriggerChange(dateStr string) Change {
-	parsedTime, err := time.Parse(expectedTimeLayout, dateStr)
-	if err != nil {
-		return triggerChange{err: err}
-	}
-
 	format := "A new build was manually triggered on %s"
-	message := fmt.Sprintf(format, parsedTime.Format(time.RFC1123Z))
+	message := fmt.Sprintf(format, dateStr)
 
 	return triggerChange{
 		message: message,
-		err:     err,
 	}
 }
 
 type triggerChange struct {
 	message string
-	err     error
 }
 
 func (t triggerChange) Reason() v1alpha1.BuildReason { return v1alpha1.BuildReasonTrigger }
 
 func (t triggerChange) IsBuildRequired() (bool, error) {
-	return t.message != "", t.err
+	return t.message != "", nil
 }
 
 func (t triggerChange) Old() interface{} { return "" }

--- a/pkg/reconciler/image/build_required.go
+++ b/pkg/reconciler/image/build_required.go
@@ -1,6 +1,8 @@
 package image
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
@@ -54,10 +56,12 @@ func triggerChange(lastBuild *v1alpha1.Build) buildchange.Change {
 		return nil
 	}
 
-	time, ok := lastBuild.Annotations[v1alpha1.BuildNeededAnnotation]
+	_, ok := lastBuild.Annotations[v1alpha1.BuildNeededAnnotation]
 	if !ok {
 		return nil
 	}
+
+	time := time.Now().Format(time.RFC1123Z)
 	return buildchange.NewTriggerChange(time)
 }
 


### PR DESCRIPTION
Server side generation of build trigger timestamp used in the build change message

Depending on client side timestamp is problematic, since a `time.Now().String()` results in different formats based on the OS. Explicitly specifying a time format in the cli would fix things, but usage of an older cli would cause problems. More details in [this Slack thread](https://vmware.slack.com/archives/GJBSG61B8/p1608068169254200)

Issue: https://github.com/pivotal/kpack/issues/513
