### PR TITLE
Match registries with trailing slash

### DIFF
--- a/pkg/dockercreds/match.go
+++ b/pkg/dockercreds/match.go
@@ -10,9 +10,18 @@ import (
 var registryDomains = []string{
 	// Allow naked domains
 	"%s",
+
+	// Allow naked domains with trailing slash
+	"%s/",
+
 	// Allow scheme-prefixed.
 	"https://%s",
 	"http://%s",
+
+	// Allow scheme-prefixed with trailing slash
+	"https://%s/",
+	"http://%s/",
+
 	// Allow scheme-prefixes with version in url path.
 	"https://%s/v1/",
 	"http://%s/v1/",

--- a/pkg/dockercreds/match_test.go
+++ b/pkg/dockercreds/match_test.go
@@ -13,18 +13,28 @@ func TestMatch(t *testing.T) {
 
 func testRegistryMatch(t *testing.T, when spec.G, it spec.S) {
 	when("#Match", func() {
-		for _, regFormat := range []string{
+		for _, f := range []string{
 			// Allow naked domains
 			"reg.io",
+
+			// Allow naked domains with trailing slash
+			"reg.io/",
+
 			// Allow scheme-prefixed.
 			"https://reg.io",
 			"http://reg.io",
+
+			// Allow scheme-prefixed with trailing slash as this is commonly provided by users.
+			"https://reg.io/",
+			"http://reg.io/",
+
 			// Allow scheme-prefixes with version in url path.
 			"https://reg.io/v1/",
 			"http://reg.io/v1/",
 			"https://reg.io/v2/",
 			"http://reg.io/v2/",
 		} {
+			regFormat := f
 			it("matches format "+regFormat, func() {
 				matcher := RegistryMatcher{Registry: regFormat}
 				assert.True(t, matcher.Match("reg.io"))


### PR DESCRIPTION
- Trailing slashes are commonly provided by users such as `https://myreg.io/` & `myreg.io/`
-  Would fix the issue seen on this issue https://github.com/pivotal/kpack/issues/643
- Is there a risk we are being to permissive with this and matching on things docker itself would not match on?

