### PR TITLE
Configure the pod security context to match the builder config

### DIFF
--- a/pkg/apis/build/v1alpha1/build_pod.go
+++ b/pkg/apis/build/v1alpha1/build_pod.go
@@ -250,7 +250,7 @@ func (b *Build) BuildPod(images BuildPodImages, secrets []corev1.Secret, taints 
 							projectMetadataVolume,
 						),
 					},
-					ifWindows(config.OS, addNetworkWaitLauncherVolume(), removeSecurityContext())...,
+					ifWindows(config.OS, addNetworkWaitLauncherVolume())...,
 				)
 				step(
 					corev1.Container{
@@ -511,13 +511,6 @@ func userprofileHomeEnv() stepModifier {
 			}
 		}
 
-		return container
-	}
-}
-
-func removeSecurityContext() stepModifier {
-	return func(container corev1.Container) corev1.Container {
-		container.SecurityContext = nil
 		return container
 	}
 }

--- a/pkg/apis/build/v1alpha1/build_pod.go
+++ b/pkg/apis/build/v1alpha1/build_pod.go
@@ -214,11 +214,7 @@ func (b *Build) BuildPod(images BuildPodImages, secrets []corev1.Secret, taints 
 					corev1.Container{
 						Name:  "prepare",
 						Image: images.buildInit(config.OS),
-						SecurityContext: &corev1.SecurityContext{
-							RunAsUser:  &config.Uid,
-							RunAsGroup: &config.Gid,
-						},
-						Args: secretArgs,
+						Args:  secretArgs,
 						Env: append(
 							b.Spec.Source.Source().BuildEnvVars(),
 							corev1.EnvVar{
@@ -476,7 +472,9 @@ func podSecurityContext(config BuildPodBuilderConfig) *corev1.PodSecurityContext
 	}
 
 	return &corev1.PodSecurityContext{
-		FSGroup: &config.Gid,
+		FSGroup:    &config.Gid,
+		RunAsUser:  &config.Uid,
+		RunAsGroup: &config.Gid,
 	}
 }
 
@@ -550,7 +548,7 @@ func (b *Build) notarySecretVolume() corev1.Volume {
 	}
 }
 
-func (b *Build) rebasePod(secrets []corev1.Secret, images BuildPodImages, buildPodBuilderConfig BuildPodBuilderConfig) (*corev1.Pod, error) {
+func (b *Build) rebasePod(secrets []corev1.Secret, images BuildPodImages, config BuildPodBuilderConfig) (*corev1.Pod, error) {
 	secretVolumes, secretVolumeMounts, secretArgs := b.setupSecretVolumesAndArgs(secrets, dockerSecrets)
 
 	return &corev1.Pod{
@@ -617,7 +615,7 @@ func (b *Build) rebasePod(secrets []corev1.Secret, images BuildPodImages, buildP
 					Image: images.RebaseImage,
 					Args: args(a(
 						"--run-image",
-						buildPodBuilderConfig.RunImage,
+						config.RunImage,
 						"--last-built-image",
 						b.Spec.LastBuild.Image,
 						"--report",

--- a/pkg/apis/build/v1alpha1/build_pod_test.go
+++ b/pkg/apis/build/v1alpha1/build_pod_test.go
@@ -214,10 +214,12 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal(t, map[string]string{"kubernetes.io/os": "linux"}, pod.Spec.NodeSelector)
 		})
 
-		it("configures the FS Mount Group with the supplied group", func() {
+		it("configures the pod security context to match the builder config user and group", func() {
 			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
 
+			assert.Equal(t, buildPodBuilderConfig.Uid, *pod.Spec.SecurityContext.RunAsUser)
+			assert.Equal(t, buildPodBuilderConfig.Gid, *pod.Spec.SecurityContext.RunAsGroup)
 			assert.Equal(t, buildPodBuilderConfig.Gid, *pod.Spec.SecurityContext.FSGroup)
 		})
 
@@ -360,8 +362,6 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 
 			assert.Equal(t, pod.Spec.InitContainers[0].Name, "prepare")
 			assert.Equal(t, pod.Spec.InitContainers[0].Image, config.BuildInitImage)
-			assert.Equal(t, buildPodBuilderConfig.Uid, *pod.Spec.InitContainers[0].SecurityContext.RunAsUser)
-			assert.Equal(t, buildPodBuilderConfig.Gid, *pod.Spec.InitContainers[0].SecurityContext.RunAsGroup)
 			assert.Contains(t, pod.Spec.InitContainers[0].Env,
 				corev1.EnvVar{
 					Name:  "PLATFORM_ENV_VARS",


### PR DESCRIPTION
- This explicitly sets the user:group to run as for each container as well as the volume groups
- This is useful for when MustRunAs is set in a pod security policy