### PR TITLE
Lifecycle image is configurable

### DIFF
--- a/cmd/build-init/main.go
+++ b/cmd/build-init/main.go
@@ -53,14 +53,14 @@ func init() {
 }
 
 const (
-	secretsHome            = "/builder/home"
-	appDir                 = "/workspace"
-	platformDir            = "/platform"
-	buildSecretsDir        = "/var/build-secrets"
-	imagePullSecretsDir    = "/imagePullSecrets"
-	builderPullSecretsDir  = "/builderPullSecrets"
-	projectMetadataDir     = "/projectMetadata"
-	networkWaitLauncherDir = "/networkWait"
+	secretsHome               = "/builder/home"
+	appDir                    = "/workspace"
+	platformDir               = "/platform"
+	buildSecretsDir           = "/var/build-secrets"
+	imagePullSecretsDir       = "/imagePullSecrets"
+	builderPullSecretsDir     = "/builderPullSecrets"
+	projectMetadataDir        = "/projectMetadata"
+	networkWaitLauncherDir    = "/networkWait"
 	networkWaitLauncherBinary = "network-wait-launcher.exe"
 )
 
@@ -249,4 +249,3 @@ func copyFile(src, dest string) error {
 
 	return os.Chmod(dest, srcInfo.Mode())
 }
-

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -174,8 +174,8 @@ func main() {
 	clusterStoreController := clusterstore.NewController(options, clusterStoreInformer, remoteStoreReader)
 	clusterStackController := clusterstack.NewController(options, clusterStackInformer, remoteStackReader)
 
-	lifecycleProvider.RegisterCallback(builderResync)
-	lifecycleProvider.RegisterCallback(clusterBuilderResync)
+	lifecycleProvider.AddEventHandler(builderResync)
+	lifecycleProvider.AddEventHandler(clusterBuilderResync)
 
 	stopChan := make(chan struct{})
 	informerFactory.Start(stopChan)

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pivotal/kpack/pkg/client/clientset/versioned"
 	"github.com/pivotal/kpack/pkg/client/informers/externalversions"
 	"github.com/pivotal/kpack/pkg/cnb"
+	"github.com/pivotal/kpack/pkg/config"
 	"github.com/pivotal/kpack/pkg/dockercreds/k8sdockercreds"
 	"github.com/pivotal/kpack/pkg/duckbuilder"
 	"github.com/pivotal/kpack/pkg/git"
@@ -125,10 +126,10 @@ func main() {
 
 	buildpodGenerator := &buildpod.Generator{
 		BuildPodConfig: v1alpha1.BuildPodImages{
-			BuildInitImage:        *buildInitImage,
-			CompletionImage:       *completionImage,
-			RebaseImage:           *rebaseImage,
-			BuildInitWindowsImage: *buildInitWindowsImage,
+			BuildInitImage:         *buildInitImage,
+			CompletionImage:        *completionImage,
+			RebaseImage:            *rebaseImage,
+			BuildInitWindowsImage:  *buildInitWindowsImage,
 			CompletionWindowsImage: *completionWindowsImage,
 		},
 		K8sClient:       k8sClient,
@@ -155,20 +156,26 @@ func main() {
 		Keychain:       kpackKeychain,
 	}
 
+	lifecycleProvider := config.NewLifecycleProvider(*lifecycleImage, &registry.Client{}, kpackKeychain)
+	configMapWatcher.Watch(config.LifecycleConfigName, lifecycleProvider.UpdateImage)
+
 	builderCreator := &cnb.RemoteBuilderCreator{
 		RegistryClient:         &registry.Client{},
-		LifecycleImage:         *lifecycleImage,
 		KpackVersion:           cmd.Identifer,
+		LifecycleProvider:      lifecycleProvider,
 		NewBuildpackRepository: newBuildpackRepository(kpackKeychain),
 	}
 
 	buildController := build.NewController(options, k8sClient, buildInformer, podInformer, metadataRetriever, buildpodGenerator)
 	imageController := image.NewController(options, k8sClient, imageInformer, buildInformer, duckBuilderInformer, sourceResolverInformer, pvcInformer)
 	sourceResolverController := sourceresolver.NewController(options, sourceResolverInformer, gitResolver, blobResolver, registryResolver)
-	builderController := builder.NewController(options, builderInformer, builderCreator, keychainFactory, clusterStoreInformer, clusterStackInformer)
-	clusterBuilderController := clusterBuilder.NewController(options, clusterBuilderInformer, builderCreator, keychainFactory, clusterStoreInformer, clusterStackInformer)
+	builderController, builderResync := builder.NewController(options, builderInformer, builderCreator, keychainFactory, clusterStoreInformer, clusterStackInformer)
+	clusterBuilderController, clusterBuilderResync := clusterBuilder.NewController(options, clusterBuilderInformer, builderCreator, keychainFactory, clusterStoreInformer, clusterStackInformer)
 	clusterStoreController := clusterstore.NewController(options, clusterStoreInformer, remoteStoreReader)
 	clusterStackController := clusterstack.NewController(options, clusterStackInformer, remoteStackReader)
+
+	lifecycleProvider.RegisterCallback(builderResync)
+	lifecycleProvider.RegisterCallback(clusterBuilderResync)
 
 	stopChan := make(chan struct{})
 	informerFactory.Start(stopChan)

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -79,7 +79,7 @@ func validatingAdmissionController(ctx context.Context, _ configmap.Watcher) *co
 		"validation.webhook.kpack.io",
 		// The path on which to serve the webhook.
 		"/validate",
-		// The resources to default.
+		// The resources to validate.
 		types,
 		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
 		func(ctx context.Context) context.Context {

--- a/pkg/apis/build/v1alpha1/build_pod.go
+++ b/pkg/apis/build/v1alpha1/build_pod.go
@@ -210,7 +210,7 @@ func (b *Build) BuildPod(images BuildPodImages, secrets []corev1.Secret, config 
 						),
 						ImagePullPolicy: corev1.PullIfNotPresent,
 					},
-					ifWindows(config.OS, addNetworkWaitLauncherVolume(), useNetworkWaitLauncher(dnsProbeHost))...)
+						ifWindows(config.OS, addNetworkWaitLauncherVolume(), useNetworkWaitLauncher(dnsProbeHost))...)
 				}
 			}),
 			SecurityContext: podSecurityContext(config),
