### PR TITLE
Don't write build cache to emptydir

### DIFF
--- a/pkg/apis/build/v1alpha1/build_pod.go
+++ b/pkg/apis/build/v1alpha1/build_pod.go
@@ -165,7 +165,7 @@ func (b *Build) BuildPod(images BuildPodImages, secrets []corev1.Secret, taints 
 
 	var cacheArgs []string
 	var cacheVolumes []corev1.VolumeMount
-	if b.Spec.CacheName == "" {
+	if b.Spec.CacheName == "" || config.OS == "windows" {
 		cacheArgs = nil
 		cacheVolumes = nil
 	} else {
@@ -636,24 +636,16 @@ func (b *Build) rebasePod(secrets []corev1.Secret, images BuildPodImages, config
 }
 
 func (b *Build) cacheVolume(os string) []corev1.Volume {
-	if b.Spec.CacheName == "" {
+	if b.Spec.CacheName == "" || os == "windows" {
 		return []corev1.Volume{}
 	}
 
-	volume := corev1.Volume{
+	return []corev1.Volume{{
 		Name: cacheDirName,
-	}
-
-	if os != "windows" {
-		volume.VolumeSource = corev1.VolumeSource{
+		VolumeSource: corev1.VolumeSource{
 			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: b.Spec.CacheName},
-		}
-	} else {
-		volume.VolumeSource = corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		}
-	}
-	return []corev1.Volume{volume}
+		},
+	}}
 }
 
 func gitAndDockerSecrets(secret corev1.Secret) bool {

--- a/pkg/apis/build/v1alpha1/build_pod_test.go
+++ b/pkg/apis/build/v1alpha1/build_pod_test.go
@@ -615,7 +615,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal(t, pod.Spec.InitContainers[5].Name, "export")
 			assert.Equal(t, pod.Spec.InitContainers[5].Image, builderImage)
 			assert.Contains(t, pod.Spec.InitContainers[5].Env, corev1.EnvVar{Name: "CNB_PLATFORM_API", Value: "0.5"})
-			assert.Equal(t, names(pod.Spec.InitContainers[5].VolumeMounts), []string{
+			assert.ElementsMatch(t, names(pod.Spec.InitContainers[5].VolumeMounts), []string{
 				"layers-dir",
 				"workspace-dir",
 				"home-dir",
@@ -627,8 +627,8 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 				"-app=/workspace",
 				"-group=/layers/group.toml",
 				"-analyzed=/layers/analyzed.toml",
-				"-cache-dir=/cache",
 				"-project-metadata=/layers/project-metadata.toml",
+				"-cache-dir=/cache",
 				"-report=/var/report/report.toml",
 				"-process-type=web",
 				build.Tag(),
@@ -668,17 +668,43 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			}, pod.Spec.Volumes[0])
 		})
 
-		it("creates a pod with empty cache when no name is provided", func() {
+		when("CacheName is empty", func() {
+			podWithCache, _ := build.BuildPod(config, nil, nil, buildPodBuilderConfig)
 			build.Spec.CacheName = ""
-			pod, err := build.BuildPod(config, nil, nil, buildPodBuilderConfig)
-			require.NoError(t, err)
 
-			assert.Equal(t, corev1.Volume{
-				Name: "cache-dir",
-				VolumeSource: corev1.VolumeSource{
-					EmptyDir: &corev1.EmptyDirVolumeSource{},
-				},
-			}, pod.Spec.Volumes[0])
+			it("creates a pod without cache volume", func() {
+				pod, err := build.BuildPod(config, nil, nil, buildPodBuilderConfig)
+				require.NoError(t, err)
+
+				assert.Len(t, pod.Spec.Volumes, len(podWithCache.Spec.Volumes)-1)
+			})
+
+			it("does not add the cache to analyze container", func() {
+				pod, err := build.BuildPod(config, nil, nil, buildPodBuilderConfig)
+				require.NoError(t, err)
+
+				analyzeContainer := pod.Spec.InitContainers[2]
+				assert.NotContains(t, analyzeContainer.Args, "-cache-dir=/cache")
+				assert.Len(t, analyzeContainer.VolumeMounts, len(podWithCache.Spec.InitContainers[2].VolumeMounts)-1)
+			})
+
+			it("does not add the cache to restore container", func() {
+				pod, err := build.BuildPod(config, nil, nil, buildPodBuilderConfig)
+				require.NoError(t, err)
+
+				restoreContainer := pod.Spec.InitContainers[3]
+				assert.NotContains(t, restoreContainer.Args, "-cache-dir=/cache")
+				assert.Len(t, restoreContainer.VolumeMounts, len(podWithCache.Spec.InitContainers[3].VolumeMounts)-1)
+			})
+
+			it("does not add the cache to exporter container", func() {
+				pod, err := build.BuildPod(config, nil, nil, buildPodBuilderConfig)
+				require.NoError(t, err)
+
+				exportContainer := pod.Spec.InitContainers[5]
+				assert.NotContains(t, exportContainer.Args, "-cache-dir=/cache")
+				assert.Len(t, exportContainer.VolumeMounts, len(podWithCache.Spec.InitContainers[5].VolumeMounts)-1)
+			})
 		})
 
 		it("attach volumes for secrets", func() {
@@ -722,8 +748,8 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 					"-app=/workspace",
 					"-group=/layers/group.toml",
 					"-analyzed=/layers/analyzed.toml",
-					"-cache-dir=/cache",
 					"-project-metadata=/layers/project-metadata.toml",
+					"-cache-dir=/cache",
 					build.Tag(),
 					"someimage/name:tag2",
 					"someimage/name:tag3",
@@ -1203,8 +1229,8 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 					"-app=/workspace",
 					"-group=/layers/group.toml",
 					"-analyzed=/layers/analyzed.toml",
-					"-cache-dir=/cache",
 					"-project-metadata=/layers/project-metadata.toml",
+					"-cache-dir=/cache",
 					"-report=/var/report/report.toml",
 					"-process-type=web",
 					"someimage/name", "someimage/name:tag2", "someimage/name:tag3"},


### PR DESCRIPTION
Previously, when no cache-volume was specified the caching-data got written to an EmptyDir.
EmptyDirs are thrown away once the Pod is finished.
For some buildpacks/apps (e.g. gradle when building spring-music) generating the cache takes a considerable amount of time. If we know that we will throw it away anyway we can skip that.

Therefore we:
- Don't pass the `--cache-dir` arg to the lifecycle steps
- Don't add the cache-dir to the `VolumeMounts`
- Don't create an EmptyDir for the cache

Tagging my pairs: @bodymindarts @Haegi