### PR TITLE
Update lifecycle to 0.10.2 & provide support for platform apis 0.5,0.4,0.3

### DIFF
--- a/hack/lifecycle/main.go
+++ b/hack/lifecycle/main.go
@@ -42,11 +42,11 @@ func main() {
 	flag.Parse()
 
 	image, err := lifecycleImage(
-		"https://github.com/buildpacks/lifecycle/releases/download/v0.9.3/lifecycle-v0.9.3+linux.x86-64.tgz",
-		"https://github.com/buildpacks/lifecycle/releases/download/v0.9.3/lifecycle-v0.9.3+windows.x86-64.tgz",
+		"https://github.com/buildpacks/lifecycle/releases/download/v0.10.2/lifecycle-v0.10.2+linux.x86-64.tgz",
+		"https://github.com/buildpacks/lifecycle/releases/download/v0.10.2/lifecycle-v0.10.2+windows.x86-64.tgz",
 		cnb.LifecycleMetadata{
 			LifecycleInfo: cnb.LifecycleInfo{
-				Version: "0.9.3",
+				Version: "0.10.2",
 			},
 			API: cnb.LifecycleAPI{
 				BuildpackVersion: "0.2",
@@ -55,11 +55,11 @@ func main() {
 			APIs: cnb.LifecycleAPIs{
 				Buildpack: cnb.APIVersions{
 					Deprecated: []string{},
-					Supported:  []string{"0.2", "0.3", "0.4"},
+					Supported:  []string{"0.2", "0.3", "0.4", "0.5"},
 				},
 				Platform: cnb.APIVersions{
 					Deprecated: []string{},
-					Supported:  []string{"0.3", "0.4"},
+					Supported:  []string{"0.3", "0.4", "0.5"},
 				},
 			},
 		},

--- a/pkg/apis/build/v1alpha1/build_pod.go
+++ b/pkg/apis/build/v1alpha1/build_pod.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/pkg/errors"
@@ -37,7 +38,8 @@ const (
 
 	networkWaitLauncherDir = "network-wait-launcher-dir"
 
-	envVarBuildChanges = "BUILD_CHANGES"
+	buildChangesEnvVar = "BUILD_CHANGES"
+	platformAPIEnvVar  = "CNB_PLATFORM_API"
 )
 
 type BuildPodImages struct {
@@ -67,12 +69,12 @@ func (bpi *BuildPodImages) completion(os string) string {
 }
 
 type BuildPodBuilderConfig struct {
-	StackID     string
-	RunImage    string
-	Uid         int64
-	Gid         int64
-	PlatformAPI string
-	OS          string
+	StackID      string
+	RunImage     string
+	Uid          int64
+	Gid          int64
+	PlatformAPIs []string
+	OS           string
 	NodeTaints  []corev1.Taint
 }
 
@@ -135,8 +137,9 @@ var (
 type stepModifier func(corev1.Container) corev1.Container
 
 func (b *Build) BuildPod(images BuildPodImages, secrets []corev1.Secret, config BuildPodBuilderConfig) (*corev1.Pod, error) {
-	if config.unsupported() {
-		return nil, errors.Errorf("incompatible builder platform API version: %s", config.PlatformAPI)
+	platformAPI, err := config.highestSupportedPlatformAPI(b)
+	if err != nil {
+		return nil, err
 	}
 
 	if b.rebasable(config.StackID) {
@@ -182,37 +185,35 @@ func (b *Build) BuildPod(images BuildPodImages, secrets []corev1.Secret, config 
 			// If the build fails, don't restart it.
 			RestartPolicy: corev1.RestartPolicyNever,
 			Containers: steps(func(step func(corev1.Container, ...stepModifier)) {
-				notaryConfig := b.NotaryV1Config()
-
-				if notaryConfig == nil {
+				if b.NotaryV1Config() == nil {
 					step(corev1.Container{
 						Name:            "completion",
 						Image:           images.completion(config.OS),
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						Resources:       b.Spec.Resources,
 					})
-				} else {
-					step(corev1.Container{
-						Name:  "completion",
-						Image: images.completion(config.OS),
-						Args: append(
-							[]string{
-								directExecute,
-								completionBinary,
-								"-notary-v1-url=" + notaryConfig.URL,
-							},
-							secretArgs...,
-						),
-						Resources: b.Spec.Resources,
-						VolumeMounts: append(
-							secretVolumeMounts,
-							notaryV1Volume,
-							reportVolume,
-						),
-						ImagePullPolicy: corev1.PullIfNotPresent,
-					},
-						ifWindows(config.OS, addNetworkWaitLauncherVolume(), useNetworkWaitLauncher(dnsProbeHost))...)
+					return
 				}
+
+				step(corev1.Container{
+					Name:  "completion",
+					Image: images.completion(config.OS),
+					Args: append(
+						[]string{
+							directExecute,
+							completionBinary,
+							"-notary-v1-url=" + b.NotaryV1Config().URL,
+						},
+						secretArgs...,
+					),
+					Resources: b.Spec.Resources,
+					VolumeMounts: append(
+						secretVolumeMounts,
+						notaryV1Volume,
+						reportVolume,
+					),
+					ImagePullPolicy: corev1.PullIfNotPresent,
+				}, ifWindows(config.OS, addNetworkWaitLauncherVolume(), useNetworkWaitLauncher(dnsProbeHost))...)
 			}),
 			SecurityContext: podSecurityContext(config),
 			InitContainers: steps(func(step func(corev1.Container, ...stepModifier)) {
@@ -248,7 +249,7 @@ func (b *Build) BuildPod(images BuildPodImages, secrets []corev1.Secret, config 
 								Value: dnsProbeHost,
 							},
 							corev1.EnvVar{
-								Name:  envVarBuildChanges,
+								Name:  buildChangesEnvVar,
 								Value: b.BuildChanges(),
 							},
 						),
@@ -282,6 +283,12 @@ func (b *Build) BuildPod(images BuildPodImages, secrets []corev1.Secret, config 
 							workspaceVolume,
 						}, bindingVolumeMounts...),
 						ImagePullPolicy: corev1.PullIfNotPresent,
+						Env: []corev1.EnvVar{
+							{
+								Name:  platformAPIEnvVar,
+								Value: platformAPI,
+							},
+						},
 					},
 					ifWindows(config.OS, addNetworkWaitLauncherVolume(), useNetworkWaitLauncher(dnsProbeHost))...,
 				)
@@ -310,6 +317,10 @@ func (b *Build) BuildPod(images BuildPodImages, secrets []corev1.Secret, config 
 						},
 						Env: []corev1.EnvVar{
 							homeEnv,
+							{
+								Name:  platformAPIEnvVar,
+								Value: platformAPI,
+							},
 						},
 						ImagePullPolicy: corev1.PullIfNotPresent,
 					},
@@ -333,6 +344,12 @@ func (b *Build) BuildPod(images BuildPodImages, secrets []corev1.Secret, config 
 							layersVolume,
 							cacheVolume,
 						},
+						Env: []corev1.EnvVar{
+							{
+								Name:  platformAPIEnvVar,
+								Value: platformAPI,
+							},
+						},
 						ImagePullPolicy: corev1.PullIfNotPresent,
 					},
 					ifWindows(config.OS, addNetworkWaitLauncherVolume(), useNetworkWaitLauncher(dnsProbeHost))...,
@@ -354,68 +371,59 @@ func (b *Build) BuildPod(images BuildPodImages, secrets []corev1.Secret, config 
 							workspaceVolume,
 						}, bindingVolumeMounts...),
 						ImagePullPolicy: corev1.PullIfNotPresent,
+						Env: []corev1.EnvVar{
+							{
+								Name:  platformAPIEnvVar,
+								Value: platformAPI,
+							},
+						},
 					},
 					ifWindows(config.OS, addNetworkWaitLauncherVolume(), useNetworkWaitLauncher(dnsProbeHost))...,
 				)
-				if config.legacy() {
-					step(
-						corev1.Container{
-							Name:    "export",
-							Image:   builderImage,
-							Command: []string{"/cnb/lifecycle/exporter"},
-							Args: append([]string{
-								"-layers=/layers",
-								"-app=/workspace",
-								"-group=/layers/group.toml",
-								"-analyzed=/layers/analyzed.toml",
-								"-cache-dir=/cache",
-							}, b.Spec.Tags...),
-							VolumeMounts: []corev1.VolumeMount{
-								layersVolume,
-								workspaceVolume,
-								homeVolume,
-								cacheVolume,
-							},
-							Env: []corev1.EnvVar{
-								homeEnv,
-							},
-							ImagePullPolicy: corev1.PullIfNotPresent,
+				step(
+					corev1.Container{
+						Name:    "export",
+						Image:   builderImage,
+						Command: []string{"/cnb/lifecycle/exporter"},
+						Args: args([]string{
+							"-layers=/layers",
+							"-app=/workspace",
+							"-group=/layers/group.toml",
+							"-analyzed=/layers/analyzed.toml",
+							"-cache-dir=/cache",
+							"-project-metadata=/layers/project-metadata.toml"},
+							func() []string {
+								if platformAPI == "0.3" {
+									return nil
+								}
+								return []string{
+									"-report=/var/report/report.toml",
+									"-process-type=web",
+								}
+							}(),
+							b.Spec.Tags),
+						VolumeMounts: []corev1.VolumeMount{
+							layersVolume,
+							workspaceVolume,
+							homeVolume,
+							cacheVolume,
+							reportVolume,
 						},
-					)
-				} else {
-					step(
-						corev1.Container{
-							Name:    "export",
-							Image:   builderImage,
-							Command: []string{"/cnb/lifecycle/exporter"},
-							Args: append([]string{
-								"-layers=/layers",
-								"-app=/workspace",
-								"-group=/layers/group.toml",
-								"-analyzed=/layers/analyzed.toml",
-								"-cache-dir=/cache",
-								"-project-metadata=/layers/project-metadata.toml",
-								"-report=/var/report/report.toml",
-							}, b.Spec.Tags...),
-							VolumeMounts: []corev1.VolumeMount{
-								layersVolume,
-								workspaceVolume,
-								homeVolume,
-								cacheVolume,
-								reportVolume,
+						Env: []corev1.EnvVar{
+							homeEnv,
+							{
+								Name:  platformAPIEnvVar,
+								Value: platformAPI,
 							},
-							Env: []corev1.EnvVar{
-								homeEnv,
-							},
-							ImagePullPolicy: corev1.PullIfNotPresent,
 						},
-						ifWindows(config.OS,
-							addNetworkWaitLauncherVolume(),
-							useNetworkWaitLauncher(dnsProbeHost),
-							userprofileHomeEnv(),
-						)...,
-					)
-				}
+						ImagePullPolicy: corev1.PullIfNotPresent,
+					},
+					ifWindows(config.OS,
+						addNetworkWaitLauncherVolume(),
+						useNetworkWaitLauncher(dnsProbeHost),
+						userprofileHomeEnv(),
+					)...,
+				)
 			}),
 			ServiceAccountName: b.Spec.ServiceAccount,
 			NodeSelector: map[string]string{
@@ -639,7 +647,7 @@ func (b *Build) rebasePod(secrets []corev1.Secret, images BuildPodImages, buildP
 					),
 					Env: []corev1.EnvVar{
 						{
-							Name:  envVarBuildChanges,
+							Name:  buildChangesEnvVar,
 							Value: b.BuildChanges(),
 						},
 					},
@@ -770,12 +778,23 @@ func (b *Build) setupBindings() ([]corev1.Volume, []corev1.VolumeMount) {
 	return volumes, volumeMounts
 }
 
-func (bc *BuildPodBuilderConfig) legacy() bool {
-	return bc.PlatformAPI == "0.2"
-}
+func (bc *BuildPodBuilderConfig) highestSupportedPlatformAPI(b *Build) (string, error) {
 
-func (bc *BuildPodBuilderConfig) unsupported() bool {
-	return bc.PlatformAPI != "0.2" && bc.PlatformAPI != "0.3"
+	var supportedPlatformAPIVersions = []string{"0.5", "0.4", "0.3"}
+	if b.NotaryV1Config() != nil || bc.OS == "windows" {
+		//windows and report.toml are only available in platform api 0.3
+		supportedPlatformAPIVersions = []string{"0.5", "0.4"}
+	}
+
+	for _, supportedVersion := range supportedPlatformAPIVersions {
+		for _, version := range bc.PlatformAPIs {
+			if supportedVersion == version {
+				return version, nil
+			}
+		}
+	}
+
+	return "", errors.Errorf("unsupported builder platform API versions: %s", strings.Join(bc.PlatformAPIs, ","))
 }
 
 func (bc *BuildPodBuilderConfig) tolerations() []corev1.Toleration {

--- a/pkg/apis/build/v1alpha1/build_pod_test.go
+++ b/pkg/apis/build/v1alpha1/build_pod_test.go
@@ -182,7 +182,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 
 	when("BuildPod", func() {
 		it("creates a pod with a builder owner reference and build labels and annotations", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Equal(t, pod.ObjectMeta, metav1.ObjectMeta{
@@ -202,28 +202,28 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("creates a pod with a correct service account", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Equal(t, serviceAccount, pod.Spec.ServiceAccountName)
 		})
 
 		it("creates a pod with the correct node selector", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Equal(t, map[string]string{"kubernetes.io/os": "linux"}, pod.Spec.NodeSelector)
 		})
 
 		it("configures the FS Mount Group with the supplied group", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Equal(t, buildPodBuilderConfig.Gid, *pod.Spec.SecurityContext.FSGroup)
 		})
 
 		it("creates init containers with all the build steps", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			var names []string
@@ -244,7 +244,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		it("configures the workspace volume with a subPath", func() {
 			build.Spec.Source.SubPath = "some/path"
 
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			vol := volumeMountFromContainer(t, pod.Spec.InitContainers, "prepare", "workspace-dir")
@@ -259,7 +259,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("configures the bindings", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Contains(t,
@@ -317,7 +317,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("configures prepare with docker and git credentials", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Equal(t, pod.Spec.InitContainers[0].Name, "prepare")
@@ -358,7 +358,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("configures prepare with the build configuration", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Equal(t, pod.Spec.InitContainers[0].Name, "prepare")
@@ -406,7 +406,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("configures the prepare step for git source", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Equal(t, "prepare", pod.Spec.InitContainers[0].Name)
@@ -429,7 +429,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			build.Spec.Source.Blob = &v1alpha1.Blob{
 				URL: "https://some-blobstore.example.com/some-blob",
 			}
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Equal(t, "prepare", pod.Spec.InitContainers[0].Name)
@@ -447,7 +447,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			build.Spec.Source.Registry = &v1alpha1.Registry{
 				Image: "some-registry.io/some-image",
 			}
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Equal(t, "prepare", pod.Spec.InitContainers[0].Name)
@@ -475,7 +475,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 					{Name: "registry-secret"},
 				},
 			}
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Equal(t, "prepare", pod.Spec.InitContainers[0].Name)
@@ -505,7 +505,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("configures detect step", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Equal(t, pod.Spec.InitContainers[1].Name, "detect")
@@ -522,7 +522,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("configures analyze step", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Equal(t, pod.Spec.InitContainers[2].Name, "analyze")
@@ -546,7 +546,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		it("configures analyze step with the current tag if no previous build", func() {
 			build.Spec.LastBuild = nil
 
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Equal(t, pod.Spec.InitContainers[2].Name, "analyze")
@@ -569,14 +569,14 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		it("configures analyze step with the current tag if previous build is corrupted", func() {
 			build.Spec.LastBuild = &v1alpha1.LastBuild{}
 
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Contains(t, pod.Spec.InitContainers[2].Args, build.Tag())
 		})
 
 		it("configures restore step", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Equal(t, pod.Spec.InitContainers[3].Name, "restore")
@@ -595,7 +595,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("configures build step", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Equal(t, pod.Spec.InitContainers[4].Name, "build")
@@ -612,7 +612,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("configures export step", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Equal(t, pod.Spec.InitContainers[5].Name, "export")
@@ -641,7 +641,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("configures the builder image in all lifecycle steps", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			for _, container := range pod.Spec.InitContainers {
@@ -652,7 +652,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("configures the completion container with resources", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			completionContainer := pod.Spec.Containers[0]
@@ -660,7 +660,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("creates a pod with reusable cache when name is provided", func() {
-			pod, err := build.BuildPod(config, nil, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, nil, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Equal(t, corev1.Volume{
@@ -673,7 +673,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 
 		it("creates a pod with empty cache when no name is provided", func() {
 			build.Spec.CacheName = ""
-			pod, err := build.BuildPod(config, nil, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, nil, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assert.Equal(t, corev1.Volume{
@@ -685,7 +685,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("attach volumes for secrets", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			assertSecretPresent(t, pod, "git-secret-1")
@@ -697,7 +697,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("attach image pull secrets to pod", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			require.Len(t, pod.Spec.ImagePullSecrets, 1)
@@ -705,7 +705,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("mounts volumes for bindings", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			require.Len(t, pod.Spec.ImagePullSecrets, 1)
@@ -716,7 +716,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			buildPodBuilderConfig.PlatformAPIs = []string{"0.3", "0.2"}
 
 			it("exports without a report and without default process type", func() {
-				pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+				pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 				require.NoError(t, err)
 
 				assert.Contains(t, pod.Spec.InitContainers[5].Env, corev1.EnvVar{Name: "CNB_PLATFORM_API", Value: "0.3"})
@@ -738,7 +738,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			buildPodBuilderConfig.PlatformAPIs = []string{"0.2", "0.6"}
 
 			it("returns an error", func() {
-				_, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+				_, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 				require.EqualError(t, err, "unsupported builder platform API versions: 0.2,0.6")
 			})
 		})
@@ -751,7 +751,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			it("creates a pod just to rebase", func() {
-				pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+				pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 				require.NoError(t, err)
 
 				assert.Equal(t, pod.ObjectMeta, metav1.ObjectMeta{
@@ -883,7 +883,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 						},
 					}
 
-					pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+					pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 					require.NoError(t, err)
 
 					require.Equal(t,
@@ -934,12 +934,12 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			it("errs if platformApi does not support report.toml", func() {
 				buildPodBuilderConfig.PlatformAPIs = []string{"0.3", "0.2"}
 
-				_, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+				_, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 				require.EqualError(t, err, "unsupported builder platform API versions: 0.3,0.2")
 			})
 
 			it("sets up the completion image to sign the image", func() {
-				pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+				pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 				require.NoError(t, err)
 
 				require.Equal(t,
@@ -979,7 +979,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("creates the pod container correctly", func() {
-			pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
 			require.Len(t, pod.Spec.Containers, 1)
@@ -992,26 +992,26 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			it("errs if platformApi does not support windows", func() {
 				buildPodBuilderConfig.PlatformAPIs = []string{"0.3", "0.2"}
 
-				_, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+				_, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 				require.EqualError(t, err, "unsupported builder platform API versions: 0.3,0.2")
 			})
 
 			it("uses windows node selector", func() {
-				pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+				pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 				require.NoError(t, err)
 
 				assert.Equal(t, map[string]string{"kubernetes.io/os": "windows"}, pod.Spec.NodeSelector)
 			})
 
 			it("removes the spec securityContext", func() {
-				pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+				pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 				require.NoError(t, err)
 
 				assert.Nil(t, pod.Spec.SecurityContext)
 			})
 
 			it("configures prepare for windows build init", func() {
-				pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+				pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 				require.NoError(t, err)
 
 				prepareContainer := pod.Spec.InitContainers[0]
@@ -1046,7 +1046,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("configures detect step for windows", func() {
-				pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+				pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 				require.NoError(t, err)
 
 				detectContainer := pod.Spec.InitContainers[1]
@@ -1077,7 +1077,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("configures analyze step", func() {
-				pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+				pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 				require.NoError(t, err)
 
 				analyzeContainer := pod.Spec.InitContainers[2]
@@ -1116,7 +1116,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("configures restore step", func() {
-				pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+				pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 				require.NoError(t, err)
 
 				restoreContainer := pod.Spec.InitContainers[3]
@@ -1147,7 +1147,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("configures build step", func() {
-				pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+				pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 				require.NoError(t, err)
 
 				buildContainer := pod.Spec.InitContainers[4]
@@ -1179,7 +1179,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("configures export step", func() {
-				pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+				pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 				require.NoError(t, err)
 
 				exportContainer := pod.Spec.InitContainers[5]
@@ -1226,7 +1226,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 					URL: "some-notary-server",
 				}}
 
-				pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+				pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 				require.NoError(t, err)
 
 				completionContainer := pod.Spec.Containers[0]
@@ -1263,7 +1263,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("configures the completion container on windows", func() {
-				pod, err := build.BuildPod(config, secrets, buildPodBuilderConfig)
+				pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 				require.NoError(t, err)
 
 				completionContainer := pod.Spec.Containers[0]
@@ -1274,7 +1274,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("uses an emptyDir for cache on windows", func() {
-				pod, err := build.BuildPod(config, nil, buildPodBuilderConfig)
+				pod, err := build.BuildPod(config, nil, nil, buildPodBuilderConfig)
 				require.NoError(t, err)
 
 				assert.Subset(t, pod.Spec.Volumes, []corev1.Volume{
@@ -1288,23 +1288,21 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("adds pod tolerations based on node taints", func() {
-				buildPodBuilderConfig.NodeTaints = []corev1.Taint{
+				pod, err := build.BuildPod(config, nil, []corev1.Taint{
 					{
 						Key:    "test-key",
 						Value:  "test-value",
 						Effect: corev1.TaintEffectNoSchedule,
 					},
-				}
-
-				pod, err := build.BuildPod(config, nil, buildPodBuilderConfig)
+				}, buildPodBuilderConfig)
 				require.NoError(t, err)
 
 				assert.Equal(t,
 					[]corev1.Toleration{
 						{
-							Key:      buildPodBuilderConfig.NodeTaints[0].Key,
+							Key:      "test-key",
 							Operator: corev1.TolerationOpEqual,
-							Value:    buildPodBuilderConfig.NodeTaints[0].Value,
+							Value:    "test-value",
 							Effect:   corev1.TaintEffectNoSchedule,
 						},
 					},

--- a/pkg/buildpod/generator.go
+++ b/pkg/buildpod/generator.go
@@ -164,12 +164,12 @@ func (g *Generator) fetchBuilderConfig(build BuildPodable) (v1alpha1.BuildPodBui
 	}
 
 	return v1alpha1.BuildPodBuilderConfig{
-		StackID:     stackId,
-		RunImage:    metadata.Stack.RunImage.Image,
-		PlatformAPI: metadata.Lifecycle.API.PlatformVersion,
-		Uid:         uid,
-		Gid:         gid,
-		OS:          config.OS,
+		StackID:      stackId,
+		RunImage:     metadata.Stack.RunImage.Image,
+		PlatformAPIs: append(metadata.Lifecycle.APIs.Platform.Deprecated, metadata.Lifecycle.APIs.Platform.Supported...),
+		Uid:          uid,
+		Gid:          gid,
+		OS:           config.OS,
 	}, nil
 }
 

--- a/pkg/buildpod/generator.go
+++ b/pkg/buildpod/generator.go
@@ -43,7 +43,7 @@ type BuildPodable interface {
 	BuilderSpec() v1alpha1.BuildBuilderSpec
 	Bindings() []v1alpha1.Binding
 
-	BuildPod(v1alpha1.BuildPodImages, []corev1.Secret, v1alpha1.BuildPodBuilderConfig) (*corev1.Pod, error)
+	BuildPod(v1alpha1.BuildPodImages, []corev1.Secret, []corev1.Taint, v1alpha1.BuildPodBuilderConfig) (*corev1.Pod, error)
 }
 
 func (g *Generator) Generate(build BuildPodable) (*v1.Pod, error) {
@@ -61,15 +61,12 @@ func (g *Generator) Generate(build BuildPodable) (*v1.Pod, error) {
 		return nil, err
 	}
 
-	if buildPodBuilderConfig.OS == "windows" {
-		taints, err := g.calculateHomogenousWindowsNodeTaints()
-		if err != nil {
-			return nil, err
-		}
-		buildPodBuilderConfig.NodeTaints = taints
+	taints, err := g.calculateHomogenousWindowsNodeTaints(buildPodBuilderConfig.OS)
+	if err != nil {
+		return nil, err
 	}
 
-	return build.BuildPod(g.BuildPodConfig, secrets, buildPodBuilderConfig)
+	return build.BuildPod(g.BuildPodConfig, secrets, taints, buildPodBuilderConfig)
 }
 
 func (g *Generator) buildAllowed(build BuildPodable) error {
@@ -181,7 +178,11 @@ func parseCNBID(image ggcrv1.Image, env string) (int64, error) {
 	return strconv.ParseInt(v, 10, 64)
 }
 
-func (g *Generator) calculateHomogenousWindowsNodeTaints() ([]v1.Taint, error) {
+func (g *Generator) calculateHomogenousWindowsNodeTaints(os string) ([]v1.Taint, error) {
+	if os != "windows" {
+		return nil, nil
+	}
+
 	windowsNodes, err := g.K8sClient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: "kubernetes.io/os=windows"})
 	if err != nil {
 		return nil, err

--- a/pkg/buildpod/generator_test.go
+++ b/pkg/buildpod/generator_test.go
@@ -206,6 +206,23 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
     "api": {
       "buildpack": "0.7",
       "platform": "0.5"
+    },
+    "apis": {
+      "platform": {
+        "deprecated": [
+          "0.4"
+        ],
+        "supported": [
+          "0.5",
+          "0.6"
+        ]
+      },
+      "buildpack": {
+        "deprecated": [],
+        "supported": [
+          "0.9"
+        ]
+      }
     }
   }
 }`)
@@ -247,12 +264,12 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 					*dockerSecret,
 				},
 				BuildPodBuilderConfig: v1alpha1.BuildPodBuilderConfig{
-					StackID:     "some.stack.id",
-					RunImage:    "some-registry.io/run-image",
-					Uid:         1234,
-					Gid:         5678,
-					PlatformAPI: "0.5",
-					OS:          "linux",
+					StackID:      "some.stack.id",
+					RunImage:     "some-registry.io/run-image",
+					Uid:          1234,
+					Gid:          5678,
+					PlatformAPIs: []string{"0.4", "0.5", "0.6"},
+					OS:           "linux",
 				},
 			}}, build.buildPodCalls)
 		})

--- a/pkg/buildpod/generator_test.go
+++ b/pkg/buildpod/generator_test.go
@@ -31,8 +31,10 @@ func TestGenerator(t *testing.T) {
 func testGenerator(t *testing.T, when spec.G, it spec.S) {
 	when("Generate", func() {
 		const (
-			serviceAccountName = "serviceAccountName"
-			namespace          = "some-namespace"
+			serviceAccountName  = "serviceAccountName"
+			namespace           = "some-namespace"
+			windowsBuilderImage = "builder/windows"
+			linuxBuilderImage   = "builder/linux"
 		)
 
 		var (
@@ -91,10 +93,6 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 				{
 					Kind: "secret",
 					Name: "git-secret-1",
-				},
-				{
-					Kind: "secret",
-					Name: "docker-secret-1",
 				},
 				{
 					Kind: "secret",
@@ -166,36 +164,240 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 			},
 		}
 
+		keychain := &registryfakes.FakeKeychain{}
+		secretRef := registry.SecretRef{
+			ServiceAccount:   serviceAccountName,
+			Namespace:        namespace,
+			ImagePullSecrets: builderPullSecrets,
+		}
 		fakeK8sClient := fake.NewSimpleClientset(serviceAccount, dockerSecret, gitSecret, ignoredSecret, linuxNode, windowsNode1, windowsNode2)
+		buildPodConfig := v1alpha1.BuildPodImages{}
 
-		it("returns pod config with deduped secrets on build's service account", func() {
-			secretRef := registry.SecretRef{
-				ServiceAccount:   serviceAccountName,
-				Namespace:        namespace,
-				ImagePullSecrets: builderPullSecrets,
-			}
-			keychain := &registryfakes.FakeKeychain{}
+		generator := &buildpod.Generator{
+			BuildPodConfig:  buildPodConfig,
+			K8sClient:       fakeK8sClient,
+			KeychainFactory: keychainFactory,
+			ImageFetcher:    imageFetcher,
+		}
+
+		it.Before(func() {
 			keychainFactory.AddKeychainForSecretRef(t, secretRef, keychain)
 
-			image := randomImage(t)
-			var err error
+			imageFetcher.AddImage(linuxBuilderImage, createImage(t, "linux"), keychain)
+			imageFetcher.AddImage(windowsBuilderImage, createImage(t, "windows"), keychain)
+		})
 
-			config, err := image.ConfigFile()
+		it("invokes the BuildPod with the builder and env config", func() {
+			var build = &testBuildPodable{
+				serviceAccount: serviceAccountName,
+				namespace:      namespace,
+				buildBuilderSpec: v1alpha1.BuildBuilderSpec{
+					Image:            linuxBuilderImage,
+					ImagePullSecrets: builderPullSecrets,
+				},
+			}
+
+			pod, err := generator.Generate(build)
 			require.NoError(t, err)
+			assert.NotNil(t, pod)
 
-			config.OS = "linux"
-			image, err = mutate.ConfigFile(image, config)
+			assert.Equal(t, []buildPodCall{{
+				BuildPodImages: buildPodConfig,
+				Secrets: []corev1.Secret{
+					*gitSecret,
+					*dockerSecret,
+				},
+				BuildPodBuilderConfig: v1alpha1.BuildPodBuilderConfig{
+					StackID:      "some.stack.id",
+					RunImage:     "some-registry.io/run-image",
+					Uid:          1234,
+					Gid:          5678,
+					PlatformAPIs: []string{"0.4", "0.5", "0.6"},
+					OS:           "linux",
+				},
+				Taints: nil,
+			}}, build.buildPodCalls)
+		})
+
+		it("dedups duplicate secrets on the service account", func() {
+			var build = &testBuildPodable{
+				serviceAccount: serviceAccountName,
+				namespace:      namespace,
+				buildBuilderSpec: v1alpha1.BuildBuilderSpec{
+					Image:            linuxBuilderImage,
+					ImagePullSecrets: builderPullSecrets,
+				},
+			}
+
+			serviceAccount.Secrets = append(serviceAccount.Secrets, corev1.ObjectReference{Name: "docker-secret-1"})
+			serviceAccount.Secrets = append(serviceAccount.Secrets, corev1.ObjectReference{Name: "docker-secret-1"})
+			fakeK8sClient.CoreV1().ServiceAccounts(namespace).Update(serviceAccount)
+
+			pod, err := generator.Generate(build)
 			require.NoError(t, err)
+			assert.NotNil(t, pod)
 
-			image, err = imagehelpers.SetStringLabel(image, lifecycle.StackIDLabel, "some.stack.id")
-			require.NoError(t, err)
+			assert.Len(t, build.buildPodCalls, 1)
+			assert.Len(t, build.buildPodCalls[0].Secrets, 2)
+		})
 
-			image, err = imagehelpers.SetStringLabel(image, cnb.BuilderMetadataLabel, //language=json
-				`{ "stack": { "runImage": { "image": "some-registry.io/run-image"} } }`)
-			require.NoError(t, err)
+		it("rejects a build with a binding secret that is attached to a service account", func() {
+			var build = &testBuildPodable{
+				namespace: namespace,
+				bindings: []v1alpha1.Binding{
+					{
+						Name:        "naughty",
+						MetadataRef: &corev1.LocalObjectReference{Name: "binding-configmap"},
+						SecretRef:   &corev1.LocalObjectReference{Name: dockerSecret.Name},
+					},
+				},
+			}
 
-			image, err = imagehelpers.SetStringLabel(image, cnb.BuilderMetadataLabel, //language=json
-				`{
+			pod, err := generator.Generate(build)
+			require.EqualError(t, err, fmt.Sprintf("build rejected: binding %q uses forbidden secret %q", "naughty", dockerSecret.Name))
+			require.Nil(t, pod)
+		})
+
+		when("windows builder image", func() {
+			it("provides all homogenous windows node taints", func() {
+				var build = &testBuildPodable{
+					serviceAccount: serviceAccountName,
+					namespace:      namespace,
+					buildBuilderSpec: v1alpha1.BuildBuilderSpec{
+						Image:            windowsBuilderImage,
+						ImagePullSecrets: builderPullSecrets,
+					},
+				}
+
+				pod, err := generator.Generate(build)
+				require.NoError(t, err)
+				assert.NotNil(t, pod)
+
+				assert.Len(t, build.buildPodCalls, 1)
+				assert.Equal(t, build.buildPodCalls[0].Taints, []corev1.Taint{
+					{
+						Key:    "test-key",
+						Value:  "test-value",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+				})
+			})
+
+			it("provides an empty list any taints if any taints different across windows nodes", func() {
+				windowsNode3 := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "windows-node-3",
+						Labels: map[string]string{
+							"kubernetes.io/os": "windows",
+						},
+					},
+					Spec: corev1.NodeSpec{
+						Taints: []corev1.Taint{
+							{
+								Key:       "different-key",
+								Value:     "different-value",
+								Effect:    corev1.TaintEffectNoSchedule,
+								TimeAdded: nil,
+							},
+						},
+					},
+				}
+
+				_, err := fakeK8sClient.CoreV1().Nodes().Create(windowsNode3)
+				require.NoError(t, err)
+
+				var build = &testBuildPodable{
+					serviceAccount: serviceAccountName,
+					namespace:      namespace,
+					buildBuilderSpec: v1alpha1.BuildBuilderSpec{
+						Image:            windowsBuilderImage,
+						ImagePullSecrets: builderPullSecrets,
+					},
+				}
+
+				pod, err := generator.Generate(build)
+				require.NoError(t, err)
+				assert.NotNil(t, pod)
+
+				assert.Len(t, build.buildPodCalls, 1)
+				assert.Len(t, build.buildPodCalls[0].Taints, 0)
+			})
+		})
+
+	})
+}
+
+func randomImage(t *testing.T) ggcrv1.Image {
+	image, err := random.Image(5, 10)
+	require.NoError(t, err)
+	return image
+}
+
+type testBuildPodable struct {
+	buildBuilderSpec v1alpha1.BuildBuilderSpec
+	serviceAccount   string
+	namespace        string
+	buildPodCalls    []buildPodCall
+	bindings         []v1alpha1.Binding
+}
+
+type buildPodCall struct {
+	BuildPodImages        v1alpha1.BuildPodImages
+	Secrets               []corev1.Secret
+	Taints                []corev1.Taint
+	BuildPodBuilderConfig v1alpha1.BuildPodBuilderConfig
+}
+
+func (tb *testBuildPodable) GetName() string {
+	panic("should not be used in this test")
+}
+
+func (tb *testBuildPodable) GetNamespace() string {
+	return tb.namespace
+}
+
+func (tb *testBuildPodable) ServiceAccount() string {
+	return tb.serviceAccount
+}
+
+func (tb *testBuildPodable) BuilderSpec() v1alpha1.BuildBuilderSpec {
+	return tb.buildBuilderSpec
+}
+
+func (tb *testBuildPodable) BuildPod(images v1alpha1.BuildPodImages, secrets []corev1.Secret, taints []corev1.Taint, config v1alpha1.BuildPodBuilderConfig) (*corev1.Pod, error) {
+	tb.buildPodCalls = append(tb.buildPodCalls, buildPodCall{
+		BuildPodImages:        images,
+		Secrets:               secrets,
+		Taints:                taints,
+		BuildPodBuilderConfig: config,
+	})
+	return &corev1.Pod{}, nil
+}
+
+func (tb *testBuildPodable) Bindings() []v1alpha1.Binding {
+	return tb.bindings
+}
+
+func createImage(t *testing.T, os string) ggcrv1.Image {
+	image := randomImage(t)
+	var err error
+
+	config, err := image.ConfigFile()
+	require.NoError(t, err)
+
+	config.OS = os
+	image, err = mutate.ConfigFile(image, config)
+	require.NoError(t, err)
+
+	image, err = imagehelpers.SetStringLabel(image, lifecycle.StackIDLabel, "some.stack.id")
+	require.NoError(t, err)
+
+	image, err = imagehelpers.SetStringLabel(image, cnb.BuilderMetadataLabel, //language=json
+		`{ "stack": { "runImage": { "image": "some-registry.io/run-image"} } }`)
+	require.NoError(t, err)
+
+	image, err = imagehelpers.SetStringLabel(image, cnb.BuilderMetadataLabel, //language=json
+		`{
   "stack": {
     "runImage": {
       "image": "some-registry.io/run-image"
@@ -226,275 +428,12 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
     }
   }
 }`)
-			require.NoError(t, err)
+	require.NoError(t, err)
 
-			image, err = imagehelpers.SetEnv(image, "CNB_USER_ID", "1234")
-			require.NoError(t, err)
+	image, err = imagehelpers.SetEnv(image, "CNB_USER_ID", "1234")
+	require.NoError(t, err)
 
-			image, err = imagehelpers.SetEnv(image, "CNB_GROUP_ID", "5678")
-			require.NoError(t, err)
-
-			imageFetcher.AddImage("some/builde@sha256:1b2911dd8eabb4bdb0bda6705158daa4149adb5ca59dc990146772c4c6deecb4", image, keychain)
-
-			buildPodConfig := v1alpha1.BuildPodImages{}
-			generator := &buildpod.Generator{
-				BuildPodConfig:  buildPodConfig,
-				K8sClient:       fakeK8sClient,
-				KeychainFactory: keychainFactory,
-				ImageFetcher:    imageFetcher,
-			}
-
-			var build = &testBuildPodable{
-				serviceAccount: serviceAccountName,
-				namespace:      namespace,
-				buildBuilderSpec: v1alpha1.BuildBuilderSpec{
-					Image:            "some/builde@sha256:1b2911dd8eabb4bdb0bda6705158daa4149adb5ca59dc990146772c4c6deecb4",
-					ImagePullSecrets: builderPullSecrets,
-				},
-			}
-
-			pod, err := generator.Generate(build)
-			require.NoError(t, err)
-			assert.NotNil(t, pod)
-
-			assert.Equal(t, []buildPodCall{{
-				BuildPodImages: buildPodConfig,
-				Secrets: []corev1.Secret{
-					*gitSecret,
-					*dockerSecret,
-				},
-				BuildPodBuilderConfig: v1alpha1.BuildPodBuilderConfig{
-					StackID:      "some.stack.id",
-					RunImage:     "some-registry.io/run-image",
-					Uid:          1234,
-					Gid:          5678,
-					PlatformAPIs: []string{"0.4", "0.5", "0.6"},
-					OS:           "linux",
-				},
-			}}, build.buildPodCalls)
-		})
-
-		it("rejects a build with a binding secret that is attached to a service account", func() {
-			buildPodConfig := v1alpha1.BuildPodImages{}
-			generator := &buildpod.Generator{
-				BuildPodConfig:  buildPodConfig,
-				K8sClient:       fakeK8sClient,
-				KeychainFactory: keychainFactory,
-				ImageFetcher:    imageFetcher,
-			}
-
-			var build = &testBuildPodable{
-				namespace: namespace,
-				bindings: []v1alpha1.Binding{
-					{
-						Name:        "naughty",
-						MetadataRef: &corev1.LocalObjectReference{Name: "binding-configmap"},
-						SecretRef:   &corev1.LocalObjectReference{Name: dockerSecret.Name},
-					},
-				},
-			}
-
-			pod, err := generator.Generate(build)
-			require.EqualError(t, err, fmt.Sprintf("build rejected: binding %q uses forbidden secret %q", "naughty", dockerSecret.Name))
-			require.Nil(t, pod)
-		})
-
-		when("calculating homogenous node taints for windows nodes", func() {
-			var(
-				build *testBuildPodable
-				generator *buildpod.Generator
-				buildPodConfig v1alpha1.BuildPodImages
-			)
-			it.Before(func() {
-				secretRef := registry.SecretRef{
-					ServiceAccount:   serviceAccountName,
-					Namespace:        namespace,
-					ImagePullSecrets: builderPullSecrets,
-				}
-				keychain := &registryfakes.FakeKeychain{}
-				keychainFactory.AddKeychainForSecretRef(t, secretRef, keychain)
-
-				image := randomImage(t)
-				var err error
-
-				config, err := image.ConfigFile()
-				require.NoError(t, err)
-
-				config.OS = "windows"
-				image, err = mutate.ConfigFile(image, config)
-				require.NoError(t, err)
-
-				image, err = imagehelpers.SetStringLabel(image, lifecycle.StackIDLabel, "some.stack.id")
-				require.NoError(t, err)
-
-				image, err = imagehelpers.SetStringLabel(image, cnb.BuilderMetadataLabel, //language=json
-					`{ "stack": { "runImage": { "image": "some-registry.io/run-image"} } }`)
-				require.NoError(t, err)
-
-				image, err = imagehelpers.SetStringLabel(image, cnb.BuilderMetadataLabel, //language=json
-					`{
-			 "stack": {
-			   "runImage": {
-			     "image": "some-registry.io/run-image"
-			   }
-			 },
-			 "lifecycle": {
-			   "version": "0.9.0",
-			   "api": {
-			     "buildpack": "0.7",
-			     "platform": "0.5"
-			   }
-			 }
-			}`)
-				require.NoError(t, err)
-
-				image, err = imagehelpers.SetEnv(image, "CNB_USER_ID", "1234")
-				require.NoError(t, err)
-
-				image, err = imagehelpers.SetEnv(image, "CNB_GROUP_ID", "5678")
-				require.NoError(t, err)
-
-				imageFetcher.AddImage("some/builde@sha256:1b2911dd8eabb4bdb0bda6705158daa4149adb5ca59dc990146772c4c6deecb4", image, keychain)
-
-				buildPodConfig = v1alpha1.BuildPodImages{}
-				generator = &buildpod.Generator{
-					BuildPodConfig:  buildPodConfig,
-					K8sClient:       fakeK8sClient,
-					KeychainFactory: keychainFactory,
-					ImageFetcher:    imageFetcher,
-				}
-
-				build = &testBuildPodable{
-					serviceAccount: serviceAccountName,
-					namespace:      namespace,
-					buildBuilderSpec: v1alpha1.BuildBuilderSpec{
-						Image:            "some/builde@sha256:1b2911dd8eabb4bdb0bda6705158daa4149adb5ca59dc990146772c4c6deecb4",
-						ImagePullSecrets: builderPullSecrets,
-					},
-				}
-			})
-			it("returns a list of taints present on all windows nodes", func() {
-				pod, err := generator.Generate(build)
-				require.NoError(t, err)
-				assert.NotNil(t, pod)
-
-				assert.Equal(t, []buildPodCall{{
-					BuildPodImages: buildPodConfig,
-					Secrets: []corev1.Secret{
-						*gitSecret,
-						*dockerSecret,
-					},
-					BuildPodBuilderConfig: v1alpha1.BuildPodBuilderConfig{
-						StackID:     "some.stack.id",
-						RunImage:    "some-registry.io/run-image",
-						Uid:         1234,
-						Gid:         5678,
-						PlatformAPI: "0.5",
-						OS:          "windows",
-						NodeTaints: []v1.Taint{
-							{
-								Key:    "test-key",
-								Value:  "test-value",
-								Effect: corev1.TaintEffectNoSchedule,
-							},
-						},
-					},
-				}}, build.buildPodCalls)
-			})
-			it("returns an empty list any taints are different across windows nodes", func() {
-				windowsNode3 := &corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "windows-node-3",
-						Labels: map[string]string{
-							"kubernetes.io/os": "windows",
-						},
-					},
-					Spec: corev1.NodeSpec{
-						Taints: []corev1.Taint{
-							{
-								Key:       "different-key",
-								Value:     "different-value",
-								Effect:    corev1.TaintEffectNoSchedule,
-								TimeAdded: nil,
-							},
-						},
-					},
-				}
-
-				_, err := fakeK8sClient.CoreV1().Nodes().Create(windowsNode3)
-				require.NoError(t, err)
-
-				pod, err := generator.Generate(build)
-				require.NoError(t, err)
-				assert.NotNil(t, pod)
-
-				assert.Equal(t, []buildPodCall{{
-					BuildPodImages: buildPodConfig,
-					Secrets: []corev1.Secret{
-						*gitSecret,
-						*dockerSecret,
-					},
-					BuildPodBuilderConfig: v1alpha1.BuildPodBuilderConfig{
-						StackID:     "some.stack.id",
-						RunImage:    "some-registry.io/run-image",
-						Uid:         1234,
-						Gid:         5678,
-						PlatformAPI: "0.5",
-						OS:          "windows",
-						NodeTaints: []v1.Taint{},
-					},
-				}}, build.buildPodCalls)
-			})
-		})
-
-	})
-}
-
-func randomImage(t *testing.T) ggcrv1.Image {
-	image, err := random.Image(5, 10)
+	image, err = imagehelpers.SetEnv(image, "CNB_GROUP_ID", "5678")
 	require.NoError(t, err)
 	return image
-}
-
-type testBuildPodable struct {
-	buildBuilderSpec v1alpha1.BuildBuilderSpec
-	serviceAccount   string
-	namespace        string
-	buildPodCalls    []buildPodCall
-	bindings         []v1alpha1.Binding
-}
-
-type buildPodCall struct {
-	BuildPodImages        v1alpha1.BuildPodImages
-	Secrets               []corev1.Secret
-	BuildPodBuilderConfig v1alpha1.BuildPodBuilderConfig
-}
-
-func (tb *testBuildPodable) GetName() string {
-	panic("should not be used in this test")
-}
-
-func (tb *testBuildPodable) GetNamespace() string {
-	return tb.namespace
-}
-
-func (tb *testBuildPodable) ServiceAccount() string {
-	return tb.serviceAccount
-}
-
-func (tb *testBuildPodable) BuilderSpec() v1alpha1.BuildBuilderSpec {
-	return tb.buildBuilderSpec
-}
-
-func (tb *testBuildPodable) BuildPod(images v1alpha1.BuildPodImages, secrets []corev1.Secret, config v1alpha1.BuildPodBuilderConfig) (*corev1.Pod, error) {
-	tb.buildPodCalls = append(tb.buildPodCalls, buildPodCall{
-		BuildPodImages:        images,
-		Secrets:               secrets,
-		BuildPodBuilderConfig: config,
-	})
-	return &corev1.Pod{}, nil
-}
-
-func (tb *testBuildPodable) Bindings() []v1alpha1.Binding {
-	return tb.bindings
 }


### PR DESCRIPTION
- Drop support for platform api 0.2
- If using 0.4+ default the process type to web (identical to pack behavior)
- Prevent notary/windows on platform api 0.3

Closes: https://github.com/pivotal/kpack/issues/607