@@ -494,7 +494,7 @@ func useNetworkWaitLauncher(dnsProbeHost string) stepModifier {
 		startCommand := container.Command
 		if len(startCommand) == 0 {
 			container.Args = args([]string{dnsProbeHost}, container.Args)
-		}else {
+		} else {
 			container.Args = args([]string{dnsProbeHost, "--"}, startCommand, container.Args)
 		}
 

--- a/pkg/cnb/create_builder.go
+++ b/pkg/cnb/create_builder.go
@@ -16,12 +16,16 @@ type BuildpackRepository interface {
 	FindByIdAndVersion(id, version string) (RemoteBuildpackInfo, error)
 }
 
+type LifecycleProvider interface {
+	GetImage() (v1.Image, error)
+}
+
 type NewBuildpackRepository func(clusterStore *v1alpha1.ClusterStore) BuildpackRepository
 
 type RemoteBuilderCreator struct {
 	RegistryClient         RegistryClient
-	LifecycleImage         string
 	NewBuildpackRepository NewBuildpackRepository
+	LifecycleProvider      LifecycleProvider
 	KpackVersion           string
 }
 
@@ -33,7 +37,7 @@ func (r *RemoteBuilderCreator) CreateBuilder(keychain authn.Keychain, clusterSto
 		return v1alpha1.BuilderRecord{}, err
 	}
 
-	lifecycleImage, _, err := r.RegistryClient.Fetch(keychain, r.LifecycleImage)
+	lifecycleImage, err := r.LifecycleProvider.GetImage()
 	if err != nil {
 		return v1alpha1.BuilderRecord{}, err
 	}

--- a/pkg/cnb/create_builder_test.go
+++ b/pkg/cnb/create_builder_test.go
@@ -167,9 +167,14 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 			},
 		}
 
-		lifecycleProvider *fakeLifecycleProvider
+		lifecycleProvider = &fakeLifecycleProvider{}
 
