### PR TITLE
Fix build required detection for buildpack change

### DIFF
--- a/pkg/buildchange/change_logger_test.go
+++ b/pkg/buildchange/change_logger_test.go
@@ -196,18 +196,14 @@ func testLog(t *testing.T, when spec.G, it spec.S) {
 							{Id: "another-buildpack-id", Version: "another-buildpack-old-version"},
 							{Id: "some-buildpack-id", Version: "some-buildpack-old-version"},
 						},
-						New: []v1alpha1.BuildpackInfo{
-							{Id: "some-buildpack-id", Version: "some-buildpack-new-version"},
-						},
 					}),
 					expectedOut: diffOutBuilder.Reset().
 						Txt("Build reason(s): BUILDPACK").
 						Txt("BUILDPACK:").
 						Old("- id: another-buildpack-id").
 						Old("  version: another-buildpack-old-version").
-						NoD("- id: some-buildpack-id").
-						Old("  version: some-buildpack-old-version").
-						New("  version: some-buildpack-new-version").Out(),
+						Old("- id: some-buildpack-id").
+						Old("  version: some-buildpack-old-version").Out(),
 				}.execute(t)
 			})
 		})

--- a/pkg/reconciler/image/build_required.go
+++ b/pkg/reconciler/image/build_required.go
@@ -104,26 +104,13 @@ func buildpackChange(lastBuild *v1alpha1.Build, builder v1alpha1.BuilderResource
 		return nil
 	}
 
-	builderBuildpacks := builder.BuildpackMetadata()
-	getBuilderBuildpackById := func(bpId string) *v1alpha1.BuildpackMetadata {
-		for _, bp := range builderBuildpacks {
-			if bp.Id == bpId {
-				return &bp
-			}
-		}
-		return nil
-	}
-
 	var old []v1alpha1.BuildpackInfo
 	var new []v1alpha1.BuildpackInfo
 
+	builderBuildpacks := builder.BuildpackMetadata()
 	for _, lastBuildBp := range lastBuild.Status.BuildMetadata {
-		builderBp := getBuilderBuildpackById(lastBuildBp.Id)
-		if builderBp == nil {
+		if !builderBuildpacks.Include(lastBuildBp) {
 			old = append(old, v1alpha1.BuildpackInfo{Id: lastBuildBp.Id, Version: lastBuildBp.Version})
-		} else if builderBp.Version != lastBuildBp.Version {
-			old = append(old, v1alpha1.BuildpackInfo{Id: lastBuildBp.Id, Version: lastBuildBp.Version})
-			new = append(new, v1alpha1.BuildpackInfo{Id: builderBp.Id, Version: builderBp.Version})
 		}
 	}
 

--- a/pkg/reconciler/image/build_required_test.go
+++ b/pkg/reconciler/image/build_required_test.go
@@ -290,12 +290,7 @@ func testImageBuilds(t *testing.T, when spec.G, it spec.S) {
         "version": "1"
       }
     ],
-    "new": [
-      {
-        "id": "buildpack.matches",
-        "version": "NEW_VERSION"
-      }
-    ]
+    "new": null
   }
 ]`)
 

--- a/pkg/reconciler/image/image_test.go
+++ b/pkg/reconciler/image/image_test.go
@@ -1478,12 +1478,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
         "version": "old-version"
       }
     ],
-    "new": [
-      {
-        "id": "io.buildpack",
-        "version": "new-version"
-      }
-    ]
+    "new": null
   }
 ]`),
 								},


### PR DESCRIPTION
- does not try to check for version change on used buildpack
- checks if all buildpacks used by the last build are
present in the builder

Issue: https://github.com/pivotal/kpack/issues/513