### PR TITLE
 Support private registry for ClusterStack & ClusterStore

### DIFF
--- a/docs/builders.md
+++ b/docs/builders.md
@@ -1,11 +1,11 @@
 # Builders
 
-kpack provides Builder and ClusterBuilder resources to define and create [Cloud Native Buildpacks builders](https://buildpacks.io/docs/using-pack/working-with-builders/) all within the kpack api. 
-This allows granular control of how stacks, buildpacks, and buildpack versions are utilized and updated.  
+kpack provides Builder and ClusterBuilder resources to define and create [Cloud Native Buildpacks builders](https://buildpacks.io/docs/using-pack/working-with-builders/) all within the kpack api.
+This allows granular control of how stacks, buildpacks, and buildpack versions are utilized and updated.
 
 Before creating Builders you will need to create a [ClusterStack](stack.md) and [ClusterStore](store.md) resources below.
 
-> Note: The Builder and ClusterBuilder were previously named CustomBuilder and CustomClusterBuilder. The previous Builder and ClusterBuilder resources that utilized pre-built builders were removed and should no longer be used with kpack. This was discussed in an approved [RFC](https://github.com/pivotal/kpack/pull/439).   
+> Note: The Builder and ClusterBuilder were previously named CustomBuilder and CustomClusterBuilder. The previous Builder and ClusterBuilder resources that utilized pre-built builders were removed and should no longer be used with kpack. This was discussed in an approved [RFC](https://github.com/pivotal/kpack/pull/439).
 
 ### <a id='builders'></a>Builders
 
@@ -19,10 +19,10 @@ metadata:
 spec:
   tag: gcr.io/sample/builder
   serviceAccount: default
-  stack: 
+  stack:
     name: bionic-stack
     kind: ClusterStack
-  store: 
+  store:
     name: sample-cluster-store
     kind: ClusterStore
   order:
@@ -37,11 +37,11 @@ spec:
       optional: true
 ```
 
-* `tag`: The tag to save the builder image. You must have access via the referenced service account.   
-* `serviceAccount`: A service account with credentials to write to the builder tag. 
+* `tag`: The tag to save the builder image. You must have access via the referenced service account.
+* `serviceAccount`: A service account with credentials to write to the builder tag.
 * `order`: The [builder order](https://buildpacks.io/docs/reference/builder-config/). See the [Order](#order) section below.
 * `stack.name`: The name of the stack resource to use as the builder stack. All buildpacks in the order must be compatible with the clusterStack.
-* `stack.kind`: The type as defined in kubernetes. This will always be ClusterStack. 
+* `stack.kind`: The type as defined in kubernetes. This will always be ClusterStack.
 * `store.name`: The name of the ClusterStore resource in kubernetes.
 * `store.kind`: The type as defined in kubernetes. This will always be ClusterStore.
 
@@ -56,7 +56,7 @@ metadata:
   name: my-cluster-builder
 spec:
   tag: gcr.io/sample/builder
-  stack: 
+  stack:
     name: bionic-stack
     kind: ClusterStack
   store:
@@ -81,7 +81,7 @@ spec:
 
 ### <a id='order'></a>Order
 
-The `spec.order` is cloud native buildpacks [builder order](https://buildpacks.io/docs/reference/builder-config/) that contains a list of buildpack groups. 
+The `spec.order` is cloud native buildpacks [builder order](https://buildpacks.io/docs/reference/builder-config/) that contains a list of buildpack groups.
 
 This list determines the order in which groups of buildpacks will be tested during detection. Detection is a phase of the buildpack execution where buildpacks are tested, one group at a time, for compatibility with the provided application source code. The first group whose non-optional buildpacks all pass detection will be the group selected for the remainder of the build.
 
@@ -89,12 +89,12 @@ This list determines the order in which groups of buildpacks will be tested duri
   A set of buildpack references. Each buildpack reference specified has the following fields:
 
     - **`id`** _(string, required)_\
-      The identifier of a buildpack from the configuration's top-level `buildpacks` list. This buildpack *must* be in available in the referenced store.  
+      The identifier of a buildpack from the configuration's top-level `buildpacks` list. This buildpack *must* be in available in the referenced store.
 
     - **`version`** _(string, optional, default: inferred)_\
       The buildpack version to chose from the store. If this field is omitted, the highest semver version number will be chosen in the store.
 
     - **`optional`** _(boolean, optional, default: `false`)_\
       Whether or not this buildpack is optional during detection.
- 
+
 > Note: Buildpacks with the same ID may appear in multiple groups at once but never in the same group.

--- a/docs/stack.md
+++ b/docs/stack.md
@@ -1,10 +1,10 @@
 # Stacks
 
 A stack resource is the specification for a [cloud native buildpacks stack](https://buildpacks.io/docs/concepts/components/stack/) used during build and in the resulting app image.
- 
-The stack will be referenced by a [builder](builders.md) resource. 
- 
-At this time only a Cluster scoped `ClusterStack` is available. 
+
+The stack will be referenced by a [builder](builders.md) resource.
+
+At this time only a Cluster scoped `ClusterStack` is available.
 
 ### <a id='cluster-store'></a>Cluster Stack Configuration
 
@@ -22,8 +22,21 @@ spec:
 ```
 
 * `id`:  The 'id' of the stack
-* `buildImage.image`: The build image of stack.   
+* `buildImage.image`: The build image of stack.
 * `runImage.image`: The run image of stack.
+
+### Using a private registry
+
+To use images from a private registry, you have to add a `serviceAccountRef` referencing a serviceaccount with the secrets needed to pull from this registry.
+
+```yaml
+spec:
+ serviceAccountRef:
+    name: private
+    namespace: private
+```
+
+* `serviceAccountRef`: An object reference to a service account in any namespace. The object reference must contain `name` and `namespace`.
 
 ### Updating a stack
 
@@ -31,5 +44,4 @@ The stack resource will not poll for updates. A CI/CD tool is needed to update t
 
 ### Suggested stacks
 
-The [pack CLI](https://github.com/buildpacks/pack) command: `pack stack suggest` will display a list of recommended stacks that can be used. We recommend starting with the `io.buildpacks.stacks.bionic` base stack. 
-  
+The [pack CLI](https://github.com/buildpacks/pack) command: `pack stack suggest` will display a list of recommended stacks that can be used. We recommend starting with the `io.buildpacks.stacks.bionic` base stack.

--- a/docs/store.md
+++ b/docs/store.md
@@ -2,9 +2,9 @@
 
 A store resource is a repository of [buildpacks](http://buildpacks.io/) packaged in [buildpackages](https://buildpacks.io/docs/buildpack-author-guide/package-a-buildpack/) that can be used by kpack to build images.
 
-The store will be referenced by a [builder](builders.md) resource. 
- 
-At this time only a Cluster scoped `ClusterStore` is available. 
+The store will be referenced by a [builder](builders.md) resource.
+
+At this time only a Cluster scoped `ClusterStore` is available.
 
 ### <a id='cluster-store'></a>Cluster Store Configuration
 
@@ -20,9 +20,22 @@ spec:
   - image: gcr.io/paketo-buildpacks/builder:base
 ```
 
-* `sources`:  List of buildpackage images to make available in the ClusterStore. Each image is an object with the key image.   
- 
+* `sources`:  List of buildpackage images to make available in the ClusterStore. Each image is an object with the key image.
+
 > Note: ClusterBuilders will also work with a prebuilt builder image if a builpack is not available in a buildpackage.
+
+### Using a private registry
+
+To use the buildpackage images from a private registry, you have to add a `serviceAccountRef` referencing a serviceaccount with the secrets needed to pull from this registry.
+
+```yaml
+spec:
+ serviceAccountRef:
+    name: private
+    namespace: private
+```
+
+* `serviceAccountRef`: An object reference to a service account in any namespace. The object reference must contain `name` and `namespace`.
 
 ### Updating a store
 
@@ -35,4 +48,4 @@ The most commonly used buildpackages are [paketo buildpacks](https://paketo.io/)
 ### Creating your own buildpackage
 
 To create your own buildpackage with custom buildpacks follow the instructions on creating them and packaging them using the [pack cli](https://buildpacks.io/docs/buildpack-author-guide/).
-  
+

--- a/pkg/apis/build/v1alpha2/cluster_stack_types.go
+++ b/pkg/apis/build/v1alpha2/cluster_stack_types.go
@@ -1,6 +1,7 @@
 package v1alpha2
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -24,9 +25,10 @@ type ClusterStack struct {
 
 // +k8s:openapi-gen=true
 type ClusterStackSpec struct {
-	Id         string                `json:"id,omitempty"`
-	BuildImage ClusterStackSpecImage `json:"buildImage,omitempty"`
-	RunImage   ClusterStackSpecImage `json:"runImage,omitempty"`
+	Id                string                  `json:"id,omitempty"`
+	BuildImage        ClusterStackSpecImage   `json:"buildImage,omitempty"`
+	RunImage          ClusterStackSpecImage   `json:"runImage,omitempty"`
+	ServiceAccountRef *corev1.ObjectReference `json:"serviceAccountRef,omitempty"`
 }
 
 // +k8s:openapi-gen=true

--- a/pkg/apis/build/v1alpha2/cluster_stack_validation.go
+++ b/pkg/apis/build/v1alpha2/cluster_stack_validation.go
@@ -16,6 +16,15 @@ func (s *ClusterStack) Validate(ctx context.Context) *apis.FieldError {
 }
 
 func (ss *ClusterStackSpec) Validate(ctx context.Context) *apis.FieldError {
+	if ss.ServiceAccountRef != nil {
+		if ss.ServiceAccountRef.Name == "" {
+			return apis.ErrMissingField("name").ViaField("serviceAccountRef")
+		}
+		if ss.ServiceAccountRef.Namespace == "" {
+			return apis.ErrMissingField("namespace").ViaField("serviceAccountRef")
+		}
+	}
+
 	return validate.FieldNotEmpty(ss.Id, "id").
 		Also(ss.BuildImage.Validate(ctx).ViaField("buildImage")).
 		Also(ss.RunImage.Validate(ctx).ViaField("runImage"))

--- a/pkg/apis/build/v1alpha2/cluster_stack_validation_test.go
+++ b/pkg/apis/build/v1alpha2/cluster_stack_validation_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sclevine/spec"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
@@ -70,6 +71,18 @@ func testClusterStackValidation(t *testing.T, when spec.G, it spec.S) {
 			clusterStack.Spec.RunImage.Image = ""
 
 			assertValidationError(clusterStack, apis.ErrMissingField("image").ViaField("runImage").ViaField("spec"))
+		})
+
+		it("missing namespace in serviceAccountRef", func() {
+			clusterStack.Spec.ServiceAccountRef = &corev1.ObjectReference{Name: "test"}
+
+			assertValidationError(clusterStack, apis.ErrMissingField("namespace").ViaField("serviceAccountRef").ViaField("spec"))
+		})
+
+		it("missing name in serviceAccountRef", func() {
+			clusterStack.Spec.ServiceAccountRef = &corev1.ObjectReference{Namespace: "test"}
+
+			assertValidationError(clusterStack, apis.ErrMissingField("name").ViaField("serviceAccountRef").ViaField("spec"))
 		})
 	})
 }

--- a/pkg/apis/build/v1alpha2/cluster_store_types.go
+++ b/pkg/apis/build/v1alpha2/cluster_store_types.go
@@ -1,6 +1,7 @@
 package v1alpha2
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -25,7 +26,8 @@ type ClusterStore struct {
 // +k8s:openapi-gen=true
 type ClusterStoreSpec struct {
 	// +listType
-	Sources []StoreImage `json:"sources,omitempty"`
+	Sources           []StoreImage            `json:"sources,omitempty"`
+	ServiceAccountRef *corev1.ObjectReference `json:"serviceAccountRef,omitempty"`
 }
 
 // +k8s:openapi-gen=true

--- a/pkg/apis/build/v1alpha2/cluster_store_validation.go
+++ b/pkg/apis/build/v1alpha2/cluster_store_validation.go
@@ -15,6 +15,15 @@ func (s *ClusterStore) Validate(ctx context.Context) *apis.FieldError {
 }
 
 func (s *ClusterStoreSpec) Validate(ctx context.Context) *apis.FieldError {
+	if s.ServiceAccountRef != nil {
+		if s.ServiceAccountRef.Name == "" {
+			return apis.ErrMissingField("name").ViaField("serviceAccountRef")
+		}
+		if s.ServiceAccountRef.Namespace == "" {
+			return apis.ErrMissingField("namespace").ViaField("serviceAccountRef")
+		}
+	}
+
 	if len(s.Sources) == 0 {
 		return apis.ErrMissingField("sources")
 	}

--- a/pkg/apis/build/v1alpha2/cluster_store_validation_test.go
+++ b/pkg/apis/build/v1alpha2/cluster_store_validation_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sclevine/spec"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
@@ -54,5 +55,18 @@ func testClusterStoreValidation(t *testing.T, when spec.G, it spec.S) {
 			clusterStore.Spec.Sources = append(clusterStore.Spec.Sources, StoreImage{Image: "invalid image"})
 			assertValidationError(clusterStore, apis.ErrInvalidArrayValue(clusterStore.Spec.Sources[3], "sources", 3).ViaField("spec"))
 		})
+
+		it("missing namespace in serviceAccountRef", func() {
+			clusterStore.Spec.ServiceAccountRef = &corev1.ObjectReference{Name: "test"}
+
+			assertValidationError(clusterStore, apis.ErrMissingField("namespace").ViaField("serviceAccountRef").ViaField("spec"))
+		})
+
+		it("missing name in serviceAccountRef", func() {
+			clusterStore.Spec.ServiceAccountRef = &corev1.ObjectReference{Namespace: "test"}
+
+			assertValidationError(clusterStore, apis.ErrMissingField("name").ViaField("serviceAccountRef").ViaField("spec"))
+		})
+
 	})
 }

--- a/pkg/apis/build/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/build/v1alpha2/zz_generated.deepcopy.go
@@ -659,7 +659,7 @@ func (in *ClusterStack) DeepCopyInto(out *ClusterStack) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	out.Spec = in.Spec
+	in.Spec.DeepCopyInto(&out.Spec)
 	in.Status.DeepCopyInto(&out.Status)
 	return
 }
@@ -728,6 +728,11 @@ func (in *ClusterStackSpec) DeepCopyInto(out *ClusterStackSpec) {
 	*out = *in
 	out.BuildImage = in.BuildImage
 	out.RunImage = in.RunImage
+	if in.ServiceAccountRef != nil {
+		in, out := &in.ServiceAccountRef, &out.ServiceAccountRef
+		*out = new(v1.ObjectReference)
+		**out = **in
+	}
 	return
 }
 
@@ -867,6 +872,11 @@ func (in *ClusterStoreSpec) DeepCopyInto(out *ClusterStoreSpec) {
 		in, out := &in.Sources, &out.Sources
 		*out = make([]StoreImage, len(*in))
 		copy(*out, *in)
+	}
+	if in.ServiceAccountRef != nil {
+		in, out := &in.ServiceAccountRef, &out.ServiceAccountRef
+		*out = new(v1.ObjectReference)
+		**out = **in
 	}
 	return
 }

--- a/pkg/apis/core/v1alpha1/status.go
+++ b/pkg/apis/core/v1alpha1/status.go
@@ -1,0 +1,42 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CreateStatusWithReadyCondition(generation int64, err error) Status {
+	msg := ""
+	conditionStatus := corev1.ConditionTrue
+
+	if err != nil {
+		msg = err.Error()
+		conditionStatus = corev1.ConditionFalse
+	}
+
+	return Status{
+		ObservedGeneration: generation,
+		Conditions: Conditions{
+			{
+				Type:               ConditionReady,
+				Status:             conditionStatus,
+				LastTransitionTime: VolatileTime{Inner: metav1.Now()},
+				Message:            msg,
+			},
+		},
+	}
+}

--- a/pkg/cnb/remote_stack_reader.go
+++ b/pkg/cnb/remote_stack_reader.go
@@ -22,16 +22,15 @@ const (
 
 type RemoteStackReader struct {
 	RegistryClient RegistryClient
-	Keychain       authn.Keychain
 }
 
-func (r *RemoteStackReader) Read(clusterStackSpec buildapi.ClusterStackSpec) (buildapi.ResolvedClusterStack, error) {
-	buildImage, buildIdentifier, err := r.RegistryClient.Fetch(r.Keychain, clusterStackSpec.BuildImage.Image)
+func (r *RemoteStackReader) Read(keychain authn.Keychain, clusterStackSpec buildapi.ClusterStackSpec) (buildapi.ResolvedClusterStack, error) {
+	buildImage, buildIdentifier, err := r.RegistryClient.Fetch(keychain, clusterStackSpec.BuildImage.Image)
 	if err != nil {
 		return buildapi.ResolvedClusterStack{}, err
 	}
 
-	runImage, runIdentifier, err := r.RegistryClient.Fetch(r.Keychain, clusterStackSpec.RunImage.Image)
+	runImage, runIdentifier, err := r.RegistryClient.Fetch(keychain, clusterStackSpec.RunImage.Image)
 	if err != nil {
 		return buildapi.ResolvedClusterStack{}, err
 	}

--- a/pkg/cnb/remote_stack_reader_test.go
+++ b/pkg/cnb/remote_stack_reader_test.go
@@ -35,7 +35,6 @@ func testRemoteStackReader(t *testing.T, when spec.G, it spec.S) {
 			expectedKeychain  = authn.NewMultiKeychain(authn.DefaultKeychain)
 			remoteStackReader = &cnb.RemoteStackReader{
 				RegistryClient: fakeClient,
-				Keychain:       expectedKeychain,
 			}
 		)
 
@@ -46,7 +45,7 @@ func testRemoteStackReader(t *testing.T, when spec.G, it spec.S) {
 			fakeClient.AddImage(runTag, runImage, expectedKeychain)
 			fakeClient.AddImage(buildTag, buildImage, expectedKeychain)
 
-			resolvedStack, err := remoteStackReader.Read(buildapi.ClusterStackSpec{
+			resolvedStack, err := remoteStackReader.Read(expectedKeychain, buildapi.ClusterStackSpec{
 				Id: "org.some.stack",
 				BuildImage: buildapi.ClusterStackSpecImage{
 					Image: buildTag,
@@ -88,7 +87,7 @@ func testRemoteStackReader(t *testing.T, when spec.G, it spec.S) {
 				fakeClient.AddImage(runTag, runImage, expectedKeychain)
 				fakeClient.AddImage(buildTag, buildImage, expectedKeychain)
 
-				_, err := remoteStackReader.Read(buildapi.ClusterStackSpec{
+				_, err := remoteStackReader.Read(expectedKeychain, buildapi.ClusterStackSpec{
 					Id: "org.some.stack",
 					BuildImage: buildapi.ClusterStackSpecImage{
 						Image: buildTag,
@@ -107,7 +106,7 @@ func testRemoteStackReader(t *testing.T, when spec.G, it spec.S) {
 				fakeClient.AddImage(runTag, runImage, expectedKeychain)
 				fakeClient.AddImage(buildTag, buildImage, expectedKeychain)
 
-				_, err := remoteStackReader.Read(buildapi.ClusterStackSpec{
+				_, err := remoteStackReader.Read(expectedKeychain, buildapi.ClusterStackSpec{
 					Id: "org.some.stack",
 					BuildImage: buildapi.ClusterStackSpecImage{
 						Image: buildTag,
@@ -126,7 +125,7 @@ func testRemoteStackReader(t *testing.T, when spec.G, it spec.S) {
 				fakeClient.AddImage(runTag, runImage, expectedKeychain)
 				fakeClient.AddImage(buildTag, buildImage, expectedKeychain)
 
-				_, err := remoteStackReader.Read(buildapi.ClusterStackSpec{
+				_, err := remoteStackReader.Read(expectedKeychain, buildapi.ClusterStackSpec{
 					Id: "org.some.stack",
 					BuildImage: buildapi.ClusterStackSpecImage{
 						Image: buildTag,
@@ -145,7 +144,7 @@ func testRemoteStackReader(t *testing.T, when spec.G, it spec.S) {
 				fakeClient.AddImage(runTag, runImage, expectedKeychain)
 				fakeClient.AddImage(buildTag, buildImage, expectedKeychain)
 
-				_, err := remoteStackReader.Read(buildapi.ClusterStackSpec{
+				_, err := remoteStackReader.Read(expectedKeychain, buildapi.ClusterStackSpec{
 					Id: "org.some.stack",
 					BuildImage: buildapi.ClusterStackSpecImage{
 						Image: buildTag,
@@ -164,7 +163,7 @@ func testRemoteStackReader(t *testing.T, when spec.G, it spec.S) {
 				fakeClient.AddImage(runTag, runImage, expectedKeychain)
 				fakeClient.AddImage(buildTag, buildImage, expectedKeychain)
 
-				_, err := remoteStackReader.Read(buildapi.ClusterStackSpec{
+				_, err := remoteStackReader.Read(expectedKeychain, buildapi.ClusterStackSpec{
 					Id: "org.some.stack",
 					BuildImage: buildapi.ClusterStackSpecImage{
 						Image: buildTag,
@@ -181,7 +180,7 @@ func testRemoteStackReader(t *testing.T, when spec.G, it spec.S) {
 
 				fakeClient.AddImage(runTag, runImage, expectedKeychain)
 
-				_, err := remoteStackReader.Read(buildapi.ClusterStackSpec{
+				_, err := remoteStackReader.Read(expectedKeychain, buildapi.ClusterStackSpec{
 					Id: "org.some.stack",
 					BuildImage: buildapi.ClusterStackSpecImage{
 						Image: runTag,

--- a/pkg/cnb/remote_store_reader.go
+++ b/pkg/cnb/remote_store_reader.go
@@ -14,17 +14,16 @@ import (
 
 type RemoteStoreReader struct {
 	RegistryClient RegistryClient
-	Keychain       authn.Keychain
 }
 
-func (r *RemoteStoreReader) Read(storeImages []buildapi.StoreImage) ([]buildapi.StoreBuildpack, error) {
+func (r *RemoteStoreReader) Read(keychain authn.Keychain, storeImages []buildapi.StoreImage) ([]buildapi.StoreBuildpack, error) {
 	var g errgroup.Group
 
 	c := make(chan buildapi.StoreBuildpack)
 	for _, storeImage := range storeImages {
 		storeImageCopy := storeImage
 		g.Go(func() error {
-			image, _, err := r.RegistryClient.Fetch(r.Keychain, storeImageCopy.Image)
+			image, _, err := r.RegistryClient.Fetch(keychain, storeImageCopy.Image)
 			if err != nil {
 				return err
 			}

--- a/pkg/cnb/remote_store_reader_test.go
+++ b/pkg/cnb/remote_store_reader_test.go
@@ -30,7 +30,6 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 			fakeClient        = registryfakes.NewFakeClient()
 			remoteStoreReader = &RemoteStoreReader{
 				RegistryClient: fakeClient,
-				Keychain:       expectedKeychain,
 			}
 		)
 
@@ -206,7 +205,7 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("returns all buildpacks from multiple images", func() {
-			storeBuildpacks, err := remoteStoreReader.Read([]buildapi.StoreImage{
+			storeBuildpacks, err := remoteStoreReader.Read(expectedKeychain, []buildapi.StoreImage{
 				{
 					Image: buildpackageA,
 				},
@@ -357,7 +356,7 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("returns all buildpacks in a deterministic order", func() {
-			expectedBuildpackOrder, err := remoteStoreReader.Read([]buildapi.StoreImage{
+			expectedBuildpackOrder, err := remoteStoreReader.Read(expectedKeychain, []buildapi.StoreImage{
 				{
 					Image: buildpackageA,
 				},
@@ -368,7 +367,7 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 			require.NoError(t, err)
 
 			for i := 1; i <= 50; i++ {
-				subsequentOrder, err := remoteStoreReader.Read([]buildapi.StoreImage{
+				subsequentOrder, err := remoteStoreReader.Read(expectedKeychain, []buildapi.StoreImage{
 					{
 						Image: buildpackageA,
 					},
@@ -446,11 +445,11 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 					Image: "image/with_duplicates",
 				},
 			}
-			expectedBuildpackOrder, err := remoteStoreReader.Read(images)
+			expectedBuildpackOrder, err := remoteStoreReader.Read(expectedKeychain, images)
 			require.NoError(t, err)
 
 			for i := 1; i <= 50; i++ {
-				subsequentOrder, err := remoteStoreReader.Read(images)
+				subsequentOrder, err := remoteStoreReader.Read(expectedKeychain, images)
 				require.NoError(t, err)
 
 				require.Equal(t, expectedBuildpackOrder, subsequentOrder)

--- a/pkg/reconciler/clusterstack/clusterstackfakes/fake_cluster_stack_reader.go
+++ b/pkg/reconciler/clusterstack/clusterstackfakes/fake_cluster_stack_reader.go
@@ -4,15 +4,17 @@ package clusterstackfakes
 import (
 	"sync"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
 	"github.com/pivotal/kpack/pkg/reconciler/clusterstack"
 )
 
 type FakeClusterStackReader struct {
-	ReadStub        func(buildapi.ClusterStackSpec) (buildapi.ResolvedClusterStack, error)
+	ReadStub        func(authn.Keychain, buildapi.ClusterStackSpec) (buildapi.ResolvedClusterStack, error)
 	readMutex       sync.RWMutex
 	readArgsForCall []struct {
-		arg1 buildapi.ClusterStackSpec
+		arg1 authn.Keychain
+		arg2 buildapi.ClusterStackSpec
 	}
 	readReturns struct {
 		result1 buildapi.ResolvedClusterStack
@@ -26,21 +28,23 @@ type FakeClusterStackReader struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeClusterStackReader) Read(arg1 buildapi.ClusterStackSpec) (buildapi.ResolvedClusterStack, error) {
+func (fake *FakeClusterStackReader) Read(arg1 authn.Keychain, arg2 buildapi.ClusterStackSpec) (buildapi.ResolvedClusterStack, error) {
 	fake.readMutex.Lock()
 	ret, specificReturn := fake.readReturnsOnCall[len(fake.readArgsForCall)]
 	fake.readArgsForCall = append(fake.readArgsForCall, struct {
-		arg1 buildapi.ClusterStackSpec
-	}{arg1})
-	fake.recordInvocation("Read", []interface{}{arg1})
+		arg1 authn.Keychain
+		arg2 buildapi.ClusterStackSpec
+	}{arg1, arg2})
+	stub := fake.ReadStub
+	fakeReturns := fake.readReturns
+	fake.recordInvocation("Read", []interface{}{arg1, arg2})
 	fake.readMutex.Unlock()
-	if fake.ReadStub != nil {
-		return fake.ReadStub(arg1)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.readReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -50,17 +54,17 @@ func (fake *FakeClusterStackReader) ReadCallCount() int {
 	return len(fake.readArgsForCall)
 }
 
-func (fake *FakeClusterStackReader) ReadCalls(stub func(buildapi.ClusterStackSpec) (buildapi.ResolvedClusterStack, error)) {
+func (fake *FakeClusterStackReader) ReadCalls(stub func(authn.Keychain, buildapi.ClusterStackSpec) (buildapi.ResolvedClusterStack, error)) {
 	fake.readMutex.Lock()
 	defer fake.readMutex.Unlock()
 	fake.ReadStub = stub
 }
 
-func (fake *FakeClusterStackReader) ReadArgsForCall(i int) buildapi.ClusterStackSpec {
+func (fake *FakeClusterStackReader) ReadArgsForCall(i int) (authn.Keychain, buildapi.ClusterStackSpec) {
 	fake.readMutex.RLock()
 	defer fake.readMutex.RUnlock()
 	argsForCall := fake.readArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeClusterStackReader) ReadReturns(result1 buildapi.ResolvedClusterStack, result2 error) {

--- a/pkg/reconciler/clusterstore/clusterstore.go
+++ b/pkg/reconciler/clusterstore/clusterstore.go
@@ -3,7 +3,7 @@ package clusterstore
 import (
 	"context"
 
-	corev1 "k8s.io/api/core/v1"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,6 +16,7 @@ import (
 	buildinformers "github.com/pivotal/kpack/pkg/client/informers/externalversions/build/v1alpha2"
 	buildlisters "github.com/pivotal/kpack/pkg/client/listers/build/v1alpha2"
 	"github.com/pivotal/kpack/pkg/reconciler"
+	"github.com/pivotal/kpack/pkg/registry"
 )
 
 const (
@@ -25,14 +26,19 @@ const (
 
 //go:generate counterfeiter . StoreReader
 type StoreReader interface {
-	Read(storeImages []buildapi.StoreImage) ([]buildapi.StoreBuildpack, error)
+	Read(keychain authn.Keychain, storeImages []buildapi.StoreImage) ([]buildapi.StoreBuildpack, error)
 }
 
-func NewController(opt reconciler.Options, clusterStoreInformer buildinformers.ClusterStoreInformer, storeReader StoreReader) *controller.Impl {
+func NewController(
+	opt reconciler.Options,
+	keychainFactory registry.KeychainFactory,
+	clusterStoreInformer buildinformers.ClusterStoreInformer,
+	storeReader StoreReader) *controller.Impl {
 	c := &Reconciler{
 		Client:             opt.Client,
 		ClusterStoreLister: clusterStoreInformer.Lister(),
 		StoreReader:        storeReader,
+		KeychainFactory:    keychainFactory,
 	}
 	impl := controller.NewImpl(c, opt.Logger, ReconcilerName)
 	clusterStoreInformer.Informer().AddEventHandler(reconciler.Handler(impl.Enqueue))
@@ -43,6 +49,7 @@ type Reconciler struct {
 	Client             versioned.Interface
 	StoreReader        StoreReader
 	ClusterStoreLister buildlisters.ClusterStoreLister
+	KeychainFactory    registry.KeychainFactory
 }
 
 func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
@@ -60,7 +67,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 	clusterStore = clusterStore.DeepCopy()
 
-	clusterStore, err = c.reconcileClusterStoreStatus(clusterStore)
+	clusterStore, err = c.reconcileClusterStoreStatus(ctx, clusterStore)
 
 	updateErr := c.updateClusterStoreStatus(ctx, clusterStore)
 	if updateErr != nil {
@@ -89,37 +96,35 @@ func (c *Reconciler) updateClusterStoreStatus(ctx context.Context, desired *buil
 	return err
 }
 
-func (c *Reconciler) reconcileClusterStoreStatus(clusterStore *buildapi.ClusterStore) (*buildapi.ClusterStore, error) {
-	buildpacks, err := c.StoreReader.Read(clusterStore.Spec.Sources)
+func (c *Reconciler) reconcileClusterStoreStatus(ctx context.Context, clusterStore *buildapi.ClusterStore) (*buildapi.ClusterStore, error) {
+	secretRef := registry.SecretRef{}
+
+	if clusterStore.Spec.ServiceAccountRef != nil {
+		secretRef = registry.SecretRef{
+			ServiceAccount: clusterStore.Spec.ServiceAccountRef.Name,
+			Namespace:      clusterStore.Spec.ServiceAccountRef.Namespace,
+		}
+	}
+
+	keychain, err := c.KeychainFactory.KeychainForSecretRef(ctx, secretRef)
 	if err != nil {
 		clusterStore.Status = buildapi.ClusterStoreStatus{
-			Status: corev1alpha1.Status{
-				ObservedGeneration: clusterStore.Generation,
-				Conditions: corev1alpha1.Conditions{
-					{
-						Type:               corev1alpha1.ConditionReady,
-						Status:             corev1.ConditionFalse,
-						LastTransitionTime: corev1alpha1.VolatileTime{Inner: metav1.Now()},
-						Message:            err.Error(),
-					},
-				},
-			},
+			Status: corev1alpha1.CreateStatusWithReadyCondition(clusterStore.Generation, err),
+		}
+		return clusterStore, err
+	}
+
+	buildpacks, err := c.StoreReader.Read(keychain, clusterStore.Spec.Sources)
+	if err != nil {
+		clusterStore.Status = buildapi.ClusterStoreStatus{
+			Status: corev1alpha1.CreateStatusWithReadyCondition(clusterStore.Generation, err),
 		}
 		return clusterStore, err
 	}
 
 	clusterStore.Status = buildapi.ClusterStoreStatus{
 		Buildpacks: buildpacks,
-		Status: corev1alpha1.Status{
-			ObservedGeneration: clusterStore.Generation,
-			Conditions: corev1alpha1.Conditions{
-				{
-					LastTransitionTime: corev1alpha1.VolatileTime{Inner: metav1.Now()},
-					Type:               corev1alpha1.ConditionReady,
-					Status:             corev1.ConditionTrue,
-				},
-			},
-		},
+		Status:     corev1alpha1.CreateStatusWithReadyCondition(clusterStore.Generation, nil),
 	}
 	return clusterStore, nil
 }

--- a/pkg/reconciler/clusterstore/clusterstore_test.go
+++ b/pkg/reconciler/clusterstore/clusterstore_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/pivotal/kpack/pkg/reconciler/clusterstore"
 	"github.com/pivotal/kpack/pkg/reconciler/clusterstore/clusterstorefakes"
 	"github.com/pivotal/kpack/pkg/reconciler/testhelpers"
+	"github.com/pivotal/kpack/pkg/registry"
+	"github.com/pivotal/kpack/pkg/registry/registryfakes"
 )
 
 func TestClusterStoreReconciler(t *testing.T) {
@@ -33,7 +35,8 @@ func testClusterStoreReconciler(t *testing.T, when spec.G, it spec.S) {
 		initialGeneration int64 = 1
 	)
 	var (
-		fakeStoreReader = &clusterstorefakes.FakeStoreReader{}
+		fakeStoreReader     = &clusterstorefakes.FakeStoreReader{}
+		fakeKeyChainFactory = &registryfakes.FakeKeychainFactory{}
 	)
 
 	rt := testhelpers.ReconcilerTester(t,
@@ -46,6 +49,7 @@ func testClusterStoreReconciler(t *testing.T, when spec.G, it spec.S) {
 				Client:             fakeClient,
 				StoreReader:        fakeStoreReader,
 				ClusterStoreLister: listers.GetClusterStoreLister(),
+				KeychainFactory:    fakeKeyChainFactory,
 			}
 			return r, rtesting.ActionRecorderList{fakeClient}, rtesting.EventList{Recorder: record.NewFakeRecorder(10)}
 		})
@@ -96,6 +100,10 @@ func testClusterStoreReconciler(t *testing.T, when spec.G, it spec.S) {
 		it("saves metadata to the status", func() {
 			fakeStoreReader.ReadReturns(readBuildpacks, nil)
 
+			emptySecretRef := registry.SecretRef{}
+			defaultKeyChain := &registryfakes.FakeKeychain{Name: "default"}
+			fakeKeyChainFactory.AddKeychainForSecretRef(t, emptySecretRef, defaultKeyChain)
+
 			rt.Test(rtesting.TableRow{
 				Key: storeKey,
 				Objects: []runtime.Object{
@@ -126,11 +134,60 @@ func testClusterStoreReconciler(t *testing.T, when spec.G, it spec.S) {
 
 			assert.Equal(t, 1, fakeStoreReader.ReadCallCount())
 
-			assert.Equal(t, store.Spec.Sources, fakeStoreReader.ReadArgsForCall(0))
+			_, clusterStoreSpec := fakeStoreReader.ReadArgsForCall(0)
+			assert.Equal(t, store.Spec.Sources, clusterStoreSpec)
+		})
+
+		it("uses the keychain of the referenced service account", func() {
+			fakeStoreReader.ReadReturns(readBuildpacks, nil)
+
+			store.Spec.ServiceAccountRef = &corev1.ObjectReference{Name: "private-account", Namespace: "my-namespace"}
+			secretRef := registry.SecretRef{
+				ServiceAccount: "private-account",
+				Namespace:      "my-namespace",
+			}
+			expectedKeyChain := &registryfakes.FakeKeychain{Name: "secret"}
+			fakeKeyChainFactory.AddKeychainForSecretRef(t, secretRef, expectedKeyChain)
+
+			rt.Test(rtesting.TableRow{
+				Key: storeKey,
+				Objects: []runtime.Object{
+					store,
+				},
+				WantErr: false,
+				WantStatusUpdates: []clientgotesting.UpdateActionImpl{
+					{
+						Object: &buildapi.ClusterStore{
+							ObjectMeta: store.ObjectMeta,
+							Spec:       store.Spec,
+							Status: buildapi.ClusterStoreStatus{
+								Status: corev1alpha1.Status{
+									ObservedGeneration: 1,
+									Conditions: corev1alpha1.Conditions{
+										{
+											Type:   corev1alpha1.ConditionReady,
+											Status: corev1.ConditionTrue,
+										},
+									},
+								},
+								Buildpacks: readBuildpacks,
+							},
+						},
+					},
+				},
+			})
+
+			assert.Equal(t, 1, fakeStoreReader.ReadCallCount())
+			actualKeyChain, _ := fakeStoreReader.ReadArgsForCall(0)
+			assert.Equal(t, expectedKeyChain, actualKeyChain)
 		})
 
 		it("does not update the status with no status change", func() {
 			fakeStoreReader.ReadReturns(readBuildpacks, nil)
+
+			emptySecretRef := registry.SecretRef{}
+			defaultKeyChain := &registryfakes.FakeKeychain{Name: "default"}
+			fakeKeyChainFactory.AddKeychainForSecretRef(t, emptySecretRef, defaultKeyChain)
 
 			store.Status = buildapi.ClusterStoreStatus{
 				Status: corev1alpha1.Status{
@@ -155,6 +212,10 @@ func testClusterStoreReconciler(t *testing.T, when spec.G, it spec.S) {
 
 		it("sets the status to Ready False if error reading buildpacks", func() {
 			fakeStoreReader.ReadReturns(nil, fmt.Errorf("no buildpacks left"))
+
+			emptySecretRef := registry.SecretRef{}
+			defaultKeyChain := &registryfakes.FakeKeychain{Name: "default"}
+			fakeKeyChainFactory.AddKeychainForSecretRef(t, emptySecretRef, defaultKeyChain)
 
 			rt.Test(rtesting.TableRow{
 				Key: storeKey,

--- a/pkg/reconciler/clusterstore/clusterstorefakes/fake_store_reader.go
+++ b/pkg/reconciler/clusterstore/clusterstorefakes/fake_store_reader.go
@@ -4,15 +4,17 @@ package clusterstorefakes
 import (
 	"sync"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
 	"github.com/pivotal/kpack/pkg/reconciler/clusterstore"
 )
 
 type FakeStoreReader struct {
-	ReadStub        func([]buildapi.StoreImage) ([]buildapi.StoreBuildpack, error)
+	ReadStub        func(authn.Keychain, []buildapi.StoreImage) ([]buildapi.StoreBuildpack, error)
 	readMutex       sync.RWMutex
 	readArgsForCall []struct {
-		arg1 []buildapi.StoreImage
+		arg1 authn.Keychain
+		arg2 []buildapi.StoreImage
 	}
 	readReturns struct {
 		result1 []buildapi.StoreBuildpack
@@ -26,26 +28,28 @@ type FakeStoreReader struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeStoreReader) Read(arg1 []buildapi.StoreImage) ([]buildapi.StoreBuildpack, error) {
-	var arg1Copy []buildapi.StoreImage
-	if arg1 != nil {
-		arg1Copy = make([]buildapi.StoreImage, len(arg1))
-		copy(arg1Copy, arg1)
+func (fake *FakeStoreReader) Read(arg1 authn.Keychain, arg2 []buildapi.StoreImage) ([]buildapi.StoreBuildpack, error) {
+	var arg2Copy []buildapi.StoreImage
+	if arg2 != nil {
+		arg2Copy = make([]buildapi.StoreImage, len(arg2))
+		copy(arg2Copy, arg2)
 	}
 	fake.readMutex.Lock()
 	ret, specificReturn := fake.readReturnsOnCall[len(fake.readArgsForCall)]
 	fake.readArgsForCall = append(fake.readArgsForCall, struct {
-		arg1 []buildapi.StoreImage
-	}{arg1Copy})
-	fake.recordInvocation("Read", []interface{}{arg1Copy})
+		arg1 authn.Keychain
+		arg2 []buildapi.StoreImage
+	}{arg1, arg2Copy})
+	stub := fake.ReadStub
+	fakeReturns := fake.readReturns
+	fake.recordInvocation("Read", []interface{}{arg1, arg2Copy})
 	fake.readMutex.Unlock()
-	if fake.ReadStub != nil {
-		return fake.ReadStub(arg1)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.readReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -55,17 +59,17 @@ func (fake *FakeStoreReader) ReadCallCount() int {
 	return len(fake.readArgsForCall)
 }
 
-func (fake *FakeStoreReader) ReadCalls(stub func([]buildapi.StoreImage) ([]buildapi.StoreBuildpack, error)) {
+func (fake *FakeStoreReader) ReadCalls(stub func(authn.Keychain, []buildapi.StoreImage) ([]buildapi.StoreBuildpack, error)) {
 	fake.readMutex.Lock()
 	defer fake.readMutex.Unlock()
 	fake.ReadStub = stub
 }
 
-func (fake *FakeStoreReader) ReadArgsForCall(i int) []buildapi.StoreImage {
+func (fake *FakeStoreReader) ReadArgsForCall(i int) (authn.Keychain, []buildapi.StoreImage) {
 	fake.readMutex.RLock()
 	defer fake.readMutex.RUnlock()
 	argsForCall := fake.readArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeStoreReader) ReadReturns(result1 []buildapi.StoreBuildpack, result2 error) {

--- a/samples/cluster_stack.yaml
+++ b/samples/cluster_stack.yaml
@@ -4,6 +4,9 @@ metadata:
   name: default
 spec:
   id: "io.buildpacks.stacks.bionic"
+  serviceAccountRef:
+    name: default
+    namespace: default
   buildImage:
     image: "paketobuildpacks/build:base-cnb"
   runImage:

--- a/samples/cluster_store.yaml
+++ b/samples/cluster_store.yaml
@@ -3,6 +3,9 @@ kind: ClusterStore
 metadata:
   name: sample-cluster-store
 spec:
+  serviceAccountRef:
+    name: default
+    namespace: default
   sources:
   - image: gcr.io/paketo-buildpacks/java
   - image: gcr.io/paketo-buildpacks/nodejs


### PR DESCRIPTION
Introducing an optional `serviceAccountRef` for `ClusterStore` and `ClusterStack` in order to allow credentials to a private registry.

Fixes #649