-		subject RemoteBuilderCreator
+		subject = RemoteBuilderCreator{
+			RegistryClient:         registryClient,
+			KpackVersion:           "v1.2.3 (git sha: abcdefg123456)",
+			NewBuildpackRepository: newBuildpackRepo,
+			LifecycleProvider:      lifecycleProvider,
+		}
 	)
 
 	buildpackRepository.AddBP("io.buildpack.1", "v1", []buildpackLayer{
@@ -300,14 +305,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 
 			registryClient.AddImage(buildImage, buildImg, keychain)
 
-			lifecycleProvider = &fakeLifecycleProvider{lifecycleImg}
-
-			subject = RemoteBuilderCreator{
-				RegistryClient:         registryClient,
-				KpackVersion:           "v1.2.3 (git sha: abcdefg123456)",
-				NewBuildpackRepository: newBuildpackRepo,
-				LifecycleProvider:      lifecycleProvider,
-			}
+			lifecycleProvider.image = lifecycleImg
 		})
 
 		it("creates a custom builder", func() {

--- a/pkg/config/lifecycle_provider.go
+++ b/pkg/config/lifecycle_provider.go
@@ -1,0 +1,90 @@
+package config
+
+import (
+	"sync/atomic"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	LifecycleConfigName = "lifecycle-image"
+	LifecycleConfigKey  = "image"
+)
+
+type RegistryClient interface {
+	Fetch(keychain authn.Keychain, repoName string) (v1.Image, string, error)
+}
+
+type lifecycleData struct {
+	image v1.Image
+	err   error
+}
+
+type LifecycleProvider struct {
+	RegistryClient RegistryClient
+	Keychain       authn.Keychain
+	lifecycleData  atomic.Value
+	callbacks      []func()
+}
+
+func NewLifecycleProvider(lifecycleImageRef string, client RegistryClient, keychain authn.Keychain) *LifecycleProvider {
+	p := &LifecycleProvider{
+		RegistryClient: client,
+		Keychain:       keychain,
+	}
+
+	data := &lifecycleData{}
+
+	data.image, data.err = p.fetchImage(lifecycleImageRef)
+
+	p.lifecycleData.Store(data)
+	return p
+}
+
+func (l *LifecycleProvider) UpdateImage(cm *corev1.ConfigMap) {
+	data := &lifecycleData{}
+	defer l.callCallBacks()
+	defer l.lifecycleData.Store(data)
+
+	imageRef, ok := cm.Data[LifecycleConfigKey]
+	if !ok {
+		data.err = errors.New("lifecycle-image config invalid")
+		return
+	}
+
+	data.image, data.err = l.fetchImage(imageRef)
+}
+
+func (l *LifecycleProvider) GetImage() (v1.Image, error) {
+	d, ok := l.lifecycleData.Load().(*lifecycleData)
+	if !ok {
+		return nil, errors.New("lifecycle image has not been loaded")
+	}
+
+	if d.err != nil {
+		return nil, d.err
+	}
+
+	return d.image, nil
+}
+
+func (l *LifecycleProvider) RegisterCallback(callback func()) {
+	l.callbacks = append(l.callbacks, callback)
+}
+
+func (l *LifecycleProvider) fetchImage(imageRef string) (v1.Image, error) {
+	img, _, err := l.RegistryClient.Fetch(l.Keychain, imageRef)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch lifecycle image")
+	}
+	return img, nil
+}
+
+func (l *LifecycleProvider) callCallBacks() {
+	for _, cb := range l.callbacks {
+		cb()
+	}
+}

--- a/pkg/config/lifecycle_provider_test.go
+++ b/pkg/config/lifecycle_provider_test.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/pivotal/kpack/pkg/registry/registryfakes"
+)
+
+func TestProvider(t *testing.T) {
+	spec.Run(t, "LifecycleProvider", testProvider)
+}
+
+func testProvider(t *testing.T, when spec.G, it spec.S) {
+	var (
+		client             = registryfakes.NewFakeClient()
+		keychain           = authn.NewMultiKeychain(authn.DefaultKeychain)
+		lifecycleImgRef    = "some-image"
+		newLifecycleImgRef = "some-other-image"
+		lifecycleImg       v1.Image
+		newLifecycleImg    v1.Image
+		callBack           *fakeCallback
+		err                error
+		p                  *LifecycleProvider
+	)
+	it.Before(func() {
+		lifecycleImg, err = random.Image(10, int64(1))
+		require.NoError(t, err)
+		newLifecycleImg, err = random.Image(10, int64(1))
+		require.NoError(t, err)
+		client.AddImage(lifecycleImgRef, lifecycleImg, keychain)
+		client.AddImage(newLifecycleImgRef, newLifecycleImg, keychain)
+		p = NewLifecycleProvider(lifecycleImgRef, client, keychain)
+		callBack = &fakeCallback{}
+
+		p.RegisterCallback(callBack.callBack)
+	})
+
+	it("is seeded with a lifecycle image", func() {
+		img, err := p.GetImage()
+		require.NoError(t, err)
+		require.Equal(t, lifecycleImg, img)
+	})
+
+	it("sets and gets the image from the ConfigMap and calls callbacks", func() {
+		cfg := &corev1.ConfigMap{
+			Data: map[string]string{"image": "some-other-image"},
+		}
+
+		p.UpdateImage(cfg)
+		img, err := p.GetImage()
+		require.NoError(t, err)
+		require.Equal(t, newLifecycleImg, img)
+		require.True(t, callBack.called)
+	})
+
+	it("errors when the image key is invalid and calls callbacks", func() {
+		cfg := &corev1.ConfigMap{
+			Data: map[string]string{"invalid": "some-other-image"},
+		}
+
+		p.UpdateImage(cfg)
+		_, err := p.GetImage()
+		require.EqualError(t, err, "lifecycle-image config invalid")
+		require.True(t, callBack.called)
+	})
+
+	it("errors when it has not loaded an image yet", func() {
+		p = &LifecycleProvider{}
+		_, err := p.GetImage()
+		require.EqualError(t, err, "lifecycle image has not been loaded")
+	})
+}
+
+type fakeCallback struct {
+	called bool
+}
+
+func (cb *fakeCallback) callBack() {
+	cb.called = true
+}

--- a/pkg/config/lifecycle_provider_test.go
+++ b/pkg/config/lifecycle_provider_test.go
@@ -88,7 +88,6 @@ func testProvider(t *testing.T, when spec.G, it spec.S) {
 		img, err := p.GetImage()
 		require.NoError(t, err)
 		require.Equal(t, newLifecycleImg, img)
-
 	})
 
 	it("errors when the image key is invalid and calls handlers", func() {

--- a/pkg/reconciler/builder/builder.go
+++ b/pkg/reconciler/builder/builder.go
@@ -38,7 +38,7 @@ func NewController(opt reconciler.Options,
 	keychainFactory registry.KeychainFactory,
 	clusterStoreInformer v1alpha1informers.ClusterStoreInformer,
 	clusterStackInformer v1alpha1informers.ClusterStackInformer,
-) *controller.Impl {
+) (*controller.Impl, func()) {
 	c := &Reconciler{
 		Client:             opt.Client,
 		BuilderLister:      builderInformer.Lister(),
@@ -54,7 +54,9 @@ func NewController(opt reconciler.Options,
 	clusterStoreInformer.Informer().AddEventHandler(reconciler.Handler(c.Tracker.OnChanged))
 	clusterStackInformer.Informer().AddEventHandler(reconciler.Handler(c.Tracker.OnChanged))
 
-	return impl
+	return impl, func() {
+		impl.GlobalResync(builderInformer.Informer())
+	}
 }
 
 type Reconciler struct {


### PR DESCRIPTION
- Builders watch configmap lifecycle-image for the image reference
- Lifecycle image platform api version is validated via annotation
- New validatingwebhookconfiguration for the configmap

https://github.com/pivotal/kpack/issues/594

Looking for feedback on:
- Lifecycle image validation lives in `pkg/apis/v1alpha1` because I thought it was part of our api
- Added a new ValidatingWebhookConfiguration resource because we could scope it to the desired ConfigMap using `objectSelector`. 
  - Added a label to the `lifecycle-image` ConfigMap to enable the `objectSelector`
- Naming:
  - lifecycle-image ConfigMap Annotation: `lifecycle.kpack.io/platformApiVersions: "0.3 0.4"`
  - lifecycle-image ConfigMap Label: `lifecycle.kpack.io/lifecycleImage: "true"`
  - new ValidatingWebhookConfiguration Name: `configmapvalidation.webhook.kpack.io`