### PR TITLE
Migrate crd apiversion to apiextensions.k8s.io/v1

### DIFF
--- a/config/build.yaml
+++ b/config/build.yaml
@@ -1,10 +1,26 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: builds.kpack.io
 spec:
   group: kpack.io
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: { }
+    additionalPrinterColumns:
+    - name: Image
+      type: string
+      jsonPath: ".status.latestImage"
+    - name: Succeeded
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
   names:
     kind: Build
     singular: build
@@ -17,12 +33,3 @@ spec:
     categories:
     - kpack
   scope: Namespaced
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - name: Image
-    type: string
-    JSONPath: ".status.latestImage"
-  - name: Succeeded
-    type: string
-    JSONPath: #@ ".status.conditions[?(@.type==\"Succeeded\")].status"

--- a/config/builder.yaml
+++ b/config/builder.yaml
@@ -1,10 +1,26 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: builders.kpack.io
 spec:
   group: kpack.io
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: LatestImage
+      type: string
+      jsonPath: ".status.latestImage"
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
   names:
     kind: Builder
     singular: builder
@@ -15,12 +31,3 @@ spec:
     categories:
     - kpack
   scope: Namespaced
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - name: LatestImage
-    type: string
-    JSONPath: ".status.latestImage"
-  - name: Ready
-    type: string
-    JSONPath: #@ ".status.conditions[?(@.type==\"Ready\")].status"

--- a/config/clusterbuilder.yaml
+++ b/config/clusterbuilder.yaml
@@ -1,10 +1,26 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterbuilders.kpack.io
 spec:
   group: kpack.io
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: LatestImage
+      type: string
+      jsonPath: ".status.latestImage"
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
   names:
     kind: ClusterBuilder
     singular: clusterbuilder
@@ -15,12 +31,3 @@ spec:
     categories:
     - kpack
   scope: Cluster
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - name: LatestImage
-    type: string
-    JSONPath: ".status.latestImage"
-  - name: Ready
-    type: string
-    JSONPath: #@ ".status.conditions[?(@.type==\"Ready\")].status"

--- a/config/clusterstore.yaml
+++ b/config/clusterstore.yaml
@@ -1,10 +1,23 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterstores.kpack.io
 spec:
   group: kpack.io
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    subresources:
+      status: {}
   names:
     kind: ClusterStore
     singular: clusterstore
@@ -12,9 +25,3 @@ spec:
     categories:
     - kpack
   scope: Cluster
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - name: Ready
-    type: string
-    JSONPath: #@ ".status.conditions[?(@.type==\"Ready\")].status"

--- a/config/image.yaml
+++ b/config/image.yaml
@@ -1,10 +1,26 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: images.kpack.io
 spec:
   group: kpack.io
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: LatestImage
+      type: string
+      jsonPath: ".status.latestImage"
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
   names:
     kind: Image
     singular: image
@@ -17,12 +33,3 @@ spec:
     categories:
     - kpack
   scope: Namespaced
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - name: LatestImage
-    type: string
-    JSONPath: ".status.latestImage"
-  - name: Ready
-    type: string
-    JSONPath: #@ ".status.conditions[?(@.type==\"Ready\")].status"

--- a/config/sourceresolver.yaml
+++ b/config/sourceresolver.yaml
@@ -1,10 +1,23 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: sourceresolvers.kpack.io
 spec:
   group: kpack.io
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
   names:
     kind: SourceResolver
     singular: sourceresolver
@@ -12,9 +25,3 @@ spec:
     categories:
     - kpack
   scope: Namespaced
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - name: Ready
-    type: string
-    JSONPath: #@ ".status.conditions[?(@.type==\"Ready\")].status"

--- a/config/stack.yaml
+++ b/config/stack.yaml
@@ -1,10 +1,23 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterstacks.kpack.io
 spec:
   group: kpack.io
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
   names:
     kind: ClusterStack
     singular: clusterstack
@@ -12,9 +25,3 @@ spec:
     categories:
     - kpack
   scope: Cluster
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - name: Ready
-    type: string
-    JSONPath: #@ ".status.conditions[?(@.type==\"Ready\")].status"


### PR DESCRIPTION
fix https://github.com/pivotal/kpack/issues/565

this was surprisingly not bad!

note: schemas not defined. I think we can do that down the line as this solves the deprecation issue.