### PR TITLE
Allow additional labels for test namespace

### DIFF
--- a/docs/local.md
+++ b/docs/local.md
@@ -10,6 +10,13 @@ kubectl cluster-info # ensure you have access to a cluster
 ### Running Tests
 
 * To run the e2e tests, kpack must be installed and running on a cluster
+
+* The KPACK_TEST_NAMESPACE_LABELS environment variable allows you define additional labels for the test namespace, e.g.
+
+```bash
+export KPACK_TEST_NAMESPACE_LABELS="istio-injection=disabled,purpose=test"
+```
+
 * The IMAGE_REGISTRY environment variable must point at a registry with local write access 
 
 ```bash


### PR DESCRIPTION
This eases coexisting with `istio` because you can disable sidecar injection with

```bash
export KPACK_TEST_NAMESPACE_LABELS="istio-injection=disabled"
```

Without, the tests would fail because of the sidecars.