### PR TITLE
Introducing stable alias for buildapi to ease version bumping

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -27,7 +27,7 @@ import (
 	"knative.dev/pkg/signals"
 
 	"github.com/pivotal/kpack/cmd"
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/blob"
 	"github.com/pivotal/kpack/pkg/buildpod"
 	"github.com/pivotal/kpack/pkg/client/clientset/versioned"
@@ -40,7 +40,7 @@ import (
 	"github.com/pivotal/kpack/pkg/reconciler"
 	"github.com/pivotal/kpack/pkg/reconciler/build"
 	"github.com/pivotal/kpack/pkg/reconciler/builder"
-	"github.com/pivotal/kpack/pkg/reconciler/clusterbuilder"
+	clusterBuilder "github.com/pivotal/kpack/pkg/reconciler/clusterbuilder"
 	"github.com/pivotal/kpack/pkg/reconciler/clusterstack"
 	"github.com/pivotal/kpack/pkg/reconciler/clusterstore"
 	"github.com/pivotal/kpack/pkg/reconciler/image"
@@ -125,7 +125,7 @@ func main() {
 	}
 
 	buildpodGenerator := &buildpod.Generator{
-		BuildPodConfig: v1alpha1.BuildPodImages{
+		BuildPodConfig: buildapi.BuildPodImages{
 			BuildInitImage:         *buildInitImage,
 			CompletionImage:        *completionImage,
 			RebaseImage:            *rebaseImage,
@@ -236,8 +236,8 @@ func runGroup(ctx context.Context, fns ...doneFunc) error {
 	return eg.Wait()
 }
 
-func newBuildpackRepository(keychain authn.Keychain) func(clusterStore *v1alpha1.ClusterStore) cnb.BuildpackRepository {
-	return func(clusterStore *v1alpha1.ClusterStore) cnb.BuildpackRepository {
+func newBuildpackRepository(keychain authn.Keychain) func(clusterStore *buildapi.ClusterStore) cnb.BuildpackRepository {
+	return func(clusterStore *buildapi.ClusterStore) cnb.BuildpackRepository {
 		return &cnb.StoreBuildpackRepository{
 			Keychain:     keychain,
 			ClusterStore: clusterStore,

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -21,16 +21,16 @@ import (
 	"knative.dev/pkg/webhook/resourcesemantics/defaulting"
 	"knative.dev/pkg/webhook/resourcesemantics/validation"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
-	v1alpha1.SchemeGroupVersion.WithKind("Image"):          &v1alpha1.Image{},
-	v1alpha1.SchemeGroupVersion.WithKind("Build"):          &v1alpha1.Build{},
-	v1alpha1.SchemeGroupVersion.WithKind("Builder"):        &v1alpha1.Builder{},
-	v1alpha1.SchemeGroupVersion.WithKind("ClusterBuilder"): &v1alpha1.ClusterBuilder{},
-	v1alpha1.SchemeGroupVersion.WithKind("ClusterStore"):   &v1alpha1.ClusterStore{},
-	v1alpha1.SchemeGroupVersion.WithKind("ClusterStack"):   &v1alpha1.ClusterStack{},
+	buildapi.SchemeGroupVersion.WithKind("Image"):          &buildapi.Image{},
+	buildapi.SchemeGroupVersion.WithKind("Build"):          &buildapi.Build{},
+	buildapi.SchemeGroupVersion.WithKind("Builder"):        &buildapi.Builder{},
+	buildapi.SchemeGroupVersion.WithKind("ClusterBuilder"): &buildapi.ClusterBuilder{},
+	buildapi.SchemeGroupVersion.WithKind("ClusterStore"):   &buildapi.ClusterStore{},
+	buildapi.SchemeGroupVersion.WithKind("ClusterStack"):   &buildapi.ClusterStack{},
 }
 
 func init() {
@@ -103,7 +103,7 @@ func withCheckDefaultStorageClass(ctx context.Context, storageClassLister lister
 		}
 
 		if val, ok := sc.Annotations["storageclass.kubernetes.io/is-default-class"]; ok && val == "true" {
-			ctx = context.WithValue(ctx, v1alpha1.HasDefaultStorageClass, true)
+			ctx = context.WithValue(ctx, buildapi.HasDefaultStorageClass, true)
 			break
 		}
 	}

--- a/docs/bump-build-api.md
+++ b/docs/bump-build-api.md
@@ -1,0 +1,43 @@
+# Bumping the build API version
+
+As an example, we show how to update from `v1alpha1` to `v1alpha2`
+
+1. Copy `./pkg/api/build/v1alpha1` to `./pkg/api/build/v1alpha2`
+1. Set package to `v1alpha2` in `./pkg/api/build/v1alpha2`
+1. Update `./pkg/api/build/v1alpha2/register.go` to include
+
+```go
+var SchemeGroupVersion = schema.GroupVersion{Group: build.GroupName, Version: "v1alpha2"}
+```
+
+1. Search and replace:
+```
+buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1" -> buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
+```
+1. Update `./hack/update-codegen.sh`
+    Append `v1alpha2` to group: `deepcopy,client,informer,lister`
+    ```bash
+    bash "${CODEGEN_PKG}"/generate-groups.sh "deepcopy,client,informer,lister" \
+    github.com/pivotal/kpack/pkg/client github.com/pivotal/kpack/pkg/apis \
+    "build:v1alpha1,v1alpha2" \
+    --output-base "${TMP_DIR}/src" \
+    --go-header-file "${SCRIPT_ROOT}"/hack/boilerplate/boilerplate.go.txt
+    ```
+1. Update `./hack/openapi-codegen.sh` to include `v1alpha2`
+```bash
+${OPENAPI_GEN_BIN} \
+  -h ./hack/boilerplate/boilerplate.go.txt \
+  -i github.com/pivotal/kpack/pkg/apis/build/v1alpha2,github.com/pivotal/kpack/pkg/apis/core/v1alpha1 \
+  -p ./pkg/openapi \
+  -o ./
+
+# VolatileTime has custom json encoding/decoding that does not map to a proper json schema. Use a basic string instead.
+sed -i.old 's/Ref\:         ref(\"github.com\/pivotal\/kpack\/pkg\/apis\/core\/v1alpha2.VolatileTime\"),/Type: []string{\"string\"}, Format: \"\",/g' pkg/openapi/openapi_generated.go
+```
+1. Run `./hack/openapi-codegen.sh` and `./hack/update-codegen.sh`
+1. Replace all occurrences of `Kpack().V1alpha1()` with `Kpack().V1alpha2()` (!*NOT* in `generic.go`)
+1. Replace all occurrences of `KpackV1alpha1()` with `KpackV1alpha2()` (!*NOT* in `pkg/client`)
+1. Adapt `config/*.yaml`
+  * `v1alpha2`
+  * `served`
+  * `storage`

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -20,7 +20,13 @@ export GOPATH=${GOPATH:-${TMP_DIR}}
 TMP_REPO_PATH="${TMP_DIR}/src/github.com/pivotal/kpack"
 mkdir -p "$(dirname "${TMP_REPO_PATH}")" && ln -s "${SCRIPT_ROOT}" "${TMP_REPO_PATH}"
 
-bash "${CODEGEN_PKG}"/generate-groups.sh "deepcopy,client,informer,lister" \
+bash "${CODEGEN_PKG}"/generate-groups.sh "deepcopy,informer,lister" \
+  github.com/pivotal/kpack/pkg/client github.com/pivotal/kpack/pkg/apis \
+  "build:v1alpha1" \
+  --output-base "${TMP_DIR}/src" \
+  --go-header-file "${SCRIPT_ROOT}"/hack/boilerplate/boilerplate.go.txt
+
+bash "${CODEGEN_PKG}"/generate-groups.sh "client" \
   github.com/pivotal/kpack/pkg/client github.com/pivotal/kpack/pkg/apis \
   "build:v1alpha1" \
   --output-base "${TMP_DIR}/src" \

--- a/pkg/apis/build/v1alpha1/build_pod_test.go
+++ b/pkg/apis/build/v1alpha1/build_pod_test.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/kmeta"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 func TestBuildPod(t *testing.T) {
@@ -39,14 +39,14 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		},
 	}
 
-	builderImageRef := v1alpha1.BuildBuilderSpec{
+	builderImageRef := buildapi.BuildBuilderSpec{
 		Image: builderImage,
 		ImagePullSecrets: []corev1.LocalObjectReference{
 			{Name: "some-image-secret"},
 		},
 	}
 
-	build := &v1alpha1.Build{
+	build := &buildapi.Build{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      buildName,
 			Namespace: namespace,
@@ -57,18 +57,18 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 				"some/annotation": "to-pass-through",
 			},
 		},
-		Spec: v1alpha1.BuildSpec{
+		Spec: buildapi.BuildSpec{
 			Tags:           []string{"someimage/name", "someimage/name:tag2", "someimage/name:tag3"},
 			Builder:        builderImageRef,
 			ServiceAccount: serviceAccount,
-			Source: v1alpha1.SourceConfig{
-				Git: &v1alpha1.Git{
+			Source: buildapi.SourceConfig{
+				Git: &buildapi.Git{
 					URL:      "giturl.com/git.git",
 					Revision: "gitrev1234",
 				},
 			},
 			CacheName: "some-cache-name",
-			Bindings: []v1alpha1.Binding{
+			Bindings: []buildapi.Binding{
 				{
 					Name: "database",
 					MetadataRef: &corev1.LocalObjectReference{
@@ -90,7 +90,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 				{Name: "keyB", Value: "valueB"},
 			},
 			Resources: resources,
-			LastBuild: &v1alpha1.LastBuild{
+			LastBuild: &buildapi.LastBuild{
 				Image:   previousAppImage,
 				StackId: "com.builder.stack.io",
 			},
@@ -103,7 +103,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "git-secret-1",
 				Annotations: map[string]string{
-					v1alpha1.GITSecretAnnotationPrefix: "https://github.com",
+					buildapi.GITSecretAnnotationPrefix: "https://github.com",
 				},
 			},
 			StringData: map[string]string{
@@ -117,7 +117,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "git-secret-2",
 				Annotations: map[string]string{
-					v1alpha1.GITSecretAnnotationPrefix: "https://bitbucket.com",
+					buildapi.GITSecretAnnotationPrefix: "https://bitbucket.com",
 				},
 			},
 			StringData: map[string]string{
@@ -129,7 +129,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "docker-secret-1",
 				Annotations: map[string]string{
-					v1alpha1.DOCKERSecretAnnotationPrefix: "acr.io",
+					buildapi.DOCKERSecretAnnotationPrefix: "acr.io",
 				},
 			},
 			Type: corev1.SecretTypeBasicAuth,
@@ -156,21 +156,21 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "secret-to-ignore",
 				Annotations: map[string]string{
-					v1alpha1.DOCKERSecretAnnotationPrefix: "ignoreme.com",
+					buildapi.DOCKERSecretAnnotationPrefix: "ignoreme.com",
 				},
 			},
 			Type: corev1.SecretTypeBootstrapToken,
 		},
 	}
 
-	config := v1alpha1.BuildPodImages{
+	config := buildapi.BuildPodImages{
 		BuildInitImage:         "build/init:image",
 		BuildInitWindowsImage:  "build/init/windows:image",
 		CompletionImage:        "completion/image:image",
 		CompletionWindowsImage: "completion/image/windows:image",
 	}
 
-	buildPodBuilderConfig := v1alpha1.BuildPodBuilderConfig{
+	buildPodBuilderConfig := buildapi.BuildPodBuilderConfig{
 		StackID:      "com.builder.stack.io",
 		RunImage:     "builderregistry.io/run",
 		Uid:          2000,
@@ -423,7 +423,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 
 		it("configures prepare with the blob source", func() {
 			build.Spec.Source.Git = nil
-			build.Spec.Source.Blob = &v1alpha1.Blob{
+			build.Spec.Source.Blob = &buildapi.Blob{
 				URL: "https://some-blobstore.example.com/some-blob",
 			}
 			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
@@ -441,7 +441,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		it("configures prepare with the registry source and empty imagePullSecrets when not provided", func() {
 			build.Spec.Source.Git = nil
 			build.Spec.Source.Blob = nil
-			build.Spec.Source.Registry = &v1alpha1.Registry{
+			build.Spec.Source.Registry = &buildapi.Registry{
 				Image: "some-registry.io/some-image",
 			}
 			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
@@ -466,7 +466,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		it("configures prepare with the registry source and a secret volume when is imagePullSecrets provided", func() {
 			build.Spec.Source.Git = nil
 			build.Spec.Source.Blob = nil
-			build.Spec.Source.Registry = &v1alpha1.Registry{
+			build.Spec.Source.Registry = &buildapi.Registry{
 				Image: "some-registry.io/some-image",
 				ImagePullSecrets: []corev1.LocalObjectReference{
 					{Name: "registry-secret"},
@@ -564,7 +564,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("configures analyze step with the current tag if previous build is corrupted", func() {
-			build.Spec.LastBuild = &v1alpha1.LastBuild{}
+			build.Spec.LastBuild = &buildapi.LastBuild{}
 
 			pod, err := build.BuildPod(config, secrets, nil, buildPodBuilderConfig)
 			require.NoError(t, err)
@@ -768,8 +768,8 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 
 		when("creating a rebase pod", func() {
 			build.Annotations = map[string]string{
-				v1alpha1.BuildReasonAnnotation:  v1alpha1.BuildReasonStack,
-				v1alpha1.BuildChangesAnnotation: "some-stack-change",
+				buildapi.BuildReasonAnnotation:  buildapi.BuildReasonStack,
+				buildapi.BuildChangesAnnotation: "some-stack-change",
 				"some/annotation":               "to-pass-through",
 			}
 
@@ -786,8 +786,8 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 					},
 					Annotations: map[string]string{
 						"some/annotation":               "to-pass-through",
-						v1alpha1.BuildReasonAnnotation:  v1alpha1.BuildReasonStack,
-						v1alpha1.BuildChangesAnnotation: "some-stack-change",
+						buildapi.BuildReasonAnnotation:  buildapi.BuildReasonStack,
+						buildapi.BuildChangesAnnotation: "some-stack-change",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						*kmeta.NewControllerRef(build),
@@ -895,10 +895,10 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 
 			when("a notary config is present on the build", func() {
 				it("sets up the completion image to sign the image", func() {
-					build.Spec.Notary = &v1alpha1.NotaryConfig{
-						V1: &v1alpha1.NotaryV1Config{
+					build.Spec.Notary = &buildapi.NotaryConfig{
+						V1: &buildapi.NotaryV1Config{
 							URL: "some-notary-url",
-							SecretRef: v1alpha1.NotarySecretRef{
+							SecretRef: buildapi.NotarySecretRef{
 								Name: "some-notary-secret",
 							},
 						},
@@ -940,10 +940,10 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("a notary config is present on the build", func() {
-			build.Spec.Notary = &v1alpha1.NotaryConfig{
-				V1: &v1alpha1.NotaryV1Config{
+			build.Spec.Notary = &buildapi.NotaryConfig{
+				V1: &buildapi.NotaryV1Config{
 					URL: "some-notary-url",
-					SecretRef: v1alpha1.NotarySecretRef{
+					SecretRef: buildapi.NotarySecretRef{
 						Name: "some-notary-secret",
 					},
 				},
@@ -1233,7 +1233,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("configures the completion container for notary on windows", func() {
-				build.Spec.Notary = &v1alpha1.NotaryConfig{V1: &v1alpha1.NotaryV1Config{
+				build.Spec.Notary = &buildapi.NotaryConfig{V1: &buildapi.NotaryV1Config{
 					URL: "some-notary-server",
 				}}
 
@@ -1330,7 +1330,7 @@ func assertSecretNotPresent(t *testing.T, pod *corev1.Pod, secretName string) {
 
 func isSecretPresent(t *testing.T, pod *corev1.Pod, secretName string) bool {
 	for _, volume := range pod.Spec.Volumes {
-		if volume.Name == fmt.Sprintf(v1alpha1.SecretTemplateName, secretName) {
+		if volume.Name == fmt.Sprintf(buildapi.SecretTemplateName, secretName) {
 			assert.Equal(t, corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: secretName,

--- a/pkg/blob/resolver.go
+++ b/pkg/blob/resolver.go
@@ -3,21 +3,21 @@ package blob
 import (
 	"context"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 type Resolver struct {
 }
 
-func (*Resolver) Resolve(ctx context.Context, sourceResolver *v1alpha1.SourceResolver) (v1alpha1.ResolvedSourceConfig, error) {
-	return v1alpha1.ResolvedSourceConfig{
-		Blob: &v1alpha1.ResolvedBlobSource{
+func (*Resolver) Resolve(ctx context.Context, sourceResolver *buildapi.SourceResolver) (buildapi.ResolvedSourceConfig, error) {
+	return buildapi.ResolvedSourceConfig{
+		Blob: &buildapi.ResolvedBlobSource{
 			URL:     sourceResolver.Spec.Source.Blob.URL,
 			SubPath: sourceResolver.Spec.Source.SubPath,
 		},
 	}, nil
 }
 
-func (*Resolver) CanResolve(sourceResolver *v1alpha1.SourceResolver) bool {
+func (*Resolver) CanResolve(sourceResolver *buildapi.SourceResolver) bool {
 	return sourceResolver.IsBlob()
 }

--- a/pkg/buildchange/buildpack_change.go
+++ b/pkg/buildchange/buildpack_change.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
-func NewBuildpackChange(oldBuildpacks, newBuildpacks []v1alpha1.BuildpackInfo) Change {
+func NewBuildpackChange(oldBuildpacks, newBuildpacks []buildapi.BuildpackInfo) Change {
 	return buildpackChange{
 		old: oldBuildpacks,
 		new: newBuildpacks,
@@ -16,11 +16,11 @@ func NewBuildpackChange(oldBuildpacks, newBuildpacks []v1alpha1.BuildpackInfo) C
 }
 
 type buildpackChange struct {
-	old []v1alpha1.BuildpackInfo
-	new []v1alpha1.BuildpackInfo
+	old []buildapi.BuildpackInfo
+	new []buildapi.BuildpackInfo
 }
 
-func (b buildpackChange) Reason() v1alpha1.BuildReason { return v1alpha1.BuildReasonBuildpack }
+func (b buildpackChange) Reason() buildapi.BuildReason { return buildapi.BuildReasonBuildpack }
 
 func (b buildpackChange) IsBuildRequired() (bool, error) {
 	sort.Slice(b.old, func(i, j int) bool {

--- a/pkg/buildchange/change.go
+++ b/pkg/buildchange/change.go
@@ -1,11 +1,11 @@
 package buildchange
 
 import (
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 type Change interface {
-	Reason() v1alpha1.BuildReason
+	Reason() buildapi.BuildReason
 	IsBuildRequired() (bool, error)
 	Old() interface{}
 	New() interface{}

--- a/pkg/buildchange/change_logger_test.go
+++ b/pkg/buildchange/change_logger_test.go
@@ -12,7 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/buildchange"
 	"github.com/pivotal/kpack/pkg/reconciler/testhelpers"
 )
@@ -102,8 +102,8 @@ func testLog(t *testing.T, when spec.G, it spec.S) {
 							corev1.ResourceMemory: resourceQuantity(t, "512M"),
 						},
 					},
-					Source: v1alpha1.SourceConfig{
-						Git: &v1alpha1.Git{
+					Source: buildapi.SourceConfig{
+						Git: &buildapi.Git{
 							URL:      "some-git-url",
 							Revision: "some-git-revision",
 						},
@@ -126,10 +126,10 @@ func testLog(t *testing.T, when spec.G, it spec.S) {
 							corev1.ResourceMemory: resourceQuantity(t, "512M"),
 						},
 					},
-					Source: v1alpha1.SourceConfig{
-						Blob: &v1alpha1.Blob{URL: "some-blob-url"},
+					Source: buildapi.SourceConfig{
+						Blob: &buildapi.Blob{URL: "some-blob-url"},
 					},
-					Bindings: []v1alpha1.Binding{
+					Bindings: []buildapi.Binding{
 						{
 							Name: "binding-name",
 							MetadataRef: &corev1.LocalObjectReference{
@@ -192,7 +192,7 @@ func testLog(t *testing.T, when spec.G, it spec.S) {
 				LogTest{
 					changesStr: changesToStr(t, buildchange.GenericChange{
 						Reason: "BUILDPACK",
-						Old: []v1alpha1.BuildpackInfo{
+						Old: []buildapi.BuildpackInfo{
 							{Id: "another-buildpack-id", Version: "another-buildpack-old-version"},
 							{Id: "some-buildpack-id", Version: "some-buildpack-old-version"},
 						},
@@ -243,8 +243,8 @@ func testLog(t *testing.T, when spec.G, it spec.S) {
 						corev1.ResourceMemory: resourceQuantity(t, "512M"),
 					},
 				},
-				Source: v1alpha1.SourceConfig{
-					Git: &v1alpha1.Git{
+				Source: buildapi.SourceConfig{
+					Git: &buildapi.Git{
 						URL:      "some-git-url",
 						Revision: "some-git-revision",
 					},
@@ -267,10 +267,10 @@ func testLog(t *testing.T, when spec.G, it spec.S) {
 						corev1.ResourceMemory: resourceQuantity(t, "512M"),
 					},
 				},
-				Source: v1alpha1.SourceConfig{
-					Blob: &v1alpha1.Blob{URL: "some-blob-url"},
+				Source: buildapi.SourceConfig{
+					Blob: &buildapi.Blob{URL: "some-blob-url"},
 				},
-				Bindings: []v1alpha1.Binding{
+				Bindings: []buildapi.Binding{
 					{
 						Name: "binding-name",
 						MetadataRef: &corev1.LocalObjectReference{
@@ -349,11 +349,11 @@ func testLog(t *testing.T, when spec.G, it spec.S) {
 					},
 					buildchange.GenericChange{
 						Reason: "BUILDPACK",
-						Old: []v1alpha1.BuildpackInfo{
+						Old: []buildapi.BuildpackInfo{
 							{Id: "another-buildpack-id", Version: "another-buildpack-old-version"},
 							{Id: "some-buildpack-id", Version: "some-buildpack-old-version"},
 						},
-						New: []v1alpha1.BuildpackInfo{
+						New: []buildapi.BuildpackInfo{
 							{Id: "some-buildpack-id", Version: "some-buildpack-new-version"},
 						},
 					},

--- a/pkg/buildchange/change_processor_test.go
+++ b/pkg/buildchange/change_processor_test.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/buildchange"
 	"github.com/pivotal/kpack/pkg/reconciler/testhelpers"
 )
@@ -109,8 +109,8 @@ func testChangeProcessor(t *testing.T, when spec.G, it spec.S) {
 		when("CONFIG", func() {
 			when("has no difference", func() {
 				oldConfig := buildchange.Config{
-					Source: v1alpha1.SourceConfig{
-						Git: &v1alpha1.Git{
+					Source: buildapi.SourceConfig{
+						Git: &buildapi.Git{
 							URL:      "some-git-url",
 							Revision: "some-git-revision",
 						},
@@ -145,8 +145,8 @@ func testChangeProcessor(t *testing.T, when spec.G, it spec.S) {
 								corev1.ResourceMemory: resourceQuantity(t, "512M"),
 							},
 						},
-						Source: v1alpha1.SourceConfig{
-							Git: &v1alpha1.Git{
+						Source: buildapi.SourceConfig{
+							Git: &buildapi.Git{
 								URL:      "some-git-url",
 								Revision: "some-git-revision",
 							},
@@ -168,10 +168,10 @@ func testChangeProcessor(t *testing.T, when spec.G, it spec.S) {
 								corev1.ResourceMemory: resourceQuantity(t, "512M"),
 							},
 						},
-						Source: v1alpha1.SourceConfig{
-							Blob: &v1alpha1.Blob{URL: "some-blob-url"},
+						Source: buildapi.SourceConfig{
+							Blob: &buildapi.Blob{URL: "some-blob-url"},
 						},
-						Bindings: []v1alpha1.Binding{
+						Bindings: []buildapi.Binding{
 							{
 								Name: "binding-name",
 								MetadataRef: &corev1.LocalObjectReference{
@@ -274,7 +274,7 @@ func testChangeProcessor(t *testing.T, when spec.G, it spec.S) {
 
 		when("BUILDPACK", func() {
 			when("has no difference", func() {
-				oldBuildpacks := []v1alpha1.BuildpackInfo{
+				oldBuildpacks := []buildapi.BuildpackInfo{
 					{Id: "some-buildpack-id", Version: "some-buildpack-version"},
 				}
 				newBuildpacks := oldBuildpacks
@@ -291,11 +291,11 @@ func testChangeProcessor(t *testing.T, when spec.G, it spec.S) {
 
 			when("has difference", func() {
 				change := buildchange.NewBuildpackChange(
-					[]v1alpha1.BuildpackInfo{
+					[]buildapi.BuildpackInfo{
 						{Id: "another-buildpack-id", Version: "another-buildpack-old-version"},
 						{Id: "some-buildpack-id", Version: "some-buildpack-old-version"},
 					},
-					[]v1alpha1.BuildpackInfo{
+					[]buildapi.BuildpackInfo{
 						{Id: "some-buildpack-id", Version: "some-buildpack-new-version"},
 					})
 
@@ -403,11 +403,11 @@ func testChangeProcessor(t *testing.T, when spec.G, it spec.S) {
 			stackChange := buildchange.NewStackChange(oldRunImageRef, newRunImageRef)
 
 			buildpackChange := buildchange.NewBuildpackChange(
-				[]v1alpha1.BuildpackInfo{
+				[]buildapi.BuildpackInfo{
 					{Id: "another-buildpack-id", Version: "another-buildpack-old-version"},
 					{Id: "some-buildpack-id", Version: "some-buildpack-old-version"},
 				},
-				[]v1alpha1.BuildpackInfo{
+				[]buildapi.BuildpackInfo{
 					{Id: "some-buildpack-id", Version: "some-buildpack-new-version"},
 				})
 
@@ -427,8 +427,8 @@ func testChangeProcessor(t *testing.T, when spec.G, it spec.S) {
 							corev1.ResourceMemory: resourceQuantity(t, "512M"),
 						},
 					},
-					Source: v1alpha1.SourceConfig{
-						Git: &v1alpha1.Git{
+					Source: buildapi.SourceConfig{
+						Git: &buildapi.Git{
 							URL:      "some-git-url",
 							Revision: "some-git-revision",
 						},
@@ -450,10 +450,10 @@ func testChangeProcessor(t *testing.T, when spec.G, it spec.S) {
 							corev1.ResourceMemory: resourceQuantity(t, "512M"),
 						},
 					},
-					Source: v1alpha1.SourceConfig{
-						Blob: &v1alpha1.Blob{URL: "some-blob-url"},
+					Source: buildapi.SourceConfig{
+						Blob: &buildapi.Blob{URL: "some-blob-url"},
 					},
-					Bindings: []v1alpha1.Binding{
+					Bindings: []buildapi.Binding{
 						{
 							Name: "binding-name",
 							MetadataRef: &corev1.LocalObjectReference{

--- a/pkg/buildchange/commit_change.go
+++ b/pkg/buildchange/commit_change.go
@@ -1,6 +1,6 @@
 package buildchange
 
-import "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+import buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 
 func NewCommitChange(oldRevision, newRevision string) Change {
 	return commitChange{
@@ -14,7 +14,7 @@ type commitChange struct {
 	oldRevision string
 }
 
-func (c commitChange) Reason() v1alpha1.BuildReason { return v1alpha1.BuildReasonCommit }
+func (c commitChange) Reason() buildapi.BuildReason { return buildapi.BuildReasonCommit }
 
 func (c commitChange) IsBuildRequired() (bool, error) { return c.oldRevision != c.newRevision, nil }
 

--- a/pkg/buildchange/config_change.go
+++ b/pkg/buildchange/config_change.go
@@ -4,7 +4,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 func NewConfigChange(oldConfig, newConfig Config) Change {
@@ -22,11 +22,11 @@ type configChange struct {
 type Config struct {
 	Env       []corev1.EnvVar             `json:"env,omitempty"`
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
-	Bindings  v1alpha1.Bindings           `json:"bindings,omitempty"`
-	Source    v1alpha1.SourceConfig       `json:"source,omitempty"`
+	Bindings  buildapi.Bindings           `json:"bindings,omitempty"`
+	Source    buildapi.SourceConfig       `json:"source,omitempty"`
 }
 
-func (c configChange) Reason() v1alpha1.BuildReason { return v1alpha1.BuildReasonConfig }
+func (c configChange) Reason() buildapi.BuildReason { return buildapi.BuildReasonConfig }
 
 func (c configChange) IsBuildRequired() (bool, error) {
 	// Git revision changes are considered as COMMIT change

--- a/pkg/buildchange/stack_change.go
+++ b/pkg/buildchange/stack_change.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/pkg/errors"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 func NewStackChange(oldRunImageRefStr, newRunImageRefStr string) Change {
@@ -39,7 +39,7 @@ type stackChange struct {
 	err               error
 }
 
-func (s stackChange) Reason() v1alpha1.BuildReason { return v1alpha1.BuildReasonStack }
+func (s stackChange) Reason() buildapi.BuildReason { return buildapi.BuildReasonStack }
 
 func (s stackChange) IsBuildRequired() (bool, error) {
 	return s.oldRunImageDigest != s.newRunImageDigest, s.err

--- a/pkg/buildchange/trigger_change.go
+++ b/pkg/buildchange/trigger_change.go
@@ -3,7 +3,7 @@ package buildchange
 import (
 	"fmt"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 func NewTriggerChange(dateStr string) Change {
@@ -19,7 +19,7 @@ type triggerChange struct {
 	message string
 }
 
-func (t triggerChange) Reason() v1alpha1.BuildReason { return v1alpha1.BuildReasonTrigger }
+func (t triggerChange) Reason() buildapi.BuildReason { return buildapi.BuildReasonTrigger }
 
 func (t triggerChange) IsBuildRequired() (bool, error) {
 	return t.message != "", nil

--- a/pkg/buildpod/generator.go
+++ b/pkg/buildpod/generator.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "k8s.io/client-go/kubernetes"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/cnb"
 	"github.com/pivotal/kpack/pkg/registry"
 	"github.com/pivotal/kpack/pkg/registry/imagehelpers"
@@ -31,7 +31,7 @@ type ImageFetcher interface {
 }
 
 type Generator struct {
-	BuildPodConfig  v1alpha1.BuildPodImages
+	BuildPodConfig  buildapi.BuildPodImages
 	K8sClient       k8sclient.Interface
 	KeychainFactory registry.KeychainFactory
 	ImageFetcher    ImageFetcher
@@ -41,10 +41,10 @@ type BuildPodable interface {
 	GetName() string
 	GetNamespace() string
 	ServiceAccount() string
-	BuilderSpec() v1alpha1.BuildBuilderSpec
-	Bindings() []v1alpha1.Binding
+	BuilderSpec() buildapi.BuildBuilderSpec
+	Bindings() []buildapi.Binding
 
-	BuildPod(v1alpha1.BuildPodImages, []corev1.Secret, []corev1.Taint, v1alpha1.BuildPodBuilderConfig) (*corev1.Pod, error)
+	BuildPod(buildapi.BuildPodImages, []corev1.Secret, []corev1.Taint, buildapi.BuildPodBuilderConfig) (*corev1.Pod, error)
 }
 
 func (g *Generator) Generate(ctx context.Context, build BuildPodable) (*v1.Pod, error) {
@@ -120,48 +120,48 @@ func (g *Generator) fetchBuildSecrets(ctx context.Context, build BuildPodable) (
 	return secrets, nil
 }
 
-func (g *Generator) fetchBuilderConfig(ctx context.Context, build BuildPodable) (v1alpha1.BuildPodBuilderConfig, error) {
+func (g *Generator) fetchBuilderConfig(ctx context.Context, build BuildPodable) (buildapi.BuildPodBuilderConfig, error) {
 	keychain, err := g.KeychainFactory.KeychainForSecretRef(ctx, registry.SecretRef{
 		Namespace:        build.GetNamespace(),
 		ImagePullSecrets: build.BuilderSpec().ImagePullSecrets,
 		ServiceAccount:   build.ServiceAccount(),
 	})
 	if err != nil {
-		return v1alpha1.BuildPodBuilderConfig{}, errors.Wrap(err, "unable to create builder image keychain")
+		return buildapi.BuildPodBuilderConfig{}, errors.Wrap(err, "unable to create builder image keychain")
 	}
 
 	image, _, err := g.ImageFetcher.Fetch(keychain, build.BuilderSpec().Image)
 	if err != nil {
-		return v1alpha1.BuildPodBuilderConfig{}, errors.Wrap(err, "unable to fetch remote builder image")
+		return buildapi.BuildPodBuilderConfig{}, errors.Wrap(err, "unable to fetch remote builder image")
 	}
 
 	stackId, err := imagehelpers.GetStringLabel(image, lifecycle.StackIDLabel)
 	if err != nil {
-		return v1alpha1.BuildPodBuilderConfig{}, errors.Wrap(err, "builder image stack ID label not present")
+		return buildapi.BuildPodBuilderConfig{}, errors.Wrap(err, "builder image stack ID label not present")
 	}
 
 	var metadata cnb.BuilderImageMetadata
 	err = imagehelpers.GetLabel(image, cnb.BuilderMetadataLabel, &metadata)
 	if err != nil {
-		return v1alpha1.BuildPodBuilderConfig{}, errors.Wrap(err, "unable to get builder metadata")
+		return buildapi.BuildPodBuilderConfig{}, errors.Wrap(err, "unable to get builder metadata")
 	}
 
 	uid, err := parseCNBID(image, cnbUserId)
 	if err != nil {
-		return v1alpha1.BuildPodBuilderConfig{}, err
+		return buildapi.BuildPodBuilderConfig{}, err
 	}
 
 	gid, err := parseCNBID(image, cnbGroupId)
 	if err != nil {
-		return v1alpha1.BuildPodBuilderConfig{}, err
+		return buildapi.BuildPodBuilderConfig{}, err
 	}
 
 	config, err := image.ConfigFile()
 	if err != nil {
-		return v1alpha1.BuildPodBuilderConfig{}, err
+		return buildapi.BuildPodBuilderConfig{}, err
 	}
 
-	return v1alpha1.BuildPodBuilderConfig{
+	return buildapi.BuildPodBuilderConfig{
 		StackID:      stackId,
 		RunImage:     metadata.Stack.RunImage.Image,
 		PlatformAPIs: append(metadata.Lifecycle.APIs.Platform.Deprecated, metadata.Lifecycle.APIs.Platform.Supported...),

--- a/pkg/cnb/builder_builder.go
+++ b/pkg/cnb/builder_builder.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/pkg/errors"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/registry/imagehelpers"
 )
 
@@ -40,7 +40,7 @@ type builderBlder struct {
 	lifecycleImage    v1.Image
 	LifecycleMetadata LifecycleMetadata
 	stackId           string
-	order             []v1alpha1.OrderEntry
+	order             []buildapi.OrderEntry
 	buildpackLayers   map[DescriptiveBuildpackInfo]buildpackLayer
 	cnbUserId         int
 	cnbGroupId        int
@@ -65,7 +65,7 @@ func newBuilderBldr(lifecycleImage v1.Image, kpackVersion string) (*builderBlder
 	}, nil
 }
 
-func (bb *builderBlder) AddStack(baseImage v1.Image, clusterStack *v1alpha1.ClusterStack) error {
+func (bb *builderBlder) AddStack(baseImage v1.Image, clusterStack *buildapi.ClusterStack) error {
 	file, err := baseImage.ConfigFile()
 	if err != nil {
 		return err
@@ -82,7 +82,7 @@ func (bb *builderBlder) AddStack(baseImage v1.Image, clusterStack *v1alpha1.Clus
 }
 
 func (bb *builderBlder) AddGroup(buildpacks ...RemoteBuildpackRef) {
-	group := make([]v1alpha1.BuildpackRef, 0, len(buildpacks))
+	group := make([]buildapi.BuildpackRef, 0, len(buildpacks))
 	for _, b := range buildpacks {
 		group = append(group, b.buildpackRef())
 
@@ -90,7 +90,7 @@ func (bb *builderBlder) AddGroup(buildpacks ...RemoteBuildpackRef) {
 			bb.buildpackLayers[layer.BuildpackInfo] = layer
 		}
 	}
-	bb.order = append(bb.order, v1alpha1.OrderEntry{Group: group})
+	bb.order = append(bb.order, buildapi.OrderEntry{Group: group})
 }
 
 func (bb *builderBlder) WriteableImage() (v1.Image, error) {

--- a/pkg/cnb/buildpack_metadata.go
+++ b/pkg/cnb/buildpack_metadata.go
@@ -1,7 +1,7 @@
 package cnb
 
 import (
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 const (
@@ -16,13 +16,13 @@ const (
 type BuildpackLayerInfo struct {
 	API         string                    `json:"api"`
 	LayerDiffID string                    `json:"layerDiffID"`
-	Order       v1alpha1.Order            `json:"order,omitempty"`
-	Stacks      []v1alpha1.BuildpackStack `json:"stacks,omitempty"`
+	Order       buildapi.Order            `json:"order,omitempty"`
+	Stacks      []buildapi.BuildpackStack `json:"stacks,omitempty"`
 	Homepage    string                    `json:"homepage,omitempty"`
 }
 
 type DescriptiveBuildpackInfo struct {
-	v1alpha1.BuildpackInfo
+	buildapi.BuildpackInfo
 	Homepage string `json:"homepage,omitempty"`
 }
 

--- a/pkg/cnb/cnb_metadata.go
+++ b/pkg/cnb/cnb_metadata.go
@@ -12,7 +12,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/registry"
 	"github.com/pivotal/kpack/pkg/registry/imagehelpers"
 )
@@ -36,7 +36,7 @@ type RemoteMetadataRetriever struct {
 	ImageFetcher    ImageFetcher
 }
 
-func (r *RemoteMetadataRetriever) GetBuiltImage(ctx context.Context, build *v1alpha1.Build) (BuiltImage, error) {
+func (r *RemoteMetadataRetriever) GetBuiltImage(ctx context.Context, build *buildapi.Build) (BuiltImage, error) {
 	keychain, err := r.KeychainFactory.KeychainForSecretRef(ctx, registry.SecretRef{
 		ServiceAccount: build.Spec.ServiceAccount,
 		Namespace:      build.Namespace,

--- a/pkg/cnb/cnb_metadata_test.go
+++ b/pkg/cnb/cnb_metadata_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/cnb"
 	"github.com/pivotal/kpack/pkg/registry"
 	"github.com/pivotal/kpack/pkg/registry/imagehelpers"
@@ -26,20 +26,20 @@ func testMetadataRetriever(t *testing.T, when spec.G, it spec.S) {
 	var (
 		keychainFactory = &registryfakes.FakeKeychainFactory{}
 		imageFetcher    = registryfakes.NewFakeClient()
-		ctx = context.Background()
+		ctx             = context.Background()
 	)
 
 	when("RemoteMetadataRetriever", func() {
 		when("GetBuiltImage", func() {
-			var build = &v1alpha1.Build{
+			var build = &buildapi.Build{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "namespace-name",
 				},
-				Spec: v1alpha1.BuildSpec{
+				Spec: buildapi.BuildSpec{
 					Tags:           []string{"reg.io/appimage/name"},
 					ServiceAccount: "service-account",
 				},
-				Status: v1alpha1.BuildStatus{},
+				Status: buildapi.BuildStatus{},
 			}
 
 			when("images are built with lifecycle 0.5", func() {

--- a/pkg/cnb/create_builder.go
+++ b/pkg/cnb/create_builder.go
@@ -4,7 +4,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 type RegistryClient interface {
@@ -20,7 +20,7 @@ type LifecycleProvider interface {
 	GetImage() (v1.Image, error)
 }
 
-type NewBuildpackRepository func(clusterStore *v1alpha1.ClusterStore) BuildpackRepository
+type NewBuildpackRepository func(clusterStore *buildapi.ClusterStore) BuildpackRepository
 
 type RemoteBuilderCreator struct {
 	RegistryClient         RegistryClient
@@ -29,27 +29,27 @@ type RemoteBuilderCreator struct {
 	KpackVersion           string
 }
 
-func (r *RemoteBuilderCreator) CreateBuilder(keychain authn.Keychain, clusterStore *v1alpha1.ClusterStore, clusterStack *v1alpha1.ClusterStack, spec v1alpha1.BuilderSpec) (v1alpha1.BuilderRecord, error) {
+func (r *RemoteBuilderCreator) CreateBuilder(keychain authn.Keychain, clusterStore *buildapi.ClusterStore, clusterStack *buildapi.ClusterStack, spec buildapi.BuilderSpec) (buildapi.BuilderRecord, error) {
 	buildpackRepo := r.NewBuildpackRepository(clusterStore)
 
 	buildImage, _, err := r.RegistryClient.Fetch(keychain, clusterStack.Status.BuildImage.LatestImage)
 	if err != nil {
-		return v1alpha1.BuilderRecord{}, err
+		return buildapi.BuilderRecord{}, err
 	}
 
 	lifecycleImage, err := r.LifecycleProvider.GetImage()
 	if err != nil {
-		return v1alpha1.BuilderRecord{}, err
+		return buildapi.BuilderRecord{}, err
 	}
 
 	builderBldr, err := newBuilderBldr(lifecycleImage, r.KpackVersion)
 	if err != nil {
-		return v1alpha1.BuilderRecord{}, err
+		return buildapi.BuilderRecord{}, err
 	}
 
 	err = builderBldr.AddStack(buildImage, clusterStack)
 	if err != nil {
-		return v1alpha1.BuilderRecord{}, err
+		return buildapi.BuilderRecord{}, err
 	}
 
 	for _, group := range spec.Order {
@@ -58,7 +58,7 @@ func (r *RemoteBuilderCreator) CreateBuilder(keychain authn.Keychain, clusterSto
 		for _, buildpack := range group.Group {
 			remoteBuildpack, err := buildpackRepo.FindByIdAndVersion(buildpack.Id, buildpack.Version)
 			if err != nil {
-				return v1alpha1.BuilderRecord{}, err
+				return buildapi.BuilderRecord{}, err
 			}
 
 			buildpacks = append(buildpacks, remoteBuildpack.Optional(buildpack.Optional))
@@ -68,22 +68,22 @@ func (r *RemoteBuilderCreator) CreateBuilder(keychain authn.Keychain, clusterSto
 
 	writeableImage, err := builderBldr.WriteableImage()
 	if err != nil {
-		return v1alpha1.BuilderRecord{}, err
+		return buildapi.BuilderRecord{}, err
 	}
 
 	identifier, err := r.RegistryClient.Save(keychain, spec.Tag, writeableImage)
 	if err != nil {
-		return v1alpha1.BuilderRecord{}, err
+		return buildapi.BuilderRecord{}, err
 	}
 
 	config, err := writeableImage.ConfigFile()
 	if err != nil {
-		return v1alpha1.BuilderRecord{}, err
+		return buildapi.BuilderRecord{}, err
 	}
 
-	return v1alpha1.BuilderRecord{
+	return buildapi.BuilderRecord{
 		Image: identifier,
-		Stack: v1alpha1.BuildStack{
+		Stack: buildapi.BuildStack{
 			RunImage: clusterStack.Status.RunImage.LatestImage,
 			ID:       clusterStack.Status.Id,
 		},
@@ -95,10 +95,10 @@ func (r *RemoteBuilderCreator) CreateBuilder(keychain authn.Keychain, clusterSto
 	}, nil
 }
 
-func buildpackMetadata(buildpacks []DescriptiveBuildpackInfo) v1alpha1.BuildpackMetadataList {
-	m := make(v1alpha1.BuildpackMetadataList, 0, len(buildpacks))
+func buildpackMetadata(buildpacks []DescriptiveBuildpackInfo) buildapi.BuildpackMetadataList {
+	m := make(buildapi.BuildpackMetadataList, 0, len(buildpacks))
 	for _, b := range buildpacks {
-		m = append(m, v1alpha1.BuildpackMetadata{
+		m = append(m, buildapi.BuildpackMetadata{
 			Id:       b.Id,
 			Version:  b.Version,
 			Homepage: b.Homepage,

--- a/pkg/cnb/create_builder_test.go
+++ b/pkg/cnb/create_builder_test.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 	"github.com/pivotal/kpack/pkg/registry/imagehelpers"
 	"github.com/pivotal/kpack/pkg/registry/registryfakes"
@@ -59,7 +59,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 		keychain = authn.NewMultiKeychain(authn.DefaultKeychain)
 
 		buildpackRepository = &fakeBuildpackRepository{buildpacks: map[string][]buildpackLayer{}}
-		newBuildpackRepo    = func(store *v1alpha1.ClusterStore) BuildpackRepository {
+		newBuildpackRepo    = func(store *buildapi.ClusterStore) BuildpackRepository {
 			return buildpackRepository
 		}
 
@@ -91,41 +91,41 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 			size:   100,
 		}
 
-		store = &v1alpha1.ClusterStore{
+		store = &buildapi.ClusterStore{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name: "sample-store",
 			},
-			Status: v1alpha1.ClusterStoreStatus{
+			Status: buildapi.ClusterStoreStatus{
 				Status: corev1alpha1.Status{
 					ObservedGeneration: 10,
 				},
 			},
 		}
 
-		stack = &v1alpha1.ClusterStack{
+		stack = &buildapi.ClusterStack{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name: "sample-stack",
 			},
-			Spec: v1alpha1.ClusterStackSpec{
+			Spec: buildapi.ClusterStackSpec{
 				Id: stackID,
-				BuildImage: v1alpha1.ClusterStackSpecImage{
+				BuildImage: buildapi.ClusterStackSpecImage{
 					Image: buildImageTag,
 				},
-				RunImage: v1alpha1.ClusterStackSpecImage{
+				RunImage: buildapi.ClusterStackSpecImage{
 					Image: runImageTag,
 				},
 			},
-			Status: v1alpha1.ClusterStackStatus{
+			Status: buildapi.ClusterStackStatus{
 				Status: corev1alpha1.Status{
 					ObservedGeneration: 11,
 				},
-				ResolvedClusterStack: v1alpha1.ResolvedClusterStack{
+				ResolvedClusterStack: buildapi.ResolvedClusterStack{
 					Id: stackID,
-					BuildImage: v1alpha1.ClusterStackStatusImage{
+					BuildImage: buildapi.ClusterStackStatusImage{
 						LatestImage: buildImage,
 						Image:       buildImageTag,
 					},
-					RunImage: v1alpha1.ClusterStackStatusImage{
+					RunImage: buildapi.ClusterStackStatusImage{
 						LatestImage: runImage,
 						Image:       runImageTag,
 					},
@@ -136,7 +136,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 			},
 		}
 
-		clusterBuilderSpec = v1alpha1.BuilderSpec{
+		clusterBuilderSpec = buildapi.BuilderSpec{
 			Tag: "custom/example",
 			Stack: corev1.ObjectReference{
 				Kind: "Stack",
@@ -146,17 +146,17 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 				Name: "some-buildpackRepository",
 				Kind: "ClusterStore",
 			},
-			Order: []v1alpha1.OrderEntry{
+			Order: []buildapi.OrderEntry{
 				{
-					Group: []v1alpha1.BuildpackRef{
+					Group: []buildapi.BuildpackRef{
 						{
-							BuildpackInfo: v1alpha1.BuildpackInfo{
+							BuildpackInfo: buildapi.BuildpackInfo{
 								Id:      "io.buildpack.1",
 								Version: "v1",
 							},
 						},
 						{
-							BuildpackInfo: v1alpha1.BuildpackInfo{
+							BuildpackInfo: buildapi.BuildpackInfo{
 								Id:      "io.buildpack.2",
 								Version: "v2",
 							},
@@ -181,7 +181,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 		{
 			v1Layer: buildpack1Layer,
 			BuildpackInfo: DescriptiveBuildpackInfo{
-				BuildpackInfo: v1alpha1.BuildpackInfo{
+				BuildpackInfo: buildapi.BuildpackInfo{
 					Id:      "io.buildpack.1",
 					Version: "v1",
 				},
@@ -190,7 +190,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 			BuildpackLayerInfo: BuildpackLayerInfo{
 				API:         "0.2",
 				LayerDiffID: buildpack1Layer.diffID,
-				Stacks: []v1alpha1.BuildpackStack{
+				Stacks: []buildapi.BuildpackStack{
 					{
 						ID:     stackID,
 						Mixins: []string{mixin},
@@ -204,7 +204,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 		{
 			v1Layer: buildpack3Layer,
 			BuildpackInfo: DescriptiveBuildpackInfo{
-				BuildpackInfo: v1alpha1.BuildpackInfo{
+				BuildpackInfo: buildapi.BuildpackInfo{
 					Id:      "io.buildpack.3",
 					Version: "v3",
 				},
@@ -213,7 +213,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 			BuildpackLayerInfo: BuildpackLayerInfo{
 				API:         "0.3",
 				LayerDiffID: buildpack3Layer.diffID,
-				Stacks: []v1alpha1.BuildpackStack{
+				Stacks: []buildapi.BuildpackStack{
 					{
 						ID: stackID,
 					},
@@ -226,7 +226,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 		{
 			v1Layer: buildpack2Layer,
 			BuildpackInfo: DescriptiveBuildpackInfo{
-				BuildpackInfo: v1alpha1.BuildpackInfo{
+				BuildpackInfo: buildapi.BuildpackInfo{
 					Id:      "io.buildpack.2",
 					Version: "v2",
 				},
@@ -235,11 +235,11 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 			BuildpackLayerInfo: BuildpackLayerInfo{
 				API:         "0.3",
 				LayerDiffID: buildpack2Layer.diffID,
-				Order: v1alpha1.Order{
+				Order: buildapi.Order{
 					{
-						Group: []v1alpha1.BuildpackRef{
+						Group: []buildapi.BuildpackRef{
 							{
-								BuildpackInfo: v1alpha1.BuildpackInfo{
+								BuildpackInfo: buildapi.BuildpackInfo{
 									Id:      "io.buildpack.3",
 									Version: "v2",
 								},
@@ -313,23 +313,23 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 			require.NoError(t, err)
 
 			assert.Len(t, builderRecord.Buildpacks, 3)
-			assert.Contains(t, builderRecord.Buildpacks, v1alpha1.BuildpackMetadata{Id: "io.buildpack.1", Version: "v1", Homepage: "buildpack.1.com"})
-			assert.Contains(t, builderRecord.Buildpacks, v1alpha1.BuildpackMetadata{Id: "io.buildpack.2", Version: "v2", Homepage: "buildpack.2.com"})
-			assert.Contains(t, builderRecord.Buildpacks, v1alpha1.BuildpackMetadata{Id: "io.buildpack.3", Version: "v3", Homepage: "buildpack.3.com"})
-			assert.Equal(t, v1alpha1.BuildStack{RunImage: runImage, ID: stackID}, builderRecord.Stack)
+			assert.Contains(t, builderRecord.Buildpacks, buildapi.BuildpackMetadata{Id: "io.buildpack.1", Version: "v1", Homepage: "buildpack.1.com"})
+			assert.Contains(t, builderRecord.Buildpacks, buildapi.BuildpackMetadata{Id: "io.buildpack.2", Version: "v2", Homepage: "buildpack.2.com"})
+			assert.Contains(t, builderRecord.Buildpacks, buildapi.BuildpackMetadata{Id: "io.buildpack.3", Version: "v3", Homepage: "buildpack.3.com"})
+			assert.Equal(t, buildapi.BuildStack{RunImage: runImage, ID: stackID}, builderRecord.Stack)
 			assert.Equal(t, int64(10), builderRecord.ObservedStoreGeneration)
 			assert.Equal(t, int64(11), builderRecord.ObservedStackGeneration)
 			assert.Equal(t, os, builderRecord.OS)
 
-			assert.Equal(t, builderRecord.Order, []v1alpha1.OrderEntry{
+			assert.Equal(t, builderRecord.Order, []buildapi.OrderEntry{
 				{
-					Group: []v1alpha1.BuildpackRef{
+					Group: []buildapi.BuildpackRef{
 						{
-							BuildpackInfo: v1alpha1.BuildpackInfo{Id: "io.buildpack.1", Version: "v1"},
+							BuildpackInfo: buildapi.BuildpackInfo{Id: "io.buildpack.1", Version: "v1"},
 							Optional:      false,
 						},
 						{
-							BuildpackInfo: v1alpha1.BuildpackInfo{Id: "io.buildpack.2", Version: "v2"},
+							BuildpackInfo: buildapi.BuildpackInfo{Id: "io.buildpack.2", Version: "v2"},
 							Optional:      true,
 						},
 					},
@@ -589,7 +589,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 					{
 						v1Layer: buildpack1Layer,
 						BuildpackInfo: DescriptiveBuildpackInfo{
-							BuildpackInfo: v1alpha1.BuildpackInfo{
+							BuildpackInfo: buildapi.BuildpackInfo{
 								Id:      "io.buildpack.unsupported.stack",
 								Version: "v4",
 							},
@@ -598,7 +598,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 						BuildpackLayerInfo: BuildpackLayerInfo{
 							API:         "0.2",
 							LayerDiffID: buildpack1Layer.diffID,
-							Stacks: []v1alpha1.BuildpackStack{
+							Stacks: []buildapi.BuildpackStack{
 								{
 									ID: "io.buildpacks.stacks.unsupported",
 								},
@@ -607,11 +607,11 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 					},
 				})
 
-				clusterBuilderSpec.Order = []v1alpha1.OrderEntry{
+				clusterBuilderSpec.Order = []buildapi.OrderEntry{
 					{
-						Group: []v1alpha1.BuildpackRef{
+						Group: []buildapi.BuildpackRef{
 							{
-								BuildpackInfo: v1alpha1.BuildpackInfo{
+								BuildpackInfo: buildapi.BuildpackInfo{
 									Id:      "io.buildpack.unsupported.stack",
 									Version: "v4",
 								},
@@ -629,7 +629,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 					{
 						v1Layer: buildpack1Layer,
 						BuildpackInfo: DescriptiveBuildpackInfo{
-							BuildpackInfo: v1alpha1.BuildpackInfo{
+							BuildpackInfo: buildapi.BuildpackInfo{
 								Id:      "io.buildpack.unsupported.mixin",
 								Version: "v4",
 							},
@@ -638,7 +638,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 						BuildpackLayerInfo: BuildpackLayerInfo{
 							API:         "0.2",
 							LayerDiffID: buildpack1Layer.diffID,
-							Stacks: []v1alpha1.BuildpackStack{
+							Stacks: []buildapi.BuildpackStack{
 								{
 									ID:     stackID,
 									Mixins: []string{mixin, "something-missing-mixin", "something-missing-mixin2"},
@@ -648,11 +648,11 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 					},
 				})
 
-				clusterBuilderSpec.Order = []v1alpha1.OrderEntry{
+				clusterBuilderSpec.Order = []buildapi.OrderEntry{
 					{
-						Group: []v1alpha1.BuildpackRef{
+						Group: []buildapi.BuildpackRef{
 							{
-								BuildpackInfo: v1alpha1.BuildpackInfo{
+								BuildpackInfo: buildapi.BuildpackInfo{
 									Id:      "io.buildpack.unsupported.mixin",
 									Version: "v4",
 								},
@@ -670,7 +670,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 					{
 						v1Layer: buildpack1Layer,
 						BuildpackInfo: DescriptiveBuildpackInfo{
-							BuildpackInfo: v1alpha1.BuildpackInfo{
+							BuildpackInfo: buildapi.BuildpackInfo{
 								Id:      "io.buildpack.unsupported.buildpack.api",
 								Version: "v4",
 							},
@@ -679,7 +679,7 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 						BuildpackLayerInfo: BuildpackLayerInfo{
 							API:         "0.1",
 							LayerDiffID: buildpack1Layer.diffID,
-							Stacks: []v1alpha1.BuildpackStack{
+							Stacks: []buildapi.BuildpackStack{
 								{
 									ID: stackID,
 								},
@@ -688,11 +688,11 @@ func testCreateBuilderOs(os string, t *testing.T, when spec.G, it spec.S) {
 					},
 				})
 
-				clusterBuilderSpec.Order = []v1alpha1.OrderEntry{
+				clusterBuilderSpec.Order = []buildapi.OrderEntry{
 					{
-						Group: []v1alpha1.BuildpackRef{
+						Group: []buildapi.BuildpackRef{
 							{
-								BuildpackInfo: v1alpha1.BuildpackInfo{
+								BuildpackInfo: buildapi.BuildpackInfo{
 									Id:      "io.buildpack.unsupported.buildpack.api",
 									Version: "v4",
 								},

--- a/pkg/cnb/mountable_buildpack_layer.go
+++ b/pkg/cnb/mountable_buildpack_layer.go
@@ -12,10 +12,10 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/pkg/errors"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
-func layerFromStoreBuildpack(keychain authn.Keychain, buildpack v1alpha1.StoreBuildpack) (v1.Layer, error) {
+func layerFromStoreBuildpack(keychain authn.Keychain, buildpack buildapi.StoreBuildpack) (v1.Layer, error) {
 	reference, err := name.ParseReference(buildpack.StoreImage.Image)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to parse %s", buildpack.StoreImage.Image)

--- a/pkg/cnb/mountable_buildpack_layer_test.go
+++ b/pkg/cnb/mountable_buildpack_layer_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 func TestMountableBuildpackLayer(t *testing.T) {
@@ -64,13 +64,13 @@ func testMountableBuildpackLayer(t *testing.T, when spec.G, it spec.S) {
 			io.Copy(writer, compressed)
 		})
 
-		layer, err = layerFromStoreBuildpack(authn.DefaultKeychain, v1alpha1.StoreBuildpack{
-			BuildpackInfo: v1alpha1.BuildpackInfo{
+		layer, err = layerFromStoreBuildpack(authn.DefaultKeychain, buildapi.StoreBuildpack{
+			BuildpackInfo: buildapi.BuildpackInfo{
 				Id:      "id.buildpack",
 				Version: "1.0",
 			},
 			DiffId: diffID.String(),
-			StoreImage: v1alpha1.StoreImage{
+			StoreImage: buildapi.StoreImage{
 				Image: tagName,
 			},
 			Digest: digest.String(),

--- a/pkg/cnb/remote_buildpack_metadata.go
+++ b/pkg/cnb/remote_buildpack_metadata.go
@@ -2,7 +2,7 @@ package cnb
 
 import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 type RemoteBuildpackInfo struct {
@@ -24,8 +24,8 @@ type RemoteBuildpackRef struct {
 	Layers                   []buildpackLayer
 }
 
-func (r RemoteBuildpackRef) buildpackRef() v1alpha1.BuildpackRef {
-	return v1alpha1.BuildpackRef{
+func (r RemoteBuildpackRef) buildpackRef() buildapi.BuildpackRef {
+	return buildapi.BuildpackRef{
 		BuildpackInfo: r.DescriptiveBuildpackInfo.BuildpackInfo,
 		Optional:      r.Optional,
 	}

--- a/pkg/cnb/remote_stack_reader.go
+++ b/pkg/cnb/remote_stack_reader.go
@@ -8,7 +8,7 @@ import (
 	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/pkg/errors"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/registry/imagehelpers"
 )
 
@@ -25,51 +25,51 @@ type RemoteStackReader struct {
 	Keychain       authn.Keychain
 }
 
-func (r *RemoteStackReader) Read(clusterStackSpec v1alpha1.ClusterStackSpec) (v1alpha1.ResolvedClusterStack, error) {
+func (r *RemoteStackReader) Read(clusterStackSpec buildapi.ClusterStackSpec) (buildapi.ResolvedClusterStack, error) {
 	buildImage, buildIdentifier, err := r.RegistryClient.Fetch(r.Keychain, clusterStackSpec.BuildImage.Image)
 	if err != nil {
-		return v1alpha1.ResolvedClusterStack{}, err
+		return buildapi.ResolvedClusterStack{}, err
 	}
 
 	runImage, runIdentifier, err := r.RegistryClient.Fetch(r.Keychain, clusterStackSpec.RunImage.Image)
 	if err != nil {
-		return v1alpha1.ResolvedClusterStack{}, err
+		return buildapi.ResolvedClusterStack{}, err
 	}
 
 	err = validateStackId(clusterStackSpec.Id, buildImage, runImage)
 	if err != nil {
-		return v1alpha1.ResolvedClusterStack{}, err
+		return buildapi.ResolvedClusterStack{}, err
 	}
 
 	userId, err := parseCNBID(buildImage, cnbUserId)
 	if err != nil {
-		return v1alpha1.ResolvedClusterStack{}, errors.Wrap(err, "validating build image")
+		return buildapi.ResolvedClusterStack{}, errors.Wrap(err, "validating build image")
 	}
 
 	groupId, err := parseCNBID(buildImage, cnbGroupId)
 	if err != nil {
-		return v1alpha1.ResolvedClusterStack{}, errors.Wrap(err, "validating build image")
+		return buildapi.ResolvedClusterStack{}, errors.Wrap(err, "validating build image")
 	}
 
 	buildMixins, err := readMixins(buildImage)
 	if err != nil {
-		return v1alpha1.ResolvedClusterStack{}, err
+		return buildapi.ResolvedClusterStack{}, err
 	}
 
 	runMixins, err := readMixins(runImage)
 	if err != nil {
-		return v1alpha1.ResolvedClusterStack{}, err
+		return buildapi.ResolvedClusterStack{}, err
 	}
 
 	mixins, err := mixins(buildMixins, runMixins)
 
-	return v1alpha1.ResolvedClusterStack{
+	return buildapi.ResolvedClusterStack{
 		Id: clusterStackSpec.Id,
-		BuildImage: v1alpha1.ClusterStackStatusImage{
+		BuildImage: buildapi.ClusterStackStatusImage{
 			LatestImage: buildIdentifier,
 			Image:       clusterStackSpec.BuildImage.Image,
 		},
-		RunImage: v1alpha1.ClusterStackStatusImage{
+		RunImage: buildapi.ClusterStackStatusImage{
 			LatestImage: runIdentifier,
 			Image:       clusterStackSpec.RunImage.Image,
 		},

--- a/pkg/cnb/remote_stack_reader_test.go
+++ b/pkg/cnb/remote_stack_reader_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/cnb"
 	"github.com/pivotal/kpack/pkg/registry/imagehelpers"
 	"github.com/pivotal/kpack/pkg/registry/registryfakes"
@@ -46,12 +46,12 @@ func testRemoteStackReader(t *testing.T, when spec.G, it spec.S) {
 			fakeClient.AddImage(runTag, runImage, expectedKeychain)
 			fakeClient.AddImage(buildTag, buildImage, expectedKeychain)
 
-			resolvedStack, err := remoteStackReader.Read(v1alpha1.ClusterStackSpec{
+			resolvedStack, err := remoteStackReader.Read(buildapi.ClusterStackSpec{
 				Id: "org.some.stack",
-				BuildImage: v1alpha1.ClusterStackSpecImage{
+				BuildImage: buildapi.ClusterStackSpecImage{
 					Image: buildTag,
 				},
-				RunImage: v1alpha1.ClusterStackSpecImage{
+				RunImage: buildapi.ClusterStackSpecImage{
 					Image: runTag,
 				},
 			})
@@ -63,13 +63,13 @@ func testRemoteStackReader(t *testing.T, when spec.G, it spec.S) {
 			buildDigest, err := buildImage.Digest()
 			require.NoError(t, err)
 
-			assert.Equal(t, v1alpha1.ResolvedClusterStack{
+			assert.Equal(t, buildapi.ResolvedClusterStack{
 				Id: stackId,
-				BuildImage: v1alpha1.ClusterStackStatusImage{
+				BuildImage: buildapi.ClusterStackStatusImage{
 					LatestImage: fmt.Sprintf("%s@%s", buildTag, buildDigest),
 					Image:       buildTag,
 				},
-				RunImage: v1alpha1.ClusterStackStatusImage{
+				RunImage: buildapi.ClusterStackStatusImage{
 					LatestImage: fmt.Sprintf("%s@%s", runTag, runDigest),
 					Image:       runTag,
 				},
@@ -88,12 +88,12 @@ func testRemoteStackReader(t *testing.T, when spec.G, it spec.S) {
 				fakeClient.AddImage(runTag, runImage, expectedKeychain)
 				fakeClient.AddImage(buildTag, buildImage, expectedKeychain)
 
-				_, err := remoteStackReader.Read(v1alpha1.ClusterStackSpec{
+				_, err := remoteStackReader.Read(buildapi.ClusterStackSpec{
 					Id: "org.some.stack",
-					BuildImage: v1alpha1.ClusterStackSpecImage{
+					BuildImage: buildapi.ClusterStackSpecImage{
 						Image: buildTag,
 					},
-					RunImage: v1alpha1.ClusterStackSpecImage{
+					RunImage: buildapi.ClusterStackSpecImage{
 						Image: runTag,
 					},
 				})
@@ -107,12 +107,12 @@ func testRemoteStackReader(t *testing.T, when spec.G, it spec.S) {
 				fakeClient.AddImage(runTag, runImage, expectedKeychain)
 				fakeClient.AddImage(buildTag, buildImage, expectedKeychain)
 
-				_, err := remoteStackReader.Read(v1alpha1.ClusterStackSpec{
+				_, err := remoteStackReader.Read(buildapi.ClusterStackSpec{
 					Id: "org.some.stack",
-					BuildImage: v1alpha1.ClusterStackSpecImage{
+					BuildImage: buildapi.ClusterStackSpecImage{
 						Image: buildTag,
 					},
-					RunImage: v1alpha1.ClusterStackSpecImage{
+					RunImage: buildapi.ClusterStackSpecImage{
 						Image: runTag,
 					},
 				})
@@ -126,12 +126,12 @@ func testRemoteStackReader(t *testing.T, when spec.G, it spec.S) {
 				fakeClient.AddImage(runTag, runImage, expectedKeychain)
 				fakeClient.AddImage(buildTag, buildImage, expectedKeychain)
 
-				_, err := remoteStackReader.Read(v1alpha1.ClusterStackSpec{
+				_, err := remoteStackReader.Read(buildapi.ClusterStackSpec{
 					Id: "org.some.stack",
-					BuildImage: v1alpha1.ClusterStackSpecImage{
+					BuildImage: buildapi.ClusterStackSpecImage{
 						Image: buildTag,
 					},
-					RunImage: v1alpha1.ClusterStackSpecImage{
+					RunImage: buildapi.ClusterStackSpecImage{
 						Image: runTag,
 					},
 				})
@@ -145,12 +145,12 @@ func testRemoteStackReader(t *testing.T, when spec.G, it spec.S) {
 				fakeClient.AddImage(runTag, runImage, expectedKeychain)
 				fakeClient.AddImage(buildTag, buildImage, expectedKeychain)
 
-				_, err := remoteStackReader.Read(v1alpha1.ClusterStackSpec{
+				_, err := remoteStackReader.Read(buildapi.ClusterStackSpec{
 					Id: "org.some.stack",
-					BuildImage: v1alpha1.ClusterStackSpecImage{
+					BuildImage: buildapi.ClusterStackSpecImage{
 						Image: buildTag,
 					},
-					RunImage: v1alpha1.ClusterStackSpecImage{
+					RunImage: buildapi.ClusterStackSpecImage{
 						Image: runTag,
 					},
 				})
@@ -164,12 +164,12 @@ func testRemoteStackReader(t *testing.T, when spec.G, it spec.S) {
 				fakeClient.AddImage(runTag, runImage, expectedKeychain)
 				fakeClient.AddImage(buildTag, buildImage, expectedKeychain)
 
-				_, err := remoteStackReader.Read(v1alpha1.ClusterStackSpec{
+				_, err := remoteStackReader.Read(buildapi.ClusterStackSpec{
 					Id: "org.some.stack",
-					BuildImage: v1alpha1.ClusterStackSpecImage{
+					BuildImage: buildapi.ClusterStackSpecImage{
 						Image: buildTag,
 					},
-					RunImage: v1alpha1.ClusterStackSpecImage{
+					RunImage: buildapi.ClusterStackSpecImage{
 						Image: runTag,
 					},
 				})
@@ -181,12 +181,12 @@ func testRemoteStackReader(t *testing.T, when spec.G, it spec.S) {
 
 				fakeClient.AddImage(runTag, runImage, expectedKeychain)
 
-				_, err := remoteStackReader.Read(v1alpha1.ClusterStackSpec{
+				_, err := remoteStackReader.Read(buildapi.ClusterStackSpec{
 					Id: "org.some.stack",
-					BuildImage: v1alpha1.ClusterStackSpecImage{
+					BuildImage: buildapi.ClusterStackSpecImage{
 						Image: runTag,
 					},
-					RunImage: v1alpha1.ClusterStackSpecImage{
+					RunImage: buildapi.ClusterStackSpecImage{
 						Image: runTag,
 					},
 				})

--- a/pkg/cnb/remote_store_reader.go
+++ b/pkg/cnb/remote_store_reader.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/registry/imagehelpers"
 )
 
@@ -17,10 +17,10 @@ type RemoteStoreReader struct {
 	Keychain       authn.Keychain
 }
 
-func (r *RemoteStoreReader) Read(storeImages []v1alpha1.StoreImage) ([]v1alpha1.StoreBuildpack, error) {
+func (r *RemoteStoreReader) Read(storeImages []buildapi.StoreImage) ([]buildapi.StoreBuildpack, error) {
 	var g errgroup.Group
 
-	c := make(chan v1alpha1.StoreBuildpack)
+	c := make(chan buildapi.StoreBuildpack)
 	for _, storeImage := range storeImages {
 		storeImageCopy := storeImage
 		g.Go(func() error {
@@ -47,13 +47,13 @@ func (r *RemoteStoreReader) Read(storeImages []v1alpha1.StoreImage) ([]v1alpha1.
 
 			for id := range layerMetadata {
 				for version, metadata := range layerMetadata[id] {
-					packageInfo := v1alpha1.BuildpackageInfo{
+					packageInfo := buildapi.BuildpackageInfo{
 						Id:       bpMetadata.Id,
 						Version:  bpMetadata.Version,
 						Homepage: bpMetadata.Homepage,
 					}
 
-					info := v1alpha1.BuildpackInfo{
+					info := buildapi.BuildpackInfo{
 						Id:      id,
 						Version: version,
 					}
@@ -78,7 +78,7 @@ func (r *RemoteStoreReader) Read(storeImages []v1alpha1.StoreImage) ([]v1alpha1.
 						return errors.Wrapf(err, "unable to get layer %s digest", info)
 					}
 
-					c <- v1alpha1.StoreBuildpack{
+					c <- buildapi.StoreBuildpack{
 						BuildpackInfo: info,
 						Buildpackage:  packageInfo,
 						StoreImage:    storeImageCopy,
@@ -101,7 +101,7 @@ func (r *RemoteStoreReader) Read(storeImages []v1alpha1.StoreImage) ([]v1alpha1.
 		close(c)
 	}()
 
-	var buildpacks []v1alpha1.StoreBuildpack
+	var buildpacks []buildapi.StoreBuildpack
 	for b := range c {
 		buildpacks = append(buildpacks, b)
 	}

--- a/pkg/cnb/remote_store_reader_test.go
+++ b/pkg/cnb/remote_store_reader_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sclevine/spec"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/registry/imagehelpers"
 	"github.com/pivotal/kpack/pkg/registry/registryfakes"
 )
@@ -206,7 +206,7 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("returns all buildpacks from multiple images", func() {
-			storeBuildpacks, err := remoteStoreReader.Read([]v1alpha1.StoreImage{
+			storeBuildpacks, err := remoteStoreReader.Read([]buildapi.StoreImage{
 				{
 					Image: buildpackageA,
 				},
@@ -217,22 +217,22 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 			require.NoError(t, err)
 
 			require.Len(t, storeBuildpacks, 4)
-			require.Contains(t, storeBuildpacks, v1alpha1.StoreBuildpack{
-				BuildpackInfo: v1alpha1.BuildpackInfo{
+			require.Contains(t, storeBuildpacks, buildapi.StoreBuildpack{
+				BuildpackInfo: buildapi.BuildpackInfo{
 					Id:      "org.buildpack.multi",
 					Version: "0.0.1",
 				},
-				Buildpackage: v1alpha1.BuildpackageInfo{
+				Buildpackage: buildapi.BuildpackageInfo{
 					Id:       "org.buildpack.meta",
 					Version:  "0.0.2",
 					Homepage: "some-homepage",
 				},
-				StoreImage: v1alpha1.StoreImage{
+				StoreImage: buildapi.StoreImage{
 					Image: buildpackageA,
 				},
 				API:      "0.2",
 				Homepage: "buildpack.multi.com/v1",
-				Stacks: []v1alpha1.BuildpackStack{
+				Stacks: []buildapi.BuildpackStack{
 					{
 						ID:     "org.some.stack",
 						Mixins: []string{"multi:mixin"},
@@ -245,22 +245,22 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 				Digest: "sha256:52f341c7c36e21e5c344856dd61bc8c2d1188647f259eaba6d375e37c9aed08e",
 				Size:   20,
 			})
-			require.Contains(t, storeBuildpacks, v1alpha1.StoreBuildpack{
-				BuildpackInfo: v1alpha1.BuildpackInfo{
+			require.Contains(t, storeBuildpacks, buildapi.StoreBuildpack{
+				BuildpackInfo: buildapi.BuildpackInfo{
 					Id:      "org.buildpack.multi",
 					Version: "0.0.2",
 				},
-				Buildpackage: v1alpha1.BuildpackageInfo{
+				Buildpackage: buildapi.BuildpackageInfo{
 					Id:       "org.buildpack.meta",
 					Version:  "0.0.2",
 					Homepage: "some-homepage",
 				},
-				StoreImage: v1alpha1.StoreImage{
+				StoreImage: buildapi.StoreImage{
 					Image: buildpackageA,
 				},
 				API:      "0.2",
 				Homepage: "buildpack.multi.com/v2",
-				Stacks: []v1alpha1.BuildpackStack{
+				Stacks: []buildapi.BuildpackStack{
 					{
 						ID:     "org.some.stack",
 						Mixins: []string{"multi:mixin"},
@@ -275,26 +275,26 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			require.Contains(t, storeBuildpacks,
-				v1alpha1.StoreBuildpack{
-					BuildpackInfo: v1alpha1.BuildpackInfo{
+				buildapi.StoreBuildpack{
+					BuildpackInfo: buildapi.BuildpackInfo{
 						Id:      "org.buildpack.meta",
 						Version: "0.0.2",
 					},
-					Buildpackage: v1alpha1.BuildpackageInfo{
+					Buildpackage: buildapi.BuildpackageInfo{
 						Id:       "org.buildpack.meta",
 						Version:  "0.0.2",
 						Homepage: "some-homepage",
 					},
-					StoreImage: v1alpha1.StoreImage{
+					StoreImage: buildapi.StoreImage{
 						Image: buildpackageA,
 					},
 					API:      "0.2",
 					Homepage: "buildpack.meta.com",
-					Order: []v1alpha1.OrderEntry{
+					Order: []buildapi.OrderEntry{
 						{
-							Group: []v1alpha1.BuildpackRef{
+							Group: []buildapi.BuildpackRef{
 								{
-									BuildpackInfo: v1alpha1.BuildpackInfo{
+									BuildpackInfo: buildapi.BuildpackInfo{
 										Id:      "org.buildpack.multi",
 										Version: "0.0.1",
 									},
@@ -302,9 +302,9 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 							},
 						},
 						{
-							Group: []v1alpha1.BuildpackRef{
+							Group: []buildapi.BuildpackRef{
 								{
-									BuildpackInfo: v1alpha1.BuildpackInfo{
+									BuildpackInfo: buildapi.BuildpackInfo{
 										Id:      "org.buildpack.multi",
 										Version: "0.0.2",
 									},
@@ -312,7 +312,7 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 							},
 						},
 					},
-					Stacks: []v1alpha1.BuildpackStack{
+					Stacks: []buildapi.BuildpackStack{
 						{
 							ID:     "org.some.stack",
 							Mixins: []string{"meta:mixin"},
@@ -326,12 +326,12 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 					Size:   10,
 				})
 
-			require.Contains(t, storeBuildpacks, v1alpha1.StoreBuildpack{
-				BuildpackInfo: v1alpha1.BuildpackInfo{
+			require.Contains(t, storeBuildpacks, buildapi.StoreBuildpack{
+				BuildpackInfo: buildapi.BuildpackInfo{
 					Id:      "org.buildpack.simple",
 					Version: "0.0.1",
 				},
-				Buildpackage: v1alpha1.BuildpackageInfo{
+				Buildpackage: buildapi.BuildpackageInfo{
 					Id:       "org.buildpack.simple",
 					Version:  "0.0.1",
 					Homepage: "some-homepage",
@@ -341,7 +341,7 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 				Size:     40,
 				API:      "0.2",
 				Homepage: "buildpack.simple.com",
-				Stacks: []v1alpha1.BuildpackStack{
+				Stacks: []buildapi.BuildpackStack{
 					{
 						ID:     "org.some.stack",
 						Mixins: []string{"simple:mixin"},
@@ -350,14 +350,14 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 						ID: "org.simple.only.stack",
 					},
 				},
-				StoreImage: v1alpha1.StoreImage{
+				StoreImage: buildapi.StoreImage{
 					Image: buildpackageB,
 				},
 			})
 		})
 
 		it("returns all buildpacks in a deterministic order", func() {
-			expectedBuildpackOrder, err := remoteStoreReader.Read([]v1alpha1.StoreImage{
+			expectedBuildpackOrder, err := remoteStoreReader.Read([]buildapi.StoreImage{
 				{
 					Image: buildpackageA,
 				},
@@ -368,7 +368,7 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 			require.NoError(t, err)
 
 			for i := 1; i <= 50; i++ {
-				subsequentOrder, err := remoteStoreReader.Read([]v1alpha1.StoreImage{
+				subsequentOrder, err := remoteStoreReader.Read([]buildapi.StoreImage{
 					{
 						Image: buildpackageA,
 					},
@@ -435,7 +435,7 @@ func testRemoteStoreReader(t *testing.T, when spec.G, it spec.S) {
 
 			fakeClient.AddImage("image/with_duplicates", imageWithDuplicates, expectedKeychain)
 
-			images := []v1alpha1.StoreImage{
+			images := []buildapi.StoreImage{
 				{
 					Image: buildpackageA,
 				},

--- a/pkg/cnb/store_buildpack_repository_test.go
+++ b/pkg/cnb/store_buildpack_repository_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 func TestBuildpackRepository(t *testing.T) {
@@ -17,21 +17,21 @@ func TestBuildpackRepository(t *testing.T) {
 
 func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 	when("FindByIdAndVersion", func() {
-		engineBuildpack := v1alpha1.StoreBuildpack{
-			BuildpackInfo: v1alpha1.BuildpackInfo{
+		engineBuildpack := buildapi.StoreBuildpack{
+			BuildpackInfo: buildapi.BuildpackInfo{
 				Id:      "io.buildpack.engine",
 				Version: "1.0.0",
 			},
 			DiffId: "sha256:1bf8899667b8d1e6b124f663faca32903b470831e5e4e992644ac5c839ab3462",
 			Digest: "sha256:d345d1b12ae6b3f7cfc617f7adaebe06c32ce60b1aa30bb80fb622b65523de8f",
 			Size:   50,
-			StoreImage: v1alpha1.StoreImage{
+			StoreImage: buildapi.StoreImage{
 				Image: "some.registry.io/build-package",
 			},
 			Order:    nil,
 			Homepage: "buildpack.engine.com",
 			API:      "0.1",
-			Stacks: []v1alpha1.BuildpackStack{
+			Stacks: []buildapi.BuildpackStack{
 				{
 					ID: "io.custom.stack",
 				},
@@ -41,21 +41,21 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 			},
 		}
 
-		packageManagerBuildpack := v1alpha1.StoreBuildpack{
-			BuildpackInfo: v1alpha1.BuildpackInfo{
+		packageManagerBuildpack := buildapi.StoreBuildpack{
+			BuildpackInfo: buildapi.BuildpackInfo{
 				Id:      "io.buildpack.package-manager",
 				Version: "1.0.0",
 			},
 			DiffId: "sha256:2bf8899667b8d1e6b124f663faca32903b470831e5e4e992644ac5c839ab3462",
 			Digest: "sha256:7c1213a54d20137a7479e72150c058268a6604b98c011b4fc11ca45927923d7b",
 			Size:   40,
-			StoreImage: v1alpha1.StoreImage{
+			StoreImage: buildapi.StoreImage{
 				Image: "some.registry.io/build-package",
 			},
 			Order:    nil,
 			Homepage: "buildpack.package-manager.com",
 			API:      "0.2",
-			Stacks: []v1alpha1.BuildpackStack{
+			Stacks: []buildapi.BuildpackStack{
 				{
 					ID: "io.custom.stack",
 				},
@@ -65,29 +65,29 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 			},
 		}
 
-		metaBuildpack := v1alpha1.StoreBuildpack{
-			BuildpackInfo: v1alpha1.BuildpackInfo{
+		metaBuildpack := buildapi.StoreBuildpack{
+			BuildpackInfo: buildapi.BuildpackInfo{
 				Id:      "io.buildpack.meta",
 				Version: "1.0.0",
 			},
 			DiffId: "sha256:3bf8899667b8d1e6b124f663faca32903b470831e5e4e992644ac5c839ab3462",
 			Digest: "sha256:07db84e57fdd7101104c2469984217696fdfe51591cb1edee2928514135920d6",
 			Size:   30,
-			StoreImage: v1alpha1.StoreImage{
+			StoreImage: buildapi.StoreImage{
 				Image: "some.registry.io/build-package",
 			},
-			Order: []v1alpha1.OrderEntry{
+			Order: []buildapi.OrderEntry{
 				{
-					Group: []v1alpha1.BuildpackRef{
+					Group: []buildapi.BuildpackRef{
 						{
-							BuildpackInfo: v1alpha1.BuildpackInfo{
+							BuildpackInfo: buildapi.BuildpackInfo{
 								Id:      "io.buildpack.engine",
 								Version: "1.0.0",
 							},
 							Optional: false,
 						},
 						{
-							BuildpackInfo: v1alpha1.BuildpackInfo{
+							BuildpackInfo: buildapi.BuildpackInfo{
 								Id:      "io.buildpack.package-manager",
 								Version: "1.0.0",
 							},
@@ -98,7 +98,7 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 			},
 			Homepage: "buildpack.meta.com",
 			API:      "0.3",
-			Stacks: []v1alpha1.BuildpackStack{
+			Stacks: []buildapi.BuildpackStack{
 				{
 					ID: "io.custom.stack",
 				},
@@ -108,21 +108,21 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 			},
 		}
 
-		v8Buildpack := v1alpha1.StoreBuildpack{
-			BuildpackInfo: v1alpha1.BuildpackInfo{
+		v8Buildpack := buildapi.StoreBuildpack{
+			BuildpackInfo: buildapi.BuildpackInfo{
 				Id:      "io.buildpack.multi",
 				Version: "8.0.0",
 			},
 			DiffId: "sha256:8bf8899667b8d1e6b124f663faca32903b470831e5e4e992644ac5c839ab3462",
 			Digest: "sha256:fc14806eb95d01b6338ba1b9fea605e84db7c8c09561ae360bad5b80b5d0d80b",
 			Size:   20,
-			StoreImage: v1alpha1.StoreImage{
+			StoreImage: buildapi.StoreImage{
 				Image: "some.registry.io/build-package",
 			},
 			Order:    nil,
 			Homepage: "buildpack.multi.com",
 			API:      "0.2",
-			Stacks: []v1alpha1.BuildpackStack{
+			Stacks: []buildapi.BuildpackStack{
 				{
 					ID: "io.custom.stack",
 				},
@@ -132,21 +132,21 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 			},
 		}
 
-		v9Buildpack := v1alpha1.StoreBuildpack{
-			BuildpackInfo: v1alpha1.BuildpackInfo{
+		v9Buildpack := buildapi.StoreBuildpack{
+			BuildpackInfo: buildapi.BuildpackInfo{
 				Id:      "io.buildpack.multi",
 				Version: "9.0.0",
 			},
 			DiffId: "sha256:9bf8899667b8d1e6b124f663faca32903b470831e5e4e992644ac5c839ab3462",
 			Digest: "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
 			Size:   10,
-			StoreImage: v1alpha1.StoreImage{
+			StoreImage: buildapi.StoreImage{
 				Image: "some.registry.io/build-package",
 			},
 			Order:    nil,
 			Homepage: "buildpack.multi.com",
 			API:      "0.2",
-			Stacks: []v1alpha1.BuildpackStack{
+			Stacks: []buildapi.BuildpackStack{
 				{
 					ID: "io.custom.stack",
 				},
@@ -158,12 +158,12 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 
 		storeBuildpackRepository := &StoreBuildpackRepository{
 			Keychain: nil,
-			ClusterStore: &v1alpha1.ClusterStore{
+			ClusterStore: &buildapi.ClusterStore{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "some-store",
 				},
-				Status: v1alpha1.ClusterStoreStatus{
-					Buildpacks: []v1alpha1.StoreBuildpack{
+				Status: buildapi.ClusterStoreStatus{
+					Buildpacks: []buildapi.StoreBuildpack{
 						engineBuildpack,
 						v9Buildpack,
 						v8Buildpack,
@@ -182,7 +182,7 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 
 			require.Equal(t, info, RemoteBuildpackInfo{
 				BuildpackInfo: DescriptiveBuildpackInfo{
-					BuildpackInfo: v1alpha1.BuildpackInfo{
+					BuildpackInfo: buildapi.BuildpackInfo{
 						Id:      "io.buildpack.engine",
 						Version: "1.0.0",
 					},
@@ -192,7 +192,7 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 					{
 						v1Layer: expectedLayer,
 						BuildpackInfo: DescriptiveBuildpackInfo{
-							BuildpackInfo: v1alpha1.BuildpackInfo{
+							BuildpackInfo: buildapi.BuildpackInfo{
 								Id:      "io.buildpack.engine",
 								Version: "1.0.0",
 							},
@@ -202,7 +202,7 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 							API:         "0.1",
 							LayerDiffID: diffID(t, expectedLayer),
 							Homepage:    "buildpack.engine.com",
-							Stacks: []v1alpha1.BuildpackStack{
+							Stacks: []buildapi.BuildpackStack{
 								{
 									ID: "io.custom.stack",
 								},
@@ -225,7 +225,7 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 
 			require.Equal(t, info, RemoteBuildpackInfo{
 				BuildpackInfo: DescriptiveBuildpackInfo{
-					BuildpackInfo: v1alpha1.BuildpackInfo{
+					BuildpackInfo: buildapi.BuildpackInfo{
 						Id:      "io.buildpack.multi",
 						Version: "9.0.0",
 					},
@@ -235,7 +235,7 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 					{
 						v1Layer: expectedLayer,
 						BuildpackInfo: DescriptiveBuildpackInfo{
-							BuildpackInfo: v1alpha1.BuildpackInfo{
+							BuildpackInfo: buildapi.BuildpackInfo{
 								Id:      "io.buildpack.multi",
 								Version: "9.0.0",
 							},
@@ -245,7 +245,7 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 							API:         "0.2",
 							LayerDiffID: diffID(t, expectedLayer),
 							Homepage:    "buildpack.multi.com",
-							Stacks: []v1alpha1.BuildpackStack{
+							Stacks: []buildapi.BuildpackStack{
 								{
 									ID: "io.custom.stack",
 								},
@@ -260,20 +260,20 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("fails to find the buildpack if version is unspecified and not all buildpacks are semver conformant", func() {
-			storeBuildpackRepository.ClusterStore.Status.Buildpacks = append(storeBuildpackRepository.ClusterStore.Status.Buildpacks, v1alpha1.StoreBuildpack{
-				BuildpackInfo: v1alpha1.BuildpackInfo{
+			storeBuildpackRepository.ClusterStore.Status.Buildpacks = append(storeBuildpackRepository.ClusterStore.Status.Buildpacks, buildapi.StoreBuildpack{
+				BuildpackInfo: buildapi.BuildpackInfo{
 					Id:      "io.buildpack.multi",
 					Version: "my-wacky-version",
 				},
 				DiffId: "sha256:9bf8899667b8d1e6b124f663faca32903b470831e5e4e992644ac5c839ab3462",
 				Digest: "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
 				Size:   10,
-				StoreImage: v1alpha1.StoreImage{
+				StoreImage: buildapi.StoreImage{
 					Image: "some.registry.io/build-package",
 				},
 				Order: nil,
 				API:   "0.2",
-				Stacks: []v1alpha1.BuildpackStack{
+				Stacks: []buildapi.BuildpackStack{
 					{
 						ID: "io.custom.stack",
 					},
@@ -302,7 +302,7 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 
 			require.Equal(t, RemoteBuildpackInfo{
 				BuildpackInfo: DescriptiveBuildpackInfo{
-					BuildpackInfo: v1alpha1.BuildpackInfo{
+					BuildpackInfo: buildapi.BuildpackInfo{
 						Id:      "io.buildpack.meta",
 						Version: "1.0.0",
 					},
@@ -312,7 +312,7 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 					{
 						v1Layer: expectedEngineLayer,
 						BuildpackInfo: DescriptiveBuildpackInfo{
-							BuildpackInfo: v1alpha1.BuildpackInfo{
+							BuildpackInfo: buildapi.BuildpackInfo{
 								Id:      "io.buildpack.engine",
 								Version: "1.0.0",
 							},
@@ -321,7 +321,7 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 						BuildpackLayerInfo: BuildpackLayerInfo{
 							API:         "0.1",
 							LayerDiffID: diffID(t, expectedEngineLayer),
-							Stacks: []v1alpha1.BuildpackStack{
+							Stacks: []buildapi.BuildpackStack{
 								{
 									ID: "io.custom.stack",
 								},
@@ -335,7 +335,7 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 					{
 						v1Layer: expectedPackageManagerLayer,
 						BuildpackInfo: DescriptiveBuildpackInfo{
-							BuildpackInfo: v1alpha1.BuildpackInfo{
+							BuildpackInfo: buildapi.BuildpackInfo{
 								Id:      "io.buildpack.package-manager",
 								Version: "1.0.0",
 							},
@@ -345,7 +345,7 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 							API:         "0.2",
 							LayerDiffID: diffID(t, expectedPackageManagerLayer),
 							Homepage:    "buildpack.package-manager.com",
-							Stacks: []v1alpha1.BuildpackStack{
+							Stacks: []buildapi.BuildpackStack{
 								{
 									ID: "io.custom.stack",
 								},
@@ -358,7 +358,7 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 					{
 						v1Layer: expectedMetaLayer,
 						BuildpackInfo: DescriptiveBuildpackInfo{
-							BuildpackInfo: v1alpha1.BuildpackInfo{
+							BuildpackInfo: buildapi.BuildpackInfo{
 								Id:      "io.buildpack.meta",
 								Version: "1.0.0",
 							},
@@ -368,18 +368,18 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 							API:         "0.3",
 							LayerDiffID: diffID(t, expectedMetaLayer),
 							Homepage:    "buildpack.meta.com",
-							Order: v1alpha1.Order{
+							Order: buildapi.Order{
 								{
-									Group: []v1alpha1.BuildpackRef{
+									Group: []buildapi.BuildpackRef{
 										{
-											BuildpackInfo: v1alpha1.BuildpackInfo{
+											BuildpackInfo: buildapi.BuildpackInfo{
 												Id:      "io.buildpack.engine",
 												Version: "1.0.0",
 											},
 											Optional: false,
 										},
 										{
-											BuildpackInfo: v1alpha1.BuildpackInfo{
+											BuildpackInfo: buildapi.BuildpackInfo{
 												Id:      "io.buildpack.package-manager",
 												Version: "1.0.0",
 											},
@@ -388,7 +388,7 @@ func testBuildpackRepository(t *testing.T, when spec.G, it spec.S) {
 									},
 								},
 							},
-							Stacks: []v1alpha1.BuildpackStack{
+							Stacks: []buildapi.BuildpackStack{
 								{
 									ID:     "io.custom.stack",
 									Mixins: nil,

--- a/pkg/dockercreds/k8sdockercreds/k8s_keychain.go
+++ b/pkg/dockercreds/k8sdockercreds/k8s_keychain.go
@@ -12,7 +12,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	k8sclient "k8s.io/client-go/kubernetes"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/dockercreds"
 	"github.com/pivotal/kpack/pkg/registry"
 	"github.com/pivotal/kpack/pkg/secret"
@@ -80,7 +80,7 @@ func keychainFromServiceAccount(ctx context.Context, secretRef registry.SecretRe
 		switch s.Type {
 		case corev1.SecretTypeBasicAuth:
 			var err error
-			if registry, ok := s.Annotations[v1alpha1.DOCKERSecretAnnotationPrefix]; ok {
+			if registry, ok := s.Annotations[buildapi.DOCKERSecretAnnotationPrefix]; ok {
 				dockerCreds, err = dockerCreds.Append(dockercreds.DockerCreds{
 					registry: authn.AuthConfig{
 						Username: string(s.Data[corev1.BasicAuthUsernameKey]),

--- a/pkg/dockercreds/k8sdockercreds/k8s_keychain_test.go
+++ b/pkg/dockercreds/k8sdockercreds/k8s_keychain_test.go
@@ -14,7 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/dockercreds"
 	"github.com/pivotal/kpack/pkg/registry"
 )
@@ -36,7 +36,7 @@ func testK8sSecretKeychainFactory(t *testing.T, when spec.G, it spec.S) {
 					Name:      "secret-1",
 					Namespace: testNamespace,
 					Annotations: map[string]string{
-						v1alpha1.DOCKERSecretAnnotationPrefix: "annotated.io",
+						buildapi.DOCKERSecretAnnotationPrefix: "annotated.io",
 					},
 				},
 				Type: corev1.SecretTypeBasicAuth,
@@ -149,7 +149,7 @@ func testK8sSecretKeychainFactory(t *testing.T, when spec.G, it spec.S) {
 						Name:      "secret-1",
 						Namespace: testNamespace,
 						Annotations: map[string]string{
-							v1alpha1.DOCKERSecretAnnotationPrefix: "annotated.io",
+							buildapi.DOCKERSecretAnnotationPrefix: "annotated.io",
 						},
 					},
 					Type: corev1.SecretTypeBasicAuth,

--- a/pkg/duckbuilder/duck_builder.go
+++ b/pkg/duckbuilder/duck_builder.go
@@ -4,7 +4,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 )
 
@@ -13,7 +13,7 @@ type DuckBuilder struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   DuckBuilderSpec        `json:"spec"`
-	Status v1alpha1.BuilderStatus `json:"status"`
+	Status buildapi.BuilderStatus `json:"status"`
 }
 type DuckBuilderSpec struct {
 	ImagePullSecrets []v1.LocalObjectReference
@@ -24,14 +24,14 @@ func (b *DuckBuilder) Ready() bool {
 		(b.Generation == b.Status.ObservedGeneration)
 }
 
-func (b *DuckBuilder) BuildBuilderSpec() v1alpha1.BuildBuilderSpec {
-	return v1alpha1.BuildBuilderSpec{
+func (b *DuckBuilder) BuildBuilderSpec() buildapi.BuildBuilderSpec {
+	return buildapi.BuildBuilderSpec{
 		Image:            b.Status.LatestImage,
 		ImagePullSecrets: b.Spec.ImagePullSecrets,
 	}
 }
 
-func (b *DuckBuilder) BuildpackMetadata() v1alpha1.BuildpackMetadataList {
+func (b *DuckBuilder) BuildpackMetadata() buildapi.BuildpackMetadataList {
 	return b.Status.BuilderMetadata
 }
 

--- a/pkg/duckbuilder/duck_builder_test.go
+++ b/pkg/duckbuilder/duck_builder_test.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 )
 
@@ -28,7 +28,7 @@ func testDuckBuilder(t *testing.T, when spec.G, it spec.S) {
 				},
 			},
 		},
-		Status: v1alpha1.BuilderStatus{
+		Status: buildapi.BuilderStatus{
 			Status: corev1alpha1.Status{
 				ObservedGeneration: 1,
 				Conditions: corev1alpha1.Conditions{
@@ -38,13 +38,13 @@ func testDuckBuilder(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			},
-			BuilderMetadata: v1alpha1.BuildpackMetadataList{
+			BuilderMetadata: buildapi.BuildpackMetadataList{
 				{
 					Id:      "test.builder",
 					Version: "test.version",
 				},
 			},
-			Stack: v1alpha1.BuildStack{
+			Stack: buildapi.BuildStack{
 				RunImage: "some/run@sha256:12345678",
 			},
 			LatestImage: "some/builder@sha256:12345678",
@@ -82,7 +82,7 @@ func testDuckBuilder(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	it("BuildBuilderSpec provides latest image and pull secrets", func() {
-		require.Equal(t, v1alpha1.BuildBuilderSpec{
+		require.Equal(t, buildapi.BuildBuilderSpec{
 			Image: "some/builder@sha256:12345678",
 			ImagePullSecrets: []corev1.LocalObjectReference{
 				{
@@ -93,7 +93,7 @@ func testDuckBuilder(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	it("BuildpackMetadata provides buildpack metadata", func() {
-		require.Equal(t, v1alpha1.BuildpackMetadataList{
+		require.Equal(t, buildapi.BuildpackMetadataList{
 			{
 				Id:      "test.builder",
 				Version: "test.version",

--- a/pkg/duckbuilder/informer.go
+++ b/pkg/duckbuilder/informer.go
@@ -5,14 +5,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
-	informerv1alpha1 "github.com/pivotal/kpack/pkg/client/informers/externalversions/build/v1alpha1"
-	v1alpha1Listers "github.com/pivotal/kpack/pkg/client/listers/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildinformers "github.com/pivotal/kpack/pkg/client/informers/externalversions/build/v1alpha1"
+	buildlisters "github.com/pivotal/kpack/pkg/client/listers/build/v1alpha1"
 )
 
 type DuckBuilderInformer struct {
-	BuilderInformer        informerv1alpha1.BuilderInformer
-	ClusterBuilderInformer informerv1alpha1.ClusterBuilderInformer
+	BuilderInformer        buildinformers.BuilderInformer
+	ClusterBuilderInformer buildinformers.ClusterBuilderInformer
 }
 
 func (di *DuckBuilderInformer) AddEventHandler(handler cache.ResourceEventHandler) {
@@ -28,8 +28,8 @@ func (di *DuckBuilderInformer) Lister() *DuckBuilderLister {
 }
 
 type DuckBuilderLister struct {
-	BuilderLister        v1alpha1Listers.BuilderLister
-	ClusterBuilderLister v1alpha1Listers.ClusterBuilderLister
+	BuilderLister        buildlisters.BuilderLister
+	ClusterBuilderLister buildlisters.ClusterBuilderLister
 }
 
 func (bl *DuckBuilderLister) Namespace(namespace string) *DuckBuilderNamespaceLister {
@@ -46,10 +46,10 @@ type DuckBuilderNamespaceLister struct {
 
 func (bl *DuckBuilderNamespaceLister) Get(reference corev1.ObjectReference) (*DuckBuilder, error) {
 	switch reference.Kind {
-	case v1alpha1.BuilderKind:
+	case buildapi.BuilderKind:
 		builder, err := bl.DuckBuilderLister.BuilderLister.Builders(bl.namespace).Get(reference.Name)
 		return convertBuilder(builder), err
-	case v1alpha1.ClusterBuilderKind:
+	case buildapi.ClusterBuilderKind:
 		builder, err := bl.DuckBuilderLister.ClusterBuilderLister.Get(reference.Name)
 		return convertClusterBuilder(builder), err
 	default:
@@ -57,7 +57,7 @@ func (bl *DuckBuilderNamespaceLister) Get(reference corev1.ObjectReference) (*Du
 	}
 }
 
-func convertBuilder(builder *v1alpha1.Builder) *DuckBuilder {
+func convertBuilder(builder *buildapi.Builder) *DuckBuilder {
 	if builder == nil {
 		return nil
 	}
@@ -69,7 +69,7 @@ func convertBuilder(builder *v1alpha1.Builder) *DuckBuilder {
 	}
 }
 
-func convertClusterBuilder(builder *v1alpha1.ClusterBuilder) *DuckBuilder {
+func convertClusterBuilder(builder *buildapi.ClusterBuilder) *DuckBuilder {
 	if builder == nil {
 		return nil
 	}

--- a/pkg/duckbuilder/informer_test.go
+++ b/pkg/duckbuilder/informer_test.go
@@ -12,7 +12,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/client/clientset/versioned/fake"
 	"github.com/pivotal/kpack/pkg/client/informers/externalversions"
 )
@@ -32,37 +32,37 @@ func testDuckBuilderInformer(t *testing.T, when spec.G, it spec.S) {
 	var (
 		stopCh = make(chan struct{})
 
-		builder = &v1alpha1.Builder{
+		builder = &buildapi.Builder{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      builderName,
 				Namespace: builderNamespace,
 			},
-			Spec: v1alpha1.NamespacedBuilderSpec{},
-			Status: v1alpha1.BuilderStatus{
-				BuilderMetadata: v1alpha1.BuildpackMetadataList{
+			Spec: buildapi.NamespacedBuilderSpec{},
+			Status: buildapi.BuilderStatus{
+				BuilderMetadata: buildapi.BuildpackMetadataList{
 					{
 						Id:      "another-buildpack",
 						Version: "another-version",
 					},
 				},
-				Stack:       v1alpha1.BuildStack{},
+				Stack:       buildapi.BuildStack{},
 				LatestImage: "",
 			},
 		}
 
-		clusterBuilder = &v1alpha1.ClusterBuilder{
+		clusterBuilder = &buildapi.ClusterBuilder{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterBuilderName,
 			},
-			Spec: v1alpha1.ClusterBuilderSpec{},
-			Status: v1alpha1.BuilderStatus{
-				BuilderMetadata: v1alpha1.BuildpackMetadataList{
+			Spec: buildapi.ClusterBuilderSpec{},
+			Status: buildapi.BuilderStatus{
+				BuilderMetadata: buildapi.BuildpackMetadataList{
 					{
 						Id:      "another-buildpack",
 						Version: "another-version",
 					},
 				},
-				Stack:       v1alpha1.BuildStack{},
+				Stack:       buildapi.BuildStack{},
 				LatestImage: "",
 			},
 		}
@@ -91,7 +91,7 @@ func testDuckBuilderInformer(t *testing.T, when spec.G, it spec.S) {
 	when("#Lister", func() {
 		it("can return a builder of type Builder", func() {
 			duckBuilder, err := duckBuilderLister.Namespace(builderNamespace).Get(v1.ObjectReference{
-				Kind:      v1alpha1.BuilderKind,
+				Kind:      buildapi.BuilderKind,
 				Namespace: builderNamespace,
 				Name:      builderName,
 			})
@@ -104,7 +104,7 @@ func testDuckBuilderInformer(t *testing.T, when spec.G, it spec.S) {
 
 		it("can return a builder of type ClusterBuilder", func() {
 			duckBuilder, err := duckBuilderLister.Namespace("").Get(v1.ObjectReference{
-				Kind: v1alpha1.ClusterBuilderKind,
+				Kind: buildapi.ClusterBuilderKind,
 				Name: clusterBuilderName,
 			})
 			require.NoError(t, err)
@@ -116,8 +116,8 @@ func testDuckBuilderInformer(t *testing.T, when spec.G, it spec.S) {
 
 		it("returns a k8s not found error on missing builder", func() {
 			for _, typ := range []string{
-				v1alpha1.ClusterBuilderKind,
-				v1alpha1.BuilderKind,
+				buildapi.ClusterBuilderKind,
+				buildapi.BuilderKind,
 			} {
 				_, err := duckBuilderLister.Namespace("some-namespace").Get(v1.ObjectReference{
 					Kind: typ,

--- a/pkg/git/k8s_git_keychain.go
+++ b/pkg/git/k8s_git_keychain.go
@@ -8,7 +8,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	k8sclient "k8s.io/client-go/kubernetes"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/secret"
 )
 
@@ -32,7 +32,7 @@ func (k *k8sGitKeychainFactory) KeychainForServiceAccount(ctx context.Context, n
 		case v1.SecretTypeBasicAuth:
 			{
 				creds = append(creds, gitBasicAuthCred{
-					Domain:      s.Annotations[v1alpha1.GITSecretAnnotationPrefix],
+					Domain:      s.Annotations[buildapi.GITSecretAnnotationPrefix],
 					SecretName:  s.Name,
 					fetchSecret: fetchBasicAuth(s),
 				})
@@ -40,7 +40,7 @@ func (k *k8sGitKeychainFactory) KeychainForServiceAccount(ctx context.Context, n
 		case v1.SecretTypeSSHAuth:
 			{
 				creds = append(creds, gitSshAuthCred{
-					Domain:      s.Annotations[v1alpha1.GITSecretAnnotationPrefix],
+					Domain:      s.Annotations[buildapi.GITSecretAnnotationPrefix],
 					SecretName:  s.Name,
 					fetchSecret: fetchSshAuth(s),
 				})

--- a/pkg/git/k8s_git_keychain_test.go
+++ b/pkg/git/k8s_git_keychain_test.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 func Test(t *testing.T) {
@@ -39,7 +39,7 @@ func (keys gitTest) testK8sGitKeychain(t *testing.T, when spec.G, it spec.S) {
 					Name:      "secret-1",
 					Namespace: testNamespace,
 					Annotations: map[string]string{
-						v1alpha1.GITSecretAnnotationPrefix: "https://github.com",
+						buildapi.GITSecretAnnotationPrefix: "https://github.com",
 					},
 				},
 				Type: v1.SecretTypeBasicAuth,
@@ -53,7 +53,7 @@ func (keys gitTest) testK8sGitKeychain(t *testing.T, when spec.G, it spec.S) {
 					Name:      "secret-2",
 					Namespace: testNamespace,
 					Annotations: map[string]string{
-						v1alpha1.GITSecretAnnotationPrefix: "noschemegit.com",
+						buildapi.GITSecretAnnotationPrefix: "noschemegit.com",
 					},
 				},
 				Type: v1.SecretTypeBasicAuth,
@@ -67,7 +67,7 @@ func (keys gitTest) testK8sGitKeychain(t *testing.T, when spec.G, it spec.S) {
 					Name:      "secret-3",
 					Namespace: testNamespace,
 					Annotations: map[string]string{
-						v1alpha1.GITSecretAnnotationPrefix: "https://bitbucket.com",
+						buildapi.GITSecretAnnotationPrefix: "https://bitbucket.com",
 					},
 				},
 				Type: v1.SecretTypeSSHAuth,
@@ -80,7 +80,7 @@ func (keys gitTest) testK8sGitKeychain(t *testing.T, when spec.G, it spec.S) {
 					Name:      "secret-4",
 					Namespace: testNamespace,
 					Annotations: map[string]string{
-						v1alpha1.GITSecretAnnotationPrefix: "https://gitlab.com",
+						buildapi.GITSecretAnnotationPrefix: "https://gitlab.com",
 					},
 				},
 				Type: v1.SecretTypeSSHAuth,
@@ -93,7 +93,7 @@ func (keys gitTest) testK8sGitKeychain(t *testing.T, when spec.G, it spec.S) {
 					Name:      "secret-5",
 					Namespace: testNamespace,
 					Annotations: map[string]string{
-						v1alpha1.GITSecretAnnotationPrefix: "https://gitlab.com",
+						buildapi.GITSecretAnnotationPrefix: "https://gitlab.com",
 					},
 				},
 				Type: v1.SecretTypeBasicAuth,
@@ -107,7 +107,7 @@ func (keys gitTest) testK8sGitKeychain(t *testing.T, when spec.G, it spec.S) {
 					Name:      "secret-6",
 					Namespace: testNamespace,
 					Annotations: map[string]string{
-						v1alpha1.GITSecretAnnotationPrefix: "https://gitlab.com",
+						buildapi.GITSecretAnnotationPrefix: "https://gitlab.com",
 					},
 				},
 				Type: v1.SecretTypeSSHAuth,
@@ -120,7 +120,7 @@ func (keys gitTest) testK8sGitKeychain(t *testing.T, when spec.G, it spec.S) {
 					Name:      "secret-7",
 					Namespace: testNamespace,
 					Annotations: map[string]string{
-						v1alpha1.GITSecretAnnotationPrefix: "https://github.com",
+						buildapi.GITSecretAnnotationPrefix: "https://github.com",
 					},
 				},
 				Type: v1.SecretTypeBasicAuth,

--- a/pkg/git/remote_git_resolver.go
+++ b/pkg/git/remote_git_resolver.go
@@ -10,7 +10,7 @@ import (
 	git2go "github.com/libgit2/git2go/v31"
 	"github.com/pkg/errors"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 const defaultRemote = "origin"
@@ -20,16 +20,16 @@ var discardLogger = log.New(ioutil.Discard, "", 0)
 type remoteGitResolver struct {
 }
 
-func (*remoteGitResolver) Resolve(keychain GitKeychain, sourceConfig v1alpha1.SourceConfig) (v1alpha1.ResolvedSourceConfig, error) {
+func (*remoteGitResolver) Resolve(keychain GitKeychain, sourceConfig buildapi.SourceConfig) (buildapi.ResolvedSourceConfig, error) {
 	dir, err := ioutil.TempDir("", "git-resolve")
 	if err != nil {
-		return v1alpha1.ResolvedSourceConfig{}, err
+		return buildapi.ResolvedSourceConfig{}, err
 	}
 	defer os.RemoveAll(dir)
 
 	repository, err := git2go.InitRepository(dir, false)
 	if err != nil {
-		return v1alpha1.ResolvedSourceConfig{}, errors.Wrap(err, "initializing repo")
+		return buildapi.ResolvedSourceConfig{}, errors.Wrap(err, "initializing repo")
 	}
 	defer repository.Free()
 
@@ -38,7 +38,7 @@ func (*remoteGitResolver) Resolve(keychain GitKeychain, sourceConfig v1alpha1.So
 		Flags: git2go.RemoteCreateSkipInsteadof,
 	})
 	if err != nil {
-		return v1alpha1.ResolvedSourceConfig{}, errors.Wrap(err, "create remote")
+		return buildapi.ResolvedSourceConfig{}, errors.Wrap(err, "create remote")
 	}
 	defer remote.Free()
 
@@ -47,11 +47,11 @@ func (*remoteGitResolver) Resolve(keychain GitKeychain, sourceConfig v1alpha1.So
 		CertificateCheckCallback: certificateCheckCallback(discardLogger),
 	}, nil, nil)
 	if err != nil {
-		return v1alpha1.ResolvedSourceConfig{
-			Git: &v1alpha1.ResolvedGitSource{
+		return buildapi.ResolvedSourceConfig{
+			Git: &buildapi.ResolvedGitSource{
 				URL:      sourceConfig.Git.URL,
 				Revision: sourceConfig.Git.Revision,
-				Type:     v1alpha1.Unknown,
+				Type:     buildapi.Unknown,
 				SubPath:  sourceConfig.SubPath,
 			},
 		}, nil
@@ -59,14 +59,14 @@ func (*remoteGitResolver) Resolve(keychain GitKeychain, sourceConfig v1alpha1.So
 
 	references, err := remote.Ls()
 	if err != nil {
-		return v1alpha1.ResolvedSourceConfig{}, errors.Wrap(err, "remote ls")
+		return buildapi.ResolvedSourceConfig{}, errors.Wrap(err, "remote ls")
 	}
 
 	for _, ref := range references {
 		for _, format := range refRevParseRules {
 			if fmt.Sprintf(format, sourceConfig.Git.Revision) == ref.Name {
-				return v1alpha1.ResolvedSourceConfig{
-					Git: &v1alpha1.ResolvedGitSource{
+				return buildapi.ResolvedSourceConfig{
+					Git: &buildapi.ResolvedGitSource{
 						URL:      sourceConfig.Git.URL,
 						Revision: ref.Id.String(),
 						Type:     sourceType(ref),
@@ -77,24 +77,24 @@ func (*remoteGitResolver) Resolve(keychain GitKeychain, sourceConfig v1alpha1.So
 		}
 	}
 
-	return v1alpha1.ResolvedSourceConfig{
-		Git: &v1alpha1.ResolvedGitSource{
+	return buildapi.ResolvedSourceConfig{
+		Git: &buildapi.ResolvedGitSource{
 			URL:      sourceConfig.Git.URL,
 			Revision: sourceConfig.Git.Revision,
-			Type:     v1alpha1.Commit,
+			Type:     buildapi.Commit,
 			SubPath:  sourceConfig.SubPath,
 		},
 	}, nil
 }
 
-func sourceType(reference git2go.RemoteHead) v1alpha1.GitSourceKind {
+func sourceType(reference git2go.RemoteHead) buildapi.GitSourceKind {
 	switch {
 	case strings.HasPrefix(reference.Name, "refs/heads"):
-		return v1alpha1.Branch
+		return buildapi.Branch
 	case strings.HasPrefix(reference.Name, "refs/tags"):
-		return v1alpha1.Tag
+		return buildapi.Tag
 	default:
-		return v1alpha1.Unknown
+		return buildapi.Unknown
 	}
 }
 

--- a/pkg/git/remote_git_resolver_test.go
+++ b/pkg/git/remote_git_resolver_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 func TestRemoteGitResolver(t *testing.T) {
@@ -28,8 +28,8 @@ func testRemoteGitResolver(t *testing.T, when spec.G, it spec.S) {
 			it("returns type commit", func() {
 				gitResolver := &remoteGitResolver{}
 
-				resolvedGitSource, err := gitResolver.Resolve(&fakeGitKeychain{}, v1alpha1.SourceConfig{
-					Git: &v1alpha1.Git{
+				resolvedGitSource, err := gitResolver.Resolve(&fakeGitKeychain{}, buildapi.SourceConfig{
+					Git: &buildapi.Git{
 						URL:      url,
 						Revision: nonHEADCommit,
 					},
@@ -37,12 +37,12 @@ func testRemoteGitResolver(t *testing.T, when spec.G, it spec.S) {
 				})
 				require.NoError(t, err)
 
-				assert.Equal(t, resolvedGitSource, v1alpha1.ResolvedSourceConfig{
-					Git: &v1alpha1.ResolvedGitSource{
+				assert.Equal(t, resolvedGitSource, buildapi.ResolvedSourceConfig{
+					Git: &buildapi.ResolvedGitSource{
 						URL:      url,
 						Revision: nonHEADCommit,
 						SubPath:  "/foo/bar",
-						Type:     v1alpha1.Commit,
+						Type:     buildapi.Commit,
 					},
 				})
 			})
@@ -52,8 +52,8 @@ func testRemoteGitResolver(t *testing.T, when spec.G, it spec.S) {
 			it("returns branch with resolved commit", func() {
 				gitResolver := &remoteGitResolver{}
 
-				resolvedGitSource, err := gitResolver.Resolve(&fakeGitKeychain{}, v1alpha1.SourceConfig{
-					Git: &v1alpha1.Git{
+				resolvedGitSource, err := gitResolver.Resolve(&fakeGitKeychain{}, buildapi.SourceConfig{
+					Git: &buildapi.Git{
 						URL:      url,
 						Revision: "master",
 					},
@@ -61,11 +61,11 @@ func testRemoteGitResolver(t *testing.T, when spec.G, it spec.S) {
 				})
 				require.NoError(t, err)
 
-				assert.Equal(t, resolvedGitSource, v1alpha1.ResolvedSourceConfig{
-					Git: &v1alpha1.ResolvedGitSource{
+				assert.Equal(t, resolvedGitSource, buildapi.ResolvedSourceConfig{
+					Git: &buildapi.ResolvedGitSource{
 						URL:      url,
 						Revision: fixtureHEADMasterCommit,
-						Type:     v1alpha1.Branch,
+						Type:     buildapi.Branch,
 						SubPath:  "/foo/bar",
 					},
 				})
@@ -78,8 +78,8 @@ func testRemoteGitResolver(t *testing.T, when spec.G, it spec.S) {
 
 				gitResolver := &remoteGitResolver{}
 
-				resolvedGitSource, err := gitResolver.Resolve(&fakeGitKeychain{}, v1alpha1.SourceConfig{
-					Git: &v1alpha1.Git{
+				resolvedGitSource, err := gitResolver.Resolve(&fakeGitKeychain{}, buildapi.SourceConfig{
+					Git: &buildapi.Git{
 						URL:      tagsUrl,
 						Revision: tag,
 					},
@@ -87,11 +87,11 @@ func testRemoteGitResolver(t *testing.T, when spec.G, it spec.S) {
 				})
 				require.NoError(t, err)
 
-				assert.Equal(t, resolvedGitSource, v1alpha1.ResolvedSourceConfig{
-					Git: &v1alpha1.ResolvedGitSource{
+				assert.Equal(t, resolvedGitSource, buildapi.ResolvedSourceConfig{
+					Git: &buildapi.ResolvedGitSource{
 						URL:      tagsUrl,
 						Revision: tagCommit,
-						Type:     v1alpha1.Tag,
+						Type:     buildapi.Tag,
 						SubPath:  "/foo/bar",
 					},
 				})
@@ -102,8 +102,8 @@ func testRemoteGitResolver(t *testing.T, when spec.G, it spec.S) {
 			it("returns an unknown type", func() {
 				gitResolver := &remoteGitResolver{}
 
-				resolvedGitSource, err := gitResolver.Resolve(&fakeGitKeychain{}, v1alpha1.SourceConfig{
-					Git: &v1alpha1.Git{
+				resolvedGitSource, err := gitResolver.Resolve(&fakeGitKeychain{}, buildapi.SourceConfig{
+					Git: &buildapi.Git{
 						URL:      "git@localhost:org/repo",
 						Revision: tag,
 					},
@@ -111,11 +111,11 @@ func testRemoteGitResolver(t *testing.T, when spec.G, it spec.S) {
 				})
 				require.NoError(t, err)
 
-				assert.Equal(t, resolvedGitSource, v1alpha1.ResolvedSourceConfig{
-					Git: &v1alpha1.ResolvedGitSource{
+				assert.Equal(t, resolvedGitSource, buildapi.ResolvedSourceConfig{
+					Git: &buildapi.ResolvedGitSource{
 						URL:      "git@localhost:org/repo",
 						Revision: tag,
-						Type:     v1alpha1.Unknown,
+						Type:     buildapi.Unknown,
 						SubPath:  "/foo/bar",
 					},
 				})

--- a/pkg/git/resolver.go
+++ b/pkg/git/resolver.go
@@ -5,7 +5,7 @@ import (
 
 	k8sclient "k8s.io/client-go/kubernetes"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 type Resolver struct {
@@ -20,15 +20,15 @@ func NewResolver(k8sClient k8sclient.Interface) *Resolver {
 	}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, sourceResolver *v1alpha1.SourceResolver) (v1alpha1.ResolvedSourceConfig, error) {
+func (r *Resolver) Resolve(ctx context.Context, sourceResolver *buildapi.SourceResolver) (buildapi.ResolvedSourceConfig, error) {
 	keychain, err := r.gitKeychain.KeychainForServiceAccount(ctx, sourceResolver.Namespace, sourceResolver.Spec.ServiceAccount)
 	if err != nil {
-		return v1alpha1.ResolvedSourceConfig{}, err
+		return buildapi.ResolvedSourceConfig{}, err
 	}
 
 	return r.remoteGitResolver.Resolve(keychain, sourceResolver.Spec.Source)
 }
 
-func (*Resolver) CanResolve(sourceResolver *v1alpha1.SourceResolver) bool {
+func (*Resolver) CanResolve(sourceResolver *buildapi.SourceResolver) bool {
 	return sourceResolver.IsGit()
 }

--- a/pkg/logs/build_logs.go
+++ b/pkg/logs/build_logs.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	k8sclient "k8s.io/client-go/kubernetes"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 type BuildLogsClient struct {
@@ -31,28 +31,28 @@ func NewBuildLogsClient(k8sClient k8sclient.Interface) *BuildLogsClient {
 func (c *BuildLogsClient) Tail(ctx context.Context, writer io.Writer, image, build, namespace string) error {
 	return c.tailPods(ctx, writer, namespace, metav1.ListOptions{
 		Watch:         true,
-		LabelSelector: fmt.Sprintf("%s=%s,%s=%s", v1alpha1.ImageLabel, image, v1alpha1.BuildNumberLabel, build),
+		LabelSelector: fmt.Sprintf("%s=%s,%s=%s", buildapi.ImageLabel, image, buildapi.BuildNumberLabel, build),
 	}, true, true)
 }
 
 func (c *BuildLogsClient) TailImage(ctx context.Context, writer io.Writer, image, namespace string) error {
 	return c.tailPods(ctx, writer, namespace, metav1.ListOptions{
 		Watch:         true,
-		LabelSelector: fmt.Sprintf("%s=%s", v1alpha1.ImageLabel, image),
+		LabelSelector: fmt.Sprintf("%s=%s", buildapi.ImageLabel, image),
 	}, false, true)
 }
 
 func (c *BuildLogsClient) GetImageLogs(ctx context.Context, writer io.Writer, image, namespace string) error {
 	return c.getPodLogs(ctx, writer, namespace, metav1.ListOptions{
 		Watch:         false,
-		LabelSelector: fmt.Sprintf("%s=%s", v1alpha1.ImageLabel, image),
+		LabelSelector: fmt.Sprintf("%s=%s", buildapi.ImageLabel, image),
 	}, false)
 }
 
 func (c *BuildLogsClient) TailBuildName(ctx context.Context, writer io.Writer, namespace string, buildName string) error {
 	return c.tailPods(ctx, writer, namespace, metav1.ListOptions{
 		Watch:         true,
-		LabelSelector: fmt.Sprintf("%s=%s", v1alpha1.BuildLabel, buildName),
+		LabelSelector: fmt.Sprintf("%s=%s", buildapi.BuildLabel, buildName),
 	}, true, true)
 }
 

--- a/pkg/logs/wait_for_image.go
+++ b/pkg/logs/wait_for_image.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	watchTools "k8s.io/client-go/tools/watch"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 	"github.com/pivotal/kpack/pkg/client/clientset/versioned"
 )
@@ -29,7 +29,7 @@ func NewImageWaiter(kpackClient versioned.Interface, logTailer ImageLogTailer) *
 	return &imageWaiter{KpackClient: kpackClient, logTailer: logTailer}
 }
 
-func (w *imageWaiter) Wait(ctx context.Context, writer io.Writer, image *v1alpha1.Image) (string, error) {
+func (w *imageWaiter) Wait(ctx context.Context, writer io.Writer, image *buildapi.Image) (string, error) {
 	if done, err := imageUpdateHasResolved(image.Generation)(watch.Event{Object: image}); err != nil {
 		return "", err
 	} else if done {
@@ -44,7 +44,7 @@ func (w *imageWaiter) Wait(ctx context.Context, writer io.Writer, image *v1alpha
 		return "", err
 	}
 
-	image, ok := event.Object.(*v1alpha1.Image)
+	image, ok := event.Object.(*buildapi.Image)
 	if !ok {
 		return "", errors.New("unexpected object received")
 	}
@@ -54,7 +54,7 @@ func (w *imageWaiter) Wait(ctx context.Context, writer io.Writer, image *v1alpha
 
 func imageUpdateHasResolved(generation int64) func(event watch.Event) (bool, error) {
 	return func(event watch.Event) (bool, error) {
-		image, ok := event.Object.(*v1alpha1.Image)
+		image, ok := event.Object.(*buildapi.Image)
 		if !ok {
 			return false, errors.New("unexpected object received")
 		}
@@ -75,7 +75,7 @@ func imageUpdateHasResolved(generation int64) func(event watch.Event) (bool, err
 	}
 }
 
-func (w *imageWaiter) resultOfImageWait(ctx context.Context, writer io.Writer, generation int64, image *v1alpha1.Image) (string, error) {
+func (w *imageWaiter) resultOfImageWait(ctx context.Context, writer io.Writer, generation int64, image *buildapi.Image) (string, error) {
 	if image.Status.LatestBuildImageGeneration == generation {
 		return w.waitBuild(ctx, writer, image.Namespace, image.Status.LatestBuildRef)
 	}
@@ -121,7 +121,7 @@ func (w *imageWaiter) waitBuild(ctx context.Context, writer io.Writer, namespace
 }
 
 func buildHasResolved(event watch.Event) (bool, error) {
-	build, ok := event.Object.(*v1alpha1.Build)
+	build, ok := event.Object.(*buildapi.Build)
 	if !ok {
 		return false, errors.New("unexpected object received, expected Build")
 	}
@@ -138,14 +138,14 @@ func buildFailure(statusMessage string) error {
 	return errors.New(errMsg)
 }
 
-func (w *imageWaiter) buildWatchUntil(ctx context.Context, namespace, buildName string, condition watchTools.ConditionFunc) (*v1alpha1.Build, error) {
+func (w *imageWaiter) buildWatchUntil(ctx context.Context, namespace, buildName string, condition watchTools.ConditionFunc) (*buildapi.Build, error) {
 	build, err := w.KpackClient.KpackV1alpha1().Builds(namespace).Get(ctx, buildName, v1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 	event, err := watchTools.UntilWithSync(ctx,
 		&watchOneBuild{context: ctx, kpackClient: w.KpackClient, namespace: namespace, buildName: buildName},
-		&v1alpha1.Build{},
+		&buildapi.Build{},
 		func(store cache.Store) (bool, error) {
 			return condition(watch.Event{Object: build})
 		},
@@ -156,7 +156,7 @@ func (w *imageWaiter) buildWatchUntil(ctx context.Context, namespace, buildName 
 	}
 	if event != nil { // event is nil if precondition is true
 		var ok bool
-		build, ok = event.Object.(*v1alpha1.Build)
+		build, ok = event.Object.(*buildapi.Build)
 		if !ok {
 			return nil, errors.New("unexpected object received, expected Build")
 		}

--- a/pkg/logs/watch_image.go
+++ b/pkg/logs/watch_image.go
@@ -7,13 +7,13 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/client/clientset/versioned"
 )
 
 type watchOneImage struct {
 	kpackClient versioned.Interface
-	image       *v1alpha1.Image
+	image       *buildapi.Image
 	ctx         context.Context
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -99,8 +99,9 @@ func schema_pkg_apis_build_v1alpha1_Binding(ref common.ReferenceCallback) common
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"metadataRef": {
@@ -130,8 +131,9 @@ func schema_pkg_apis_build_v1alpha1_Blob(ref common.ReferenceCallback) common.Op
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 				},
@@ -163,17 +165,20 @@ func schema_pkg_apis_build_v1alpha1_Build(ref common.ReferenceCallback) common.O
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildStatus"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildStatus"),
 						},
 					},
 				},
@@ -210,7 +215,8 @@ func schema_pkg_apis_build_v1alpha1_BuildBuilderSpec(ref common.ReferenceCallbac
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.LocalObjectReference"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.LocalObjectReference"),
 									},
 								},
 							},
@@ -246,7 +252,8 @@ func schema_pkg_apis_build_v1alpha1_BuildList(ref common.ReferenceCallback) comm
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -255,7 +262,8 @@ func schema_pkg_apis_build_v1alpha1_BuildList(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Build"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Build"),
 									},
 								},
 							},
@@ -287,8 +295,9 @@ func schema_pkg_apis_build_v1alpha1_BuildSpec(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -296,7 +305,8 @@ func schema_pkg_apis_build_v1alpha1_BuildSpec(ref common.ReferenceCallback) comm
 					},
 					"builder": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildBuilderSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildBuilderSpec"),
 						},
 					},
 					"serviceAccount": {
@@ -307,7 +317,8 @@ func schema_pkg_apis_build_v1alpha1_BuildSpec(ref common.ReferenceCallback) comm
 					},
 					"source": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceConfig"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceConfig"),
 						},
 					},
 					"cacheName": {
@@ -327,7 +338,8 @@ func schema_pkg_apis_build_v1alpha1_BuildSpec(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Binding"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Binding"),
 									},
 								},
 							},
@@ -344,7 +356,8 @@ func schema_pkg_apis_build_v1alpha1_BuildSpec(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.EnvVar"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.EnvVar"),
 									},
 								},
 							},
@@ -352,7 +365,8 @@ func schema_pkg_apis_build_v1alpha1_BuildSpec(ref common.ReferenceCallback) comm
 					},
 					"resources": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/api/core/v1.ResourceRequirements"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/api/core/v1.ResourceRequirements"),
 						},
 					},
 					"lastBuild": {
@@ -424,7 +438,8 @@ func schema_pkg_apis_build_v1alpha1_BuildStatus(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -436,7 +451,8 @@ func schema_pkg_apis_build_v1alpha1_BuildStatus(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackMetadata"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackMetadata"),
 									},
 								},
 							},
@@ -444,7 +460,8 @@ func schema_pkg_apis_build_v1alpha1_BuildStatus(ref common.ReferenceCallback) co
 					},
 					"stack": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildStack"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildStack"),
 						},
 					},
 					"latestImage": {
@@ -470,7 +487,8 @@ func schema_pkg_apis_build_v1alpha1_BuildStatus(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.ContainerState"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.ContainerState"),
 									},
 								},
 							},
@@ -487,8 +505,9 @@ func schema_pkg_apis_build_v1alpha1_BuildStatus(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -524,17 +543,20 @@ func schema_pkg_apis_build_v1alpha1_Builder(ref common.ReferenceCallback) common
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.NamespacedBuilderSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.NamespacedBuilderSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuilderStatus"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuilderStatus"),
 						},
 					},
 				},
@@ -568,7 +590,8 @@ func schema_pkg_apis_build_v1alpha1_BuilderList(ref common.ReferenceCallback) co
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -577,7 +600,8 @@ func schema_pkg_apis_build_v1alpha1_BuilderList(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Builder"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Builder"),
 									},
 								},
 							},
@@ -606,12 +630,14 @@ func schema_pkg_apis_build_v1alpha1_BuilderSpec(ref common.ReferenceCallback) co
 					},
 					"stack": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"store": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"order": {
@@ -625,7 +651,8 @@ func schema_pkg_apis_build_v1alpha1_BuilderSpec(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
 									},
 								},
 							},
@@ -665,7 +692,8 @@ func schema_pkg_apis_build_v1alpha1_BuilderStatus(ref common.ReferenceCallback) 
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -677,7 +705,8 @@ func schema_pkg_apis_build_v1alpha1_BuilderStatus(ref common.ReferenceCallback) 
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackMetadata"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackMetadata"),
 									},
 								},
 							},
@@ -689,7 +718,8 @@ func schema_pkg_apis_build_v1alpha1_BuilderStatus(ref common.ReferenceCallback) 
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
 									},
 								},
 							},
@@ -697,7 +727,8 @@ func schema_pkg_apis_build_v1alpha1_BuilderStatus(ref common.ReferenceCallback) 
 					},
 					"stack": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildStack"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildStack"),
 						},
 					},
 					"latestImage": {
@@ -740,8 +771,9 @@ func schema_pkg_apis_build_v1alpha1_BuildpackInfo(ref common.ReferenceCallback) 
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"version": {
@@ -765,14 +797,16 @@ func schema_pkg_apis_build_v1alpha1_BuildpackMetadata(ref common.ReferenceCallba
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"homepage": {
@@ -796,8 +830,9 @@ func schema_pkg_apis_build_v1alpha1_BuildpackRef(ref common.ReferenceCallback) c
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"version": {
@@ -827,8 +862,9 @@ func schema_pkg_apis_build_v1alpha1_BuildpackStack(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"mixins": {
@@ -842,8 +878,9 @@ func schema_pkg_apis_build_v1alpha1_BuildpackStack(ref common.ReferenceCallback)
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -908,17 +945,20 @@ func schema_pkg_apis_build_v1alpha1_ClusterBuilder(ref common.ReferenceCallback)
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterBuilderSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterBuilderSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuilderStatus"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuilderStatus"),
 						},
 					},
 				},
@@ -952,7 +992,8 @@ func schema_pkg_apis_build_v1alpha1_ClusterBuilderList(ref common.ReferenceCallb
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -961,7 +1002,8 @@ func schema_pkg_apis_build_v1alpha1_ClusterBuilderList(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterBuilder"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterBuilder"),
 									},
 								},
 							},
@@ -990,12 +1032,14 @@ func schema_pkg_apis_build_v1alpha1_ClusterBuilderSpec(ref common.ReferenceCallb
 					},
 					"stack": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"store": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"order": {
@@ -1009,7 +1053,8 @@ func schema_pkg_apis_build_v1alpha1_ClusterBuilderSpec(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
 									},
 								},
 							},
@@ -1017,7 +1062,8 @@ func schema_pkg_apis_build_v1alpha1_ClusterBuilderSpec(ref common.ReferenceCallb
 					},
 					"serviceAccountRef": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 				},
@@ -1050,17 +1096,20 @@ func schema_pkg_apis_build_v1alpha1_ClusterStack(ref common.ReferenceCallback) c
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatus"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatus"),
 						},
 					},
 				},
@@ -1094,7 +1143,8 @@ func schema_pkg_apis_build_v1alpha1_ClusterStackList(ref common.ReferenceCallbac
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -1103,7 +1153,8 @@ func schema_pkg_apis_build_v1alpha1_ClusterStackList(ref common.ReferenceCallbac
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStack"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStack"),
 									},
 								},
 							},
@@ -1132,12 +1183,14 @@ func schema_pkg_apis_build_v1alpha1_ClusterStackSpec(ref common.ReferenceCallbac
 					},
 					"buildImage": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackSpecImage"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackSpecImage"),
 						},
 					},
 					"runImage": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackSpecImage"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackSpecImage"),
 						},
 					},
 				},
@@ -1192,7 +1245,8 @@ func schema_pkg_apis_build_v1alpha1_ClusterStackStatus(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -1206,12 +1260,14 @@ func schema_pkg_apis_build_v1alpha1_ClusterStackStatus(ref common.ReferenceCallb
 					},
 					"buildImage": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatusImage"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatusImage"),
 						},
 					},
 					"runImage": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatusImage"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatusImage"),
 						},
 					},
 					"mixins": {
@@ -1225,8 +1281,9 @@ func schema_pkg_apis_build_v1alpha1_ClusterStackStatus(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -1298,17 +1355,20 @@ func schema_pkg_apis_build_v1alpha1_ClusterStore(ref common.ReferenceCallback) c
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStoreSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStoreSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStoreStatus"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStoreStatus"),
 						},
 					},
 				},
@@ -1342,7 +1402,8 @@ func schema_pkg_apis_build_v1alpha1_ClusterStoreList(ref common.ReferenceCallbac
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -1351,7 +1412,8 @@ func schema_pkg_apis_build_v1alpha1_ClusterStoreList(ref common.ReferenceCallbac
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStore"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStore"),
 									},
 								},
 							},
@@ -1383,7 +1445,8 @@ func schema_pkg_apis_build_v1alpha1_ClusterStoreSpec(ref common.ReferenceCallbac
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.StoreImage"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.StoreImage"),
 									},
 								},
 							},
@@ -1423,7 +1486,8 @@ func schema_pkg_apis_build_v1alpha1_ClusterStoreStatus(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -1440,7 +1504,8 @@ func schema_pkg_apis_build_v1alpha1_ClusterStoreStatus(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.StoreBuildpack"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.StoreBuildpack"),
 									},
 								},
 							},
@@ -1462,14 +1527,16 @@ func schema_pkg_apis_build_v1alpha1_Git(ref common.ReferenceCallback) common.Ope
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"revision": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 				},
@@ -1501,17 +1568,20 @@ func schema_pkg_apis_build_v1alpha1_Image(ref common.ReferenceCallback) common.O
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ImageSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ImageSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ImageStatus"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ImageStatus"),
 						},
 					},
 				},
@@ -1540,7 +1610,8 @@ func schema_pkg_apis_build_v1alpha1_ImageBuild(ref common.ReferenceCallback) com
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Binding"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Binding"),
 									},
 								},
 							},
@@ -1557,7 +1628,8 @@ func schema_pkg_apis_build_v1alpha1_ImageBuild(ref common.ReferenceCallback) com
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.EnvVar"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.EnvVar"),
 									},
 								},
 							},
@@ -1565,7 +1637,8 @@ func schema_pkg_apis_build_v1alpha1_ImageBuild(ref common.ReferenceCallback) com
 					},
 					"resources": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/api/core/v1.ResourceRequirements"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/api/core/v1.ResourceRequirements"),
 						},
 					},
 				},
@@ -1598,8 +1671,9 @@ func schema_pkg_apis_build_v1alpha1_ImageBuilder(ref common.ReferenceCallback) c
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 				},
@@ -1631,7 +1705,8 @@ func schema_pkg_apis_build_v1alpha1_ImageList(ref common.ReferenceCallback) comm
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -1640,7 +1715,8 @@ func schema_pkg_apis_build_v1alpha1_ImageList(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Image"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Image"),
 									},
 								},
 							},
@@ -1663,13 +1739,15 @@ func schema_pkg_apis_build_v1alpha1_ImageSpec(ref common.ReferenceCallback) comm
 				Properties: map[string]spec.Schema{
 					"tag": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"builder": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"serviceAccount": {
@@ -1680,7 +1758,8 @@ func schema_pkg_apis_build_v1alpha1_ImageSpec(ref common.ReferenceCallback) comm
 					},
 					"source": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceConfig"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceConfig"),
 						},
 					},
 					"cacheSize": {
@@ -1751,7 +1830,8 @@ func schema_pkg_apis_build_v1alpha1_ImageStatus(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -1845,12 +1925,14 @@ func schema_pkg_apis_build_v1alpha1_NamespacedBuilderSpec(ref common.ReferenceCa
 					},
 					"stack": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"store": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"order": {
@@ -1864,7 +1946,8 @@ func schema_pkg_apis_build_v1alpha1_NamespacedBuilderSpec(ref common.ReferenceCa
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
 									},
 								},
 							},
@@ -1911,8 +1994,9 @@ func schema_pkg_apis_build_v1alpha1_NotarySecretRef(ref common.ReferenceCallback
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 				},
@@ -1930,13 +2014,15 @@ func schema_pkg_apis_build_v1alpha1_NotaryV1Config(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"secretRef": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.NotarySecretRef"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.NotarySecretRef"),
 						},
 					},
 				},
@@ -1965,7 +2051,8 @@ func schema_pkg_apis_build_v1alpha1_OrderEntry(ref common.ReferenceCallback) com
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackRef"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackRef"),
 									},
 								},
 							},
@@ -1987,8 +2074,9 @@ func schema_pkg_apis_build_v1alpha1_Registry(ref common.ReferenceCallback) commo
 				Properties: map[string]spec.Schema{
 					"image": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"imagePullSecrets": {
@@ -2004,7 +2092,8 @@ func schema_pkg_apis_build_v1alpha1_Registry(ref common.ReferenceCallback) commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.LocalObjectReference"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.LocalObjectReference"),
 									},
 								},
 							},
@@ -2027,8 +2116,9 @@ func schema_pkg_apis_build_v1alpha1_ResolvedBlobSource(ref common.ReferenceCallb
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"subPath": {
@@ -2058,12 +2148,14 @@ func schema_pkg_apis_build_v1alpha1_ResolvedClusterStack(ref common.ReferenceCal
 					},
 					"buildImage": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatusImage"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatusImage"),
 						},
 					},
 					"runImage": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatusImage"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatusImage"),
 						},
 					},
 					"mixins": {
@@ -2077,8 +2169,9 @@ func schema_pkg_apis_build_v1alpha1_ResolvedClusterStack(ref common.ReferenceCal
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -2112,14 +2205,16 @@ func schema_pkg_apis_build_v1alpha1_ResolvedGitSource(ref common.ReferenceCallba
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"revision": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"subPath": {
@@ -2130,8 +2225,9 @@ func schema_pkg_apis_build_v1alpha1_ResolvedGitSource(ref common.ReferenceCallba
 					},
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 				},
@@ -2149,8 +2245,9 @@ func schema_pkg_apis_build_v1alpha1_ResolvedRegistrySource(ref common.ReferenceC
 				Properties: map[string]spec.Schema{
 					"image": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"subPath": {
@@ -2172,7 +2269,8 @@ func schema_pkg_apis_build_v1alpha1_ResolvedRegistrySource(ref common.ReferenceC
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.LocalObjectReference"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.LocalObjectReference"),
 									},
 								},
 							},
@@ -2273,17 +2371,20 @@ func schema_pkg_apis_build_v1alpha1_SourceResolver(ref common.ReferenceCallback)
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceResolverSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceResolverSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceResolverStatus"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceResolverStatus"),
 						},
 					},
 				},
@@ -2317,7 +2418,8 @@ func schema_pkg_apis_build_v1alpha1_SourceResolverList(ref common.ReferenceCallb
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -2326,7 +2428,8 @@ func schema_pkg_apis_build_v1alpha1_SourceResolverList(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceResolver"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceResolver"),
 									},
 								},
 							},
@@ -2355,7 +2458,8 @@ func schema_pkg_apis_build_v1alpha1_SourceResolverSpec(ref common.ReferenceCallb
 					},
 					"source": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceConfig"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceConfig"),
 						},
 					},
 				},
@@ -2393,7 +2497,8 @@ func schema_pkg_apis_build_v1alpha1_SourceResolverStatus(ref common.ReferenceCal
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -2401,7 +2506,8 @@ func schema_pkg_apis_build_v1alpha1_SourceResolverStatus(ref common.ReferenceCal
 					},
 					"source": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ResolvedSourceConfig"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ResolvedSourceConfig"),
 						},
 					},
 				},
@@ -2420,8 +2526,9 @@ func schema_pkg_apis_build_v1alpha1_StoreBuildpack(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"version": {
@@ -2432,12 +2539,14 @@ func schema_pkg_apis_build_v1alpha1_StoreBuildpack(ref common.ReferenceCallback)
 					},
 					"buildpackage": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackageInfo"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackageInfo"),
 						},
 					},
 					"storeImage": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.StoreImage"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.StoreImage"),
 						},
 					},
 					"diffId": {
@@ -2481,7 +2590,8 @@ func schema_pkg_apis_build_v1alpha1_StoreBuildpack(ref common.ReferenceCallback)
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
 									},
 								},
 							},
@@ -2498,7 +2608,8 @@ func schema_pkg_apis_build_v1alpha1_StoreBuildpack(ref common.ReferenceCallback)
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackStack"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackStack"),
 									},
 								},
 							},
@@ -2541,6 +2652,7 @@ func schema_pkg_apis_core_v1alpha1_Condition(ref common.ReferenceCallback) commo
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Type of condition.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2548,6 +2660,7 @@ func schema_pkg_apis_core_v1alpha1_Condition(ref common.ReferenceCallback) commo
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status of the condition, one of True, False, Unknown.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2562,7 +2675,8 @@ func schema_pkg_apis_core_v1alpha1_Condition(ref common.ReferenceCallback) commo
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).",
-							Type:        []string{"string"}, Format: "",
+							Default:     map[string]interface{}{},
+							Type: []string{"string"}, Format: "",
 						},
 					},
 					"reason": {
@@ -2615,7 +2729,8 @@ func schema_pkg_apis_core_v1alpha1_Status(ref common.ReferenceCallback) common.O
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -2638,7 +2753,8 @@ func schema_pkg_apis_core_v1alpha1_VolatileTime(ref common.ReferenceCallback) co
 				Properties: map[string]spec.Schema{
 					"inner": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 				},

--- a/pkg/reconciler/build/build_test.go
+++ b/pkg/reconciler/build/build_test.go
@@ -20,7 +20,7 @@ import (
 	"knative.dev/pkg/controller"
 	rtesting "knative.dev/pkg/reconciler/testing"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 	"github.com/pivotal/kpack/pkg/buildpod"
 	"github.com/pivotal/kpack/pkg/client/clientset/versioned/fake"
@@ -76,7 +76,7 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 			return r, actionRecorderList, eventList
 		})
 
-	build := &v1alpha1.Build{
+	build := &buildapi.Build{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      buildName,
 			Namespace: namespace,
@@ -85,10 +85,10 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 			},
 			Generation: originalGeneration,
 		},
-		Spec: v1alpha1.BuildSpec{
+		Spec: buildapi.BuildSpec{
 			Tags:           []string{"someimage/name", "someimage/name:tag2", "someimage/name:tag3"},
 			ServiceAccount: serviceAccountName,
-			Builder: v1alpha1.BuildBuilderSpec{
+			Builder: buildapi.BuildBuilderSpec{
 				Image: "somebuilder/123@sha256:12334563ad",
 				ImagePullSecrets: []corev1.LocalObjectReference{
 					{Name: "some-image-secret"},
@@ -108,8 +108,8 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 					corev1.ResourceMemory: resource.MustParse("128M"),
 				},
 			},
-			Source: v1alpha1.SourceConfig{
-				Git: &v1alpha1.Git{
+			Source: buildapi.SourceConfig{
+				Git: &buildapi.Git{
 					URL:      "giturl.com/git.git",
 					Revision: "gitrev1234",
 				},
@@ -134,10 +134,10 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 				},
 				WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 					{
-						Object: &v1alpha1.Build{
+						Object: &buildapi.Build{
 							ObjectMeta: build.ObjectMeta,
 							Spec:       build.Spec,
-							Status: v1alpha1.BuildStatus{
+							Status: buildapi.BuildStatus{
 								Status: corev1alpha1.Status{
 									ObservedGeneration: originalGeneration,
 									Conditions: corev1alpha1.Conditions{
@@ -169,10 +169,10 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 				WantErr: false,
 				WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 					{
-						Object: &v1alpha1.Build{
+						Object: &buildapi.Build{
 							ObjectMeta: build.ObjectMeta,
 							Spec:       build.Spec,
-							Status: v1alpha1.BuildStatus{
+							Status: buildapi.BuildStatus{
 								Status: corev1alpha1.Status{
 									ObservedGeneration: originalGeneration,
 									Conditions: corev1alpha1.Conditions{
@@ -204,10 +204,10 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 				WantErr: false,
 				WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 					{
-						Object: &v1alpha1.Build{
+						Object: &buildapi.Build{
 							ObjectMeta: build.ObjectMeta,
 							Spec:       build.Spec,
-							Status: v1alpha1.BuildStatus{
+							Status: buildapi.BuildStatus{
 								Status: corev1alpha1.Status{
 									ObservedGeneration: 3,
 									Conditions: corev1alpha1.Conditions{
@@ -229,7 +229,7 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 			buildPod, err := podGenerator.Generate(ctx, build)
 			require.NoError(t, err)
 
-			build.Status = v1alpha1.BuildStatus{
+			build.Status = buildapi.BuildStatus{
 				Status: corev1alpha1.Status{
 					ObservedGeneration: 1,
 					Conditions: corev1alpha1.Conditions{
@@ -263,10 +263,10 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 				WantErr: false,
 				WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 					{
-						Object: &v1alpha1.Build{
+						Object: &buildapi.Build{
 							ObjectMeta: build.ObjectMeta,
 							Spec:       build.Spec,
-							Status: v1alpha1.BuildStatus{
+							Status: buildapi.BuildStatus{
 								Status: corev1alpha1.Status{
 									ObservedGeneration: 1,
 									Conditions: corev1alpha1.Conditions{
@@ -297,10 +297,10 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 				WantErr: false,
 				WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 					{
-						Object: &v1alpha1.Build{
+						Object: &buildapi.Build{
 							ObjectMeta: build.ObjectMeta,
 							Spec:       build.Spec,
-							Status: v1alpha1.BuildStatus{
+							Status: buildapi.BuildStatus{
 								Status: corev1alpha1.Status{
 									ObservedGeneration: originalGeneration,
 									Conditions: corev1alpha1.Conditions{
@@ -365,10 +365,10 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 					WantErr: false,
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Build{
+							Object: &buildapi.Build{
 								ObjectMeta: build.ObjectMeta,
 								Spec:       build.Spec,
-								Status: v1alpha1.BuildStatus{
+								Status: buildapi.BuildStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions: corev1alpha1.Conditions{
@@ -448,10 +448,10 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 					WantErr: false,
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Build{
+							Object: &buildapi.Build{
 								ObjectMeta: build.ObjectMeta,
 								Spec:       build.Spec,
-								Status: v1alpha1.BuildStatus{
+								Status: buildapi.BuildStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions: corev1alpha1.Conditions{
@@ -547,10 +547,10 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 					WantErr: false,
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Build{
+							Object: &buildapi.Build{
 								ObjectMeta: build.ObjectMeta,
 								Spec:       build.Spec,
-								Status: v1alpha1.BuildStatus{
+								Status: buildapi.BuildStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions: corev1alpha1.Conditions{
@@ -561,13 +561,13 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 										},
 									},
 									PodName: "build-name-build-pod",
-									BuildMetadata: v1alpha1.BuildpackMetadataList{{
+									BuildMetadata: buildapi.BuildpackMetadataList{{
 										Id:       "io.buildpack.executed",
 										Version:  "1.1",
 										Homepage: "mysupercoolsite.com",
 									}},
 									LatestImage: identifier,
-									Stack: v1alpha1.BuildStack{
+									Stack: buildapi.BuildStack{
 										RunImage: "somerun/123@sha256:12334563ad",
 										ID:       "io.buildpacks.stacks.bionic",
 									},
@@ -634,10 +634,10 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 				rt.Test(rtesting.TableRow{
 					Key: key,
 					Objects: []runtime.Object{
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: build.ObjectMeta,
 							Spec:       build.Spec,
-							Status: v1alpha1.BuildStatus{
+							Status: buildapi.BuildStatus{
 								Status: corev1alpha1.Status{
 									ObservedGeneration: originalGeneration,
 									Conditions: corev1alpha1.Conditions{
@@ -647,7 +647,7 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 										},
 									},
 								},
-								BuildMetadata: v1alpha1.BuildpackMetadataList{{
+								BuildMetadata: buildapi.BuildpackMetadataList{{
 									Id:      "io.buildpack.previouslyfetched",
 									Version: "1.1",
 								}},
@@ -690,10 +690,10 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 				rt.Test(rtesting.TableRow{
 					Key: key,
 					Objects: []runtime.Object{
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: build.ObjectMeta,
 							Spec:       build.Spec,
-							Status: v1alpha1.BuildStatus{
+							Status: buildapi.BuildStatus{
 								Status: corev1alpha1.Status{
 									ObservedGeneration: originalGeneration,
 									Conditions: corev1alpha1.Conditions{
@@ -703,7 +703,7 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 										},
 									},
 								},
-								BuildMetadata: v1alpha1.BuildpackMetadataList{{
+								BuildMetadata: buildapi.BuildpackMetadataList{{
 									Id:      "io.buildpack.previouslyfetched",
 									Version: "1.1",
 								}},
@@ -777,10 +777,10 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 					WantErr: false,
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Build{
+							Object: &buildapi.Build{
 								ObjectMeta: build.ObjectMeta,
 								Spec:       build.Spec,
-								Status: v1alpha1.BuildStatus{
+								Status: buildapi.BuildStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions: corev1alpha1.Conditions{
@@ -821,10 +821,10 @@ func testBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 				rt.Test(rtesting.TableRow{
 					Key: key,
 					Objects: []runtime.Object{
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: build.ObjectMeta,
 							Spec:       build.Spec,
-							Status: v1alpha1.BuildStatus{
+							Status: buildapi.BuildStatus{
 								Status: corev1alpha1.Status{
 									ObservedGeneration: originalGeneration,
 									Conditions: corev1alpha1.Conditions{

--- a/pkg/reconciler/build/buildfakes/fake_metadata_retriever.go
+++ b/pkg/reconciler/build/buildfakes/fake_metadata_retriever.go
@@ -5,17 +5,17 @@ import (
 	"context"
 	"sync"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/cnb"
 	"github.com/pivotal/kpack/pkg/reconciler/build"
 )
 
 type FakeMetadataRetriever struct {
-	GetBuiltImageStub        func(context.Context, *v1alpha1.Build) (cnb.BuiltImage, error)
+	GetBuiltImageStub        func(context.Context, *buildapi.Build) (cnb.BuiltImage, error)
 	getBuiltImageMutex       sync.RWMutex
 	getBuiltImageArgsForCall []struct {
 		arg1 context.Context
-		arg2 *v1alpha1.Build
+		arg2 *buildapi.Build
 	}
 	getBuiltImageReturns struct {
 		result1 cnb.BuiltImage
@@ -29,12 +29,12 @@ type FakeMetadataRetriever struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeMetadataRetriever) GetBuiltImage(arg1 context.Context, arg2 *v1alpha1.Build) (cnb.BuiltImage, error) {
+func (fake *FakeMetadataRetriever) GetBuiltImage(arg1 context.Context, arg2 *buildapi.Build) (cnb.BuiltImage, error) {
 	fake.getBuiltImageMutex.Lock()
 	ret, specificReturn := fake.getBuiltImageReturnsOnCall[len(fake.getBuiltImageArgsForCall)]
 	fake.getBuiltImageArgsForCall = append(fake.getBuiltImageArgsForCall, struct {
 		arg1 context.Context
-		arg2 *v1alpha1.Build
+		arg2 *buildapi.Build
 	}{arg1, arg2})
 	stub := fake.GetBuiltImageStub
 	fakeReturns := fake.getBuiltImageReturns
@@ -55,13 +55,13 @@ func (fake *FakeMetadataRetriever) GetBuiltImageCallCount() int {
 	return len(fake.getBuiltImageArgsForCall)
 }
 
-func (fake *FakeMetadataRetriever) GetBuiltImageCalls(stub func(context.Context, *v1alpha1.Build) (cnb.BuiltImage, error)) {
+func (fake *FakeMetadataRetriever) GetBuiltImageCalls(stub func(context.Context, *buildapi.Build) (cnb.BuiltImage, error)) {
 	fake.getBuiltImageMutex.Lock()
 	defer fake.getBuiltImageMutex.Unlock()
 	fake.GetBuiltImageStub = stub
 }
 
-func (fake *FakeMetadataRetriever) GetBuiltImageArgsForCall(i int) (context.Context, *v1alpha1.Build) {
+func (fake *FakeMetadataRetriever) GetBuiltImageArgsForCall(i int) (context.Context, *buildapi.Build) {
 	fake.getBuiltImageMutex.RLock()
 	defer fake.getBuiltImageMutex.RUnlock()
 	argsForCall := fake.getBuiltImageArgsForCall[i]

--- a/pkg/reconciler/build/sort.go
+++ b/pkg/reconciler/build/sort.go
@@ -3,10 +3,10 @@ package build
 import (
 	_ "strconv"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
-type ByCreationTimestamp []*v1alpha1.Build
+type ByCreationTimestamp []*buildapi.Build
 
 func (o ByCreationTimestamp) Len() int      { return len(o) }
 func (o ByCreationTimestamp) Swap(i, j int) { o[i], o[j] = o[j], o[i] }

--- a/pkg/reconciler/builder/builder_test.go
+++ b/pkg/reconciler/builder/builder_test.go
@@ -15,7 +15,7 @@ import (
 	"knative.dev/pkg/controller"
 	rtesting "knative.dev/pkg/reconciler/testing"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 	"github.com/pivotal/kpack/pkg/client/clientset/versioned/fake"
 	"github.com/pivotal/kpack/pkg/reconciler/builder"
@@ -60,19 +60,19 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 			return r, rtesting.ActionRecorderList{fakeClient}, rtesting.EventList{Recorder: record.NewFakeRecorder(10)}
 		})
 
-	clusterStore := &v1alpha1.ClusterStore{
+	clusterStore := &buildapi.ClusterStore{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "some-store",
 		},
-		Spec:   v1alpha1.ClusterStoreSpec{},
-		Status: v1alpha1.ClusterStoreStatus{},
+		Spec:   buildapi.ClusterStoreSpec{},
+		Status: buildapi.ClusterStoreStatus{},
 	}
 
-	clusterStack := &v1alpha1.ClusterStack{
+	clusterStack := &buildapi.ClusterStack{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "some-stack",
 		},
-		Status: v1alpha1.ClusterStackStatus{
+		Status: buildapi.ClusterStackStatus{
 			Status: corev1alpha1.Status{
 				ObservedGeneration: 0,
 				Conditions: []corev1alpha1.Condition{
@@ -85,14 +85,14 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 		},
 	}
 
-	builder := &v1alpha1.Builder{
+	builder := &buildapi.Builder{
 		ObjectMeta: v1.ObjectMeta{
 			Name:       builderName,
 			Generation: initialGeneration,
 			Namespace:  testNamespace,
 		},
-		Spec: v1alpha1.NamespacedBuilderSpec{
-			BuilderSpec: v1alpha1.BuilderSpec{
+		Spec: buildapi.NamespacedBuilderSpec{
+			BuilderSpec: buildapi.BuilderSpec{
 				Tag: builderTag,
 				Stack: corev1.ObjectReference{
 					Kind: "Stack",
@@ -102,18 +102,18 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 					Kind: "ClusterStore",
 					Name: "some-store",
 				},
-				Order: []v1alpha1.OrderEntry{
+				Order: []buildapi.OrderEntry{
 					{
-						Group: []v1alpha1.BuildpackRef{
+						Group: []buildapi.BuildpackRef{
 							{
-								BuildpackInfo: v1alpha1.BuildpackInfo{
+								BuildpackInfo: buildapi.BuildpackInfo{
 									Id:      "buildpack.id.1",
 									Version: "1.0.0",
 								},
 								Optional: false,
 							},
 							{
-								BuildpackInfo: v1alpha1.BuildpackInfo{
+								BuildpackInfo: buildapi.BuildpackInfo{
 									Id:      "buildpack.id.2",
 									Version: "2.0.0",
 								},
@@ -138,13 +138,13 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("saves metadata to the status", func() {
-			builderCreator.Record = v1alpha1.BuilderRecord{
+			builderCreator.Record = buildapi.BuilderRecord{
 				Image: builderIdentifier,
-				Stack: v1alpha1.BuildStack{
+				Stack: buildapi.BuildStack{
 					RunImage: "example.com/run-image@sha256:123456",
 					ID:       "fake.stack.id",
 				},
-				Buildpacks: v1alpha1.BuildpackMetadataList{
+				Buildpacks: buildapi.BuildpackMetadataList{
 					{
 						Id:      "buildpack.id.1",
 						Version: "1.0.0",
@@ -158,10 +158,10 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 				ObservedStackGeneration: 11,
 			}
 
-			expectedBuilder := &v1alpha1.Builder{
+			expectedBuilder := &buildapi.Builder{
 				ObjectMeta: builder.ObjectMeta,
 				Spec:       builder.Spec,
-				Status: v1alpha1.BuilderStatus{
+				Status: buildapi.BuilderStatus{
 					Status: corev1alpha1.Status{
 						ObservedGeneration: 1,
 						Conditions: corev1alpha1.Conditions{
@@ -171,7 +171,7 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 							},
 						},
 					},
-					BuilderMetadata: []v1alpha1.BuildpackMetadata{
+					BuilderMetadata: []buildapi.BuildpackMetadata{
 						{
 							Id:      "buildpack.id.1",
 							Version: "1.0.0",
@@ -181,7 +181,7 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 							Version: "2.0.0",
 						},
 					},
-					Stack: v1alpha1.BuildStack{
+					Stack: buildapi.BuildStack{
 						RunImage: "example.com/run-image@sha256:123456",
 						ID:       "fake.stack.id",
 					},
@@ -215,19 +215,19 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("tracks the stack and store for a custom builder", func() {
-			builderCreator.Record = v1alpha1.BuilderRecord{
+			builderCreator.Record = buildapi.BuilderRecord{
 				Image: builderIdentifier,
-				Stack: v1alpha1.BuildStack{
+				Stack: buildapi.BuildStack{
 					RunImage: "example.com/run-image@sha256:123456",
 					ID:       "fake.stack.id",
 				},
-				Buildpacks: v1alpha1.BuildpackMetadataList{},
+				Buildpacks: buildapi.BuildpackMetadataList{},
 			}
 
-			expectedBuilder := &v1alpha1.Builder{
+			expectedBuilder := &buildapi.Builder{
 				ObjectMeta: builder.ObjectMeta,
 				Spec:       builder.Spec,
-				Status: v1alpha1.BuilderStatus{
+				Status: buildapi.BuilderStatus{
 					Status: corev1alpha1.Status{
 						ObservedGeneration: 1,
 						Conditions: corev1alpha1.Conditions{
@@ -237,8 +237,8 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 							},
 						},
 					},
-					BuilderMetadata: []v1alpha1.BuildpackMetadata{},
-					Stack: v1alpha1.BuildStack{
+					BuilderMetadata: []buildapi.BuildpackMetadata{},
+					Stack: buildapi.BuildStack{
 						RunImage: "example.com/run-image@sha256:123456",
 						ID:       "fake.stack.id",
 					},
@@ -261,13 +261,13 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("does not update the status with no status change", func() {
-			builderCreator.Record = v1alpha1.BuilderRecord{
+			builderCreator.Record = buildapi.BuilderRecord{
 				Image: builderIdentifier,
-				Stack: v1alpha1.BuildStack{
+				Stack: buildapi.BuildStack{
 					RunImage: "example.com/run-image@sha256:123456",
 					ID:       "fake.stack.id",
 				},
-				Buildpacks: v1alpha1.BuildpackMetadataList{
+				Buildpacks: buildapi.BuildpackMetadataList{
 					{
 						Id:      "buildpack.id.1",
 						Version: "1.0.0",
@@ -275,7 +275,7 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 				},
 			}
 
-			builder.Status = v1alpha1.BuilderStatus{
+			builder.Status = buildapi.BuilderStatus{
 				Status: corev1alpha1.Status{
 					ObservedGeneration: builder.Generation,
 					Conditions: corev1alpha1.Conditions{
@@ -285,13 +285,13 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 						},
 					},
 				},
-				BuilderMetadata: []v1alpha1.BuildpackMetadata{
+				BuilderMetadata: []buildapi.BuildpackMetadata{
 					{
 						Id:      "buildpack.id.1",
 						Version: "1.0.0",
 					},
 				},
-				Stack: v1alpha1.BuildStack{
+				Stack: buildapi.BuildStack{
 					RunImage: "example.com/run-image@sha256:123456",
 					ID:       "fake.stack.id",
 				},
@@ -322,10 +322,10 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 				WantErr: true,
 				WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 					{
-						Object: &v1alpha1.Builder{
+						Object: &buildapi.Builder{
 							ObjectMeta: builder.ObjectMeta,
 							Spec:       builder.Spec,
-							Status: v1alpha1.BuilderStatus{
+							Status: buildapi.BuilderStatus{
 								Status: corev1alpha1.Status{
 									ObservedGeneration: 1,
 									Conditions: corev1alpha1.Conditions{
@@ -345,11 +345,11 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("updates status and doesn't build builder when stack not ready", func() {
-			notReadyClusterStack := &v1alpha1.ClusterStack{
+			notReadyClusterStack := &buildapi.ClusterStack{
 				ObjectMeta: v1.ObjectMeta{
 					Name: "some-stack",
 				},
-				Status: v1alpha1.ClusterStackStatus{
+				Status: buildapi.ClusterStackStatus{
 					Status: corev1alpha1.Status{
 						ObservedGeneration: 0,
 						Conditions: []corev1alpha1.Condition{
@@ -371,10 +371,10 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 				WantErr: true,
 				WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 					{
-						Object: &v1alpha1.Builder{
+						Object: &buildapi.Builder{
 							ObjectMeta: builder.ObjectMeta,
 							Spec:       builder.Spec,
-							Status: v1alpha1.BuilderStatus{
+							Status: buildapi.BuilderStatus{
 								Status: corev1alpha1.Status{
 									ObservedGeneration: 1,
 									Conditions: corev1alpha1.Conditions{

--- a/pkg/reconciler/clusterstack/clusterstack_test.go
+++ b/pkg/reconciler/clusterstack/clusterstack_test.go
@@ -14,7 +14,7 @@ import (
 	"knative.dev/pkg/controller"
 	rtesting "knative.dev/pkg/reconciler/testing"
 
-	v1alpha1 "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 	"github.com/pivotal/kpack/pkg/client/clientset/versioned/fake"
 	"github.com/pivotal/kpack/pkg/reconciler/clusterstack"
@@ -35,17 +35,17 @@ func testClusterStackReconciler(t *testing.T, when spec.G, it spec.S) {
 
 	fakeClusterStackReader := &clusterstackfakes.FakeClusterStackReader{}
 
-	testClusterStack := &v1alpha1.ClusterStack{
+	testClusterStack := &buildapi.ClusterStack{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       clusterStackName,
 			Generation: initialGeneration,
 		},
-		Spec: v1alpha1.ClusterStackSpec{
+		Spec: buildapi.ClusterStackSpec{
 			Id: "some.clusterStack.id",
-			BuildImage: v1alpha1.ClusterStackSpecImage{
+			BuildImage: buildapi.ClusterStackSpecImage{
 				Image: "some-registry.io/build-image",
 			},
-			RunImage: v1alpha1.ClusterStackSpecImage{
+			RunImage: buildapi.ClusterStackSpecImage{
 				Image: "some-registry.io/run-image",
 			},
 		},
@@ -65,11 +65,11 @@ func testClusterStackReconciler(t *testing.T, when spec.G, it spec.S) {
 
 	when("#Reconcile", func() {
 		it("saves metadata to the status", func() {
-			resolvedClusterStack := v1alpha1.ResolvedClusterStack{
-				BuildImage: v1alpha1.ClusterStackStatusImage{
+			resolvedClusterStack := buildapi.ResolvedClusterStack{
+				BuildImage: buildapi.ClusterStackStatusImage{
 					LatestImage: "some-registry.io/build-image@sha245:123",
 				},
-				RunImage: v1alpha1.ClusterStackStatusImage{
+				RunImage: buildapi.ClusterStackStatusImage{
 					LatestImage: "some-registry.io/run-image@sha245:123",
 				},
 				Mixins:  []string{"a-nice-mixin"},
@@ -86,10 +86,10 @@ func testClusterStackReconciler(t *testing.T, when spec.G, it spec.S) {
 				WantErr: false,
 				WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 					{
-						Object: &v1alpha1.ClusterStack{
+						Object: &buildapi.ClusterStack{
 							ObjectMeta: testClusterStack.ObjectMeta,
 							Spec:       testClusterStack.Spec,
-							Status: v1alpha1.ClusterStackStatus{
+							Status: buildapi.ClusterStackStatus{
 								Status: corev1alpha1.Status{
 									ObservedGeneration: 1,
 									Conditions: corev1alpha1.Conditions{
@@ -111,11 +111,11 @@ func testClusterStackReconciler(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("does not update the status with no status change", func() {
-			resolvedClusterStack := v1alpha1.ResolvedClusterStack{
-				BuildImage: v1alpha1.ClusterStackStatusImage{
+			resolvedClusterStack := buildapi.ResolvedClusterStack{
+				BuildImage: buildapi.ClusterStackStatusImage{
 					LatestImage: "some-registry.io/build-image@sha245:123",
 				},
-				RunImage: v1alpha1.ClusterStackStatusImage{
+				RunImage: buildapi.ClusterStackStatusImage{
 					LatestImage: "some-registry.io/run-image@sha245:123",
 				},
 				Mixins:  []string{"a-nice-mixin"},
@@ -124,7 +124,7 @@ func testClusterStackReconciler(t *testing.T, when spec.G, it spec.S) {
 			}
 			fakeClusterStackReader.ReadReturns(resolvedClusterStack, nil)
 
-			testClusterStack.Status = v1alpha1.ClusterStackStatus{
+			testClusterStack.Status = buildapi.ClusterStackStatus{
 				Status: corev1alpha1.Status{
 					ObservedGeneration: 1,
 					Conditions: corev1alpha1.Conditions{
@@ -146,7 +146,7 @@ func testClusterStackReconciler(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("sets the status to Ready False if error reading from clusterStack", func() {
-			fakeClusterStackReader.ReadReturns(v1alpha1.ResolvedClusterStack{}, errors.New("invalid mixins on run image"))
+			fakeClusterStackReader.ReadReturns(buildapi.ResolvedClusterStack{}, errors.New("invalid mixins on run image"))
 
 			rt.Test(rtesting.TableRow{
 				Key: clusterStackKey,
@@ -156,10 +156,10 @@ func testClusterStackReconciler(t *testing.T, when spec.G, it spec.S) {
 				WantErr: true,
 				WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 					{
-						Object: &v1alpha1.ClusterStack{
+						Object: &buildapi.ClusterStack{
 							ObjectMeta: testClusterStack.ObjectMeta,
 							Spec:       testClusterStack.Spec,
-							Status: v1alpha1.ClusterStackStatus{
+							Status: buildapi.ClusterStackStatus{
 								Status: corev1alpha1.Status{
 									ObservedGeneration: 1,
 									Conditions: corev1alpha1.Conditions{

--- a/pkg/reconciler/clusterstack/clusterstackfakes/fake_cluster_stack_reader.go
+++ b/pkg/reconciler/clusterstack/clusterstackfakes/fake_cluster_stack_reader.go
@@ -4,33 +4,33 @@ package clusterstackfakes
 import (
 	"sync"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/reconciler/clusterstack"
 )
 
 type FakeClusterStackReader struct {
-	ReadStub        func(v1alpha1.ClusterStackSpec) (v1alpha1.ResolvedClusterStack, error)
+	ReadStub        func(buildapi.ClusterStackSpec) (buildapi.ResolvedClusterStack, error)
 	readMutex       sync.RWMutex
 	readArgsForCall []struct {
-		arg1 v1alpha1.ClusterStackSpec
+		arg1 buildapi.ClusterStackSpec
 	}
 	readReturns struct {
-		result1 v1alpha1.ResolvedClusterStack
+		result1 buildapi.ResolvedClusterStack
 		result2 error
 	}
 	readReturnsOnCall map[int]struct {
-		result1 v1alpha1.ResolvedClusterStack
+		result1 buildapi.ResolvedClusterStack
 		result2 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeClusterStackReader) Read(arg1 v1alpha1.ClusterStackSpec) (v1alpha1.ResolvedClusterStack, error) {
+func (fake *FakeClusterStackReader) Read(arg1 buildapi.ClusterStackSpec) (buildapi.ResolvedClusterStack, error) {
 	fake.readMutex.Lock()
 	ret, specificReturn := fake.readReturnsOnCall[len(fake.readArgsForCall)]
 	fake.readArgsForCall = append(fake.readArgsForCall, struct {
-		arg1 v1alpha1.ClusterStackSpec
+		arg1 buildapi.ClusterStackSpec
 	}{arg1})
 	fake.recordInvocation("Read", []interface{}{arg1})
 	fake.readMutex.Unlock()
@@ -50,41 +50,41 @@ func (fake *FakeClusterStackReader) ReadCallCount() int {
 	return len(fake.readArgsForCall)
 }
 
-func (fake *FakeClusterStackReader) ReadCalls(stub func(v1alpha1.ClusterStackSpec) (v1alpha1.ResolvedClusterStack, error)) {
+func (fake *FakeClusterStackReader) ReadCalls(stub func(buildapi.ClusterStackSpec) (buildapi.ResolvedClusterStack, error)) {
 	fake.readMutex.Lock()
 	defer fake.readMutex.Unlock()
 	fake.ReadStub = stub
 }
 
-func (fake *FakeClusterStackReader) ReadArgsForCall(i int) v1alpha1.ClusterStackSpec {
+func (fake *FakeClusterStackReader) ReadArgsForCall(i int) buildapi.ClusterStackSpec {
 	fake.readMutex.RLock()
 	defer fake.readMutex.RUnlock()
 	argsForCall := fake.readArgsForCall[i]
 	return argsForCall.arg1
 }
 
-func (fake *FakeClusterStackReader) ReadReturns(result1 v1alpha1.ResolvedClusterStack, result2 error) {
+func (fake *FakeClusterStackReader) ReadReturns(result1 buildapi.ResolvedClusterStack, result2 error) {
 	fake.readMutex.Lock()
 	defer fake.readMutex.Unlock()
 	fake.ReadStub = nil
 	fake.readReturns = struct {
-		result1 v1alpha1.ResolvedClusterStack
+		result1 buildapi.ResolvedClusterStack
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeClusterStackReader) ReadReturnsOnCall(i int, result1 v1alpha1.ResolvedClusterStack, result2 error) {
+func (fake *FakeClusterStackReader) ReadReturnsOnCall(i int, result1 buildapi.ResolvedClusterStack, result2 error) {
 	fake.readMutex.Lock()
 	defer fake.readMutex.Unlock()
 	fake.ReadStub = nil
 	if fake.readReturnsOnCall == nil {
 		fake.readReturnsOnCall = make(map[int]struct {
-			result1 v1alpha1.ResolvedClusterStack
+			result1 buildapi.ResolvedClusterStack
 			result2 error
 		})
 	}
 	fake.readReturnsOnCall[i] = struct {
-		result1 v1alpha1.ResolvedClusterStack
+		result1 buildapi.ResolvedClusterStack
 		result2 error
 	}{result1, result2}
 }

--- a/pkg/reconciler/clusterstore/clusterstore_test.go
+++ b/pkg/reconciler/clusterstore/clusterstore_test.go
@@ -14,7 +14,7 @@ import (
 	"knative.dev/pkg/controller"
 	rtesting "knative.dev/pkg/reconciler/testing"
 
-	v1alpha1 "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 	"github.com/pivotal/kpack/pkg/client/clientset/versioned/fake"
 	"github.com/pivotal/kpack/pkg/reconciler/clusterstore"
@@ -50,13 +50,13 @@ func testClusterStoreReconciler(t *testing.T, when spec.G, it spec.S) {
 			return r, rtesting.ActionRecorderList{fakeClient}, rtesting.EventList{Recorder: record.NewFakeRecorder(10)}
 		})
 
-	store := &v1alpha1.ClusterStore{
+	store := &buildapi.ClusterStore{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       storeName,
 			Generation: initialGeneration,
 		},
-		Spec: v1alpha1.ClusterStoreSpec{
-			Sources: []v1alpha1.StoreImage{
+		Spec: buildapi.ClusterStoreSpec{
+			Sources: []buildapi.StoreImage{
 				{
 					Image: "some.registry/some-image-1",
 				},
@@ -68,25 +68,25 @@ func testClusterStoreReconciler(t *testing.T, when spec.G, it spec.S) {
 	}
 
 	when("#Reconcile", func() {
-		readBuildpacks := []v1alpha1.StoreBuildpack{
+		readBuildpacks := []buildapi.StoreBuildpack{
 			{
-				BuildpackInfo: v1alpha1.BuildpackInfo{
+				BuildpackInfo: buildapi.BuildpackInfo{
 					Id:      "paketo-buildpacks/node-engine",
 					Version: "0.0.116",
 				},
 				DiffId: "sha256:d57937f5ccb6f524afa02dd95224e1914c94a02483d37b07aa668e560dcb3bf4",
-				StoreImage: v1alpha1.StoreImage{
+				StoreImage: buildapi.StoreImage{
 					Image: "some.registry/some-image-1",
 				},
 				Order: nil,
 			},
 			{
-				BuildpackInfo: v1alpha1.BuildpackInfo{
+				BuildpackInfo: buildapi.BuildpackInfo{
 					Id:      "paketo-buildpacks/npm",
 					Version: "0.0.71",
 				},
 				DiffId: "sha256:c67840e5ccb6f524afa02dd95224e1914c94a02483d37b07aa668e560dcb3bf5",
-				StoreImage: v1alpha1.StoreImage{
+				StoreImage: buildapi.StoreImage{
 					Image: "some.registry/some-image-2",
 				},
 				Order: nil,
@@ -104,10 +104,10 @@ func testClusterStoreReconciler(t *testing.T, when spec.G, it spec.S) {
 				WantErr: false,
 				WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 					{
-						Object: &v1alpha1.ClusterStore{
+						Object: &buildapi.ClusterStore{
 							ObjectMeta: store.ObjectMeta,
 							Spec:       store.Spec,
-							Status: v1alpha1.ClusterStoreStatus{
+							Status: buildapi.ClusterStoreStatus{
 								Status: corev1alpha1.Status{
 									ObservedGeneration: 1,
 									Conditions: corev1alpha1.Conditions{
@@ -132,7 +132,7 @@ func testClusterStoreReconciler(t *testing.T, when spec.G, it spec.S) {
 		it("does not update the status with no status change", func() {
 			fakeStoreReader.ReadReturns(readBuildpacks, nil)
 
-			store.Status = v1alpha1.ClusterStoreStatus{
+			store.Status = buildapi.ClusterStoreStatus{
 				Status: corev1alpha1.Status{
 					ObservedGeneration: 1,
 					Conditions: corev1alpha1.Conditions{
@@ -164,10 +164,10 @@ func testClusterStoreReconciler(t *testing.T, when spec.G, it spec.S) {
 				WantErr: true,
 				WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 					{
-						Object: &v1alpha1.ClusterStore{
+						Object: &buildapi.ClusterStore{
 							ObjectMeta: store.ObjectMeta,
 							Spec:       store.Spec,
-							Status: v1alpha1.ClusterStoreStatus{
+							Status: buildapi.ClusterStoreStatus{
 								Status: corev1alpha1.Status{
 									ObservedGeneration: 1,
 									Conditions: corev1alpha1.Conditions{

--- a/pkg/reconciler/clusterstore/clusterstorefakes/fake_store_reader.go
+++ b/pkg/reconciler/clusterstore/clusterstorefakes/fake_store_reader.go
@@ -4,38 +4,38 @@ package clusterstorefakes
 import (
 	"sync"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/reconciler/clusterstore"
 )
 
 type FakeStoreReader struct {
-	ReadStub        func([]v1alpha1.StoreImage) ([]v1alpha1.StoreBuildpack, error)
+	ReadStub        func([]buildapi.StoreImage) ([]buildapi.StoreBuildpack, error)
 	readMutex       sync.RWMutex
 	readArgsForCall []struct {
-		arg1 []v1alpha1.StoreImage
+		arg1 []buildapi.StoreImage
 	}
 	readReturns struct {
-		result1 []v1alpha1.StoreBuildpack
+		result1 []buildapi.StoreBuildpack
 		result2 error
 	}
 	readReturnsOnCall map[int]struct {
-		result1 []v1alpha1.StoreBuildpack
+		result1 []buildapi.StoreBuildpack
 		result2 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeStoreReader) Read(arg1 []v1alpha1.StoreImage) ([]v1alpha1.StoreBuildpack, error) {
-	var arg1Copy []v1alpha1.StoreImage
+func (fake *FakeStoreReader) Read(arg1 []buildapi.StoreImage) ([]buildapi.StoreBuildpack, error) {
+	var arg1Copy []buildapi.StoreImage
 	if arg1 != nil {
-		arg1Copy = make([]v1alpha1.StoreImage, len(arg1))
+		arg1Copy = make([]buildapi.StoreImage, len(arg1))
 		copy(arg1Copy, arg1)
 	}
 	fake.readMutex.Lock()
 	ret, specificReturn := fake.readReturnsOnCall[len(fake.readArgsForCall)]
 	fake.readArgsForCall = append(fake.readArgsForCall, struct {
-		arg1 []v1alpha1.StoreImage
+		arg1 []buildapi.StoreImage
 	}{arg1Copy})
 	fake.recordInvocation("Read", []interface{}{arg1Copy})
 	fake.readMutex.Unlock()
@@ -55,41 +55,41 @@ func (fake *FakeStoreReader) ReadCallCount() int {
 	return len(fake.readArgsForCall)
 }
 
-func (fake *FakeStoreReader) ReadCalls(stub func([]v1alpha1.StoreImage) ([]v1alpha1.StoreBuildpack, error)) {
+func (fake *FakeStoreReader) ReadCalls(stub func([]buildapi.StoreImage) ([]buildapi.StoreBuildpack, error)) {
 	fake.readMutex.Lock()
 	defer fake.readMutex.Unlock()
 	fake.ReadStub = stub
 }
 
-func (fake *FakeStoreReader) ReadArgsForCall(i int) []v1alpha1.StoreImage {
+func (fake *FakeStoreReader) ReadArgsForCall(i int) []buildapi.StoreImage {
 	fake.readMutex.RLock()
 	defer fake.readMutex.RUnlock()
 	argsForCall := fake.readArgsForCall[i]
 	return argsForCall.arg1
 }
 
-func (fake *FakeStoreReader) ReadReturns(result1 []v1alpha1.StoreBuildpack, result2 error) {
+func (fake *FakeStoreReader) ReadReturns(result1 []buildapi.StoreBuildpack, result2 error) {
 	fake.readMutex.Lock()
 	defer fake.readMutex.Unlock()
 	fake.ReadStub = nil
 	fake.readReturns = struct {
-		result1 []v1alpha1.StoreBuildpack
+		result1 []buildapi.StoreBuildpack
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeStoreReader) ReadReturnsOnCall(i int, result1 []v1alpha1.StoreBuildpack, result2 error) {
+func (fake *FakeStoreReader) ReadReturnsOnCall(i int, result1 []buildapi.StoreBuildpack, result2 error) {
 	fake.readMutex.Lock()
 	defer fake.readMutex.Unlock()
 	fake.ReadStub = nil
 	if fake.readReturnsOnCall == nil {
 		fake.readReturnsOnCall = make(map[int]struct {
-			result1 []v1alpha1.StoreBuildpack
+			result1 []buildapi.StoreBuildpack
 			result2 error
 		})
 	}
 	fake.readReturnsOnCall[i] = struct {
-		result1 []v1alpha1.StoreBuildpack
+		result1 []buildapi.StoreBuildpack
 		result2 error
 	}{result1, result2}
 }

--- a/pkg/reconciler/image/build_list.go
+++ b/pkg/reconciler/image/build_list.go
@@ -5,16 +5,16 @@ import (
 
 	v1alpha1build "github.com/pivotal/kpack/pkg/reconciler/build"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 type buildList struct {
-	successfulBuilds []*v1alpha1.Build
-	failedBuilds     []*v1alpha1.Build
-	lastBuild        *v1alpha1.Build
+	successfulBuilds []*buildapi.Build
+	failedBuilds     []*buildapi.Build
+	lastBuild        *buildapi.Build
 }
 
-func newBuildList(builds []*v1alpha1.Build) (buildList, error) {
+func newBuildList(builds []*buildapi.Build) (buildList, error) {
 	sort.Sort(v1alpha1build.ByCreationTimestamp(builds)) //nobody enforcing this
 
 	buildList := buildList{}
@@ -38,7 +38,7 @@ func (l buildList) NumberFailedBuilds() int64 {
 	return int64(len(l.failedBuilds))
 }
 
-func (l buildList) OldestFailure() *v1alpha1.Build {
+func (l buildList) OldestFailure() *buildapi.Build {
 	return l.failedBuilds[0]
 }
 
@@ -46,6 +46,6 @@ func (l buildList) NumberSuccessfulBuilds() int64 {
 	return int64(len(l.successfulBuilds))
 }
 
-func (l buildList) OldestSuccess() *v1alpha1.Build {
+func (l buildList) OldestSuccess() *buildapi.Build {
 	return l.successfulBuilds[0]
 }

--- a/pkg/reconciler/image/image_test.go
+++ b/pkg/reconciler/image/image_test.go
@@ -21,7 +21,7 @@ import (
 	"knative.dev/pkg/kmeta"
 	rtesting "knative.dev/pkg/reconciler/testing"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 	"github.com/pivotal/kpack/pkg/client/clientset/versioned/fake"
 	"github.com/pivotal/kpack/pkg/reconciler/image"
@@ -76,7 +76,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 			return r, actionRecorderList, eventList
 		})
 
-	image := &v1alpha1.Image{
+	image := &buildapi.Image{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       imageName,
 			Namespace:  namespace,
@@ -85,25 +85,25 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 				someLabelKey: someValueToPassThrough,
 			},
 		},
-		Spec: v1alpha1.ImageSpec{
+		Spec: buildapi.ImageSpec{
 			Tag: "some/image",
 			Builder: corev1.ObjectReference{
 				Kind: "Builder",
 				Name: builderName,
 			},
 			ServiceAccount: serviceAccount,
-			Source: v1alpha1.SourceConfig{
-				Git: &v1alpha1.Git{
+			Source: buildapi.SourceConfig{
+				Git: &buildapi.Git{
 					URL:      "https://some.git/url",
 					Revision: "1234567",
 				},
 			},
 			FailedBuildHistoryLimit:  limit(10),
 			SuccessBuildHistoryLimit: limit(10),
-			ImageTaggingStrategy:     v1alpha1.None,
-			Build:                    &v1alpha1.ImageBuild{},
+			ImageTaggingStrategy:     buildapi.None,
+			Build:                    &buildapi.ImageBuild{},
 		},
-		Status: v1alpha1.ImageStatus{
+		Status: buildapi.ImageStatus{
 			Status: corev1alpha1.Status{
 				ObservedGeneration: originalGeneration,
 				Conditions:         conditionReadyUnknown(),
@@ -111,20 +111,20 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 		},
 	}
 
-	builder := &v1alpha1.Builder{
+	builder := &buildapi.Builder{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      builderName,
 			Namespace: namespace,
 		},
-		Status: v1alpha1.BuilderStatus{
+		Status: buildapi.BuilderStatus{
 			LatestImage: "some/builder@sha256:acf123",
-			BuilderMetadata: v1alpha1.BuildpackMetadataList{
+			BuilderMetadata: buildapi.BuildpackMetadataList{
 				{
 					Id:      "buildpack.version",
 					Version: "version",
 				},
 			},
-			Stack: v1alpha1.BuildStack{
+			Stack: buildapi.BuildStack{
 				RunImage: "some/run@sha256:67e3de2af270bf09c02e9a644aeb7e87e6b3c049abe6766bf6b6c3728a83e7fb",
 				ID:       "io.buildpacks.stacks.bionic",
 			},
@@ -139,19 +139,19 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 		},
 	}
 
-	clusterBuilder := &v1alpha1.ClusterBuilder{
+	clusterBuilder := &buildapi.ClusterBuilder{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clusterBuilderName,
 		},
-		Status: v1alpha1.BuilderStatus{
+		Status: buildapi.BuilderStatus{
 			LatestImage: "some/clusterbuilder@sha256:acf123",
-			BuilderMetadata: v1alpha1.BuildpackMetadataList{
+			BuilderMetadata: buildapi.BuildpackMetadataList{
 				{
 					Id:      "buildpack.version",
 					Version: "version",
 				},
 			},
-			Stack: v1alpha1.BuildStack{
+			Stack: buildapi.BuildStack{
 				RunImage: "some/run@sha256:67e3de2af270bf09c02e9a644aeb7e87e6b3c049abe6766bf6b6c3728a83e7fb",
 				ID:       "io.buildpacks.stacks.bionic",
 			},
@@ -183,10 +183,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 				WantErr: false,
 				WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 					{
-						Object: &v1alpha1.Image{
+						Object: &buildapi.Image{
 							ObjectMeta: image.ObjectMeta,
 							Spec:       image.Spec,
-							Status: v1alpha1.ImageStatus{
+							Status: buildapi.ImageStatus{
 								Status: corev1alpha1.Status{
 									ObservedGeneration: updatedGeneration,
 									Conditions:         conditionReadyUnknown(),
@@ -235,10 +235,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 				WantErr: false,
 				WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 					{
-						Object: &v1alpha1.Image{
+						Object: &buildapi.Image{
 							ObjectMeta: image.ObjectMeta,
 							Spec:       image.Spec,
-							Status: v1alpha1.ImageStatus{
+							Status: buildapi.ImageStatus{
 								Status: corev1alpha1.Status{
 									ObservedGeneration: originalGeneration,
 									Conditions: corev1alpha1.Conditions{
@@ -267,7 +267,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantErr: false,
 					WantCreates: []runtime.Object{
-						&v1alpha1.SourceResolver{
+						&buildapi.SourceResolver{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      image.SourceResolverName(),
 								Namespace: namespace,
@@ -278,7 +278,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									someLabelKey: someValueToPassThrough,
 								},
 							},
-							Spec: v1alpha1.SourceResolverSpec{
+							Spec: buildapi.SourceResolverSpec{
 								ServiceAccount: image.Spec.ServiceAccount,
 								Source:         image.Spec.Source,
 							},
@@ -305,7 +305,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					Objects: []runtime.Object{
 						image,
 						builder,
-						&v1alpha1.SourceResolver{
+						&buildapi.SourceResolver{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      image.SourceResolverName(),
 								Namespace: namespace,
@@ -316,10 +316,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 							},
-							Spec: v1alpha1.SourceResolverSpec{
+							Spec: buildapi.SourceResolverSpec{
 								ServiceAccount: "old-account",
-								Source: v1alpha1.SourceConfig{
-									Git: &v1alpha1.Git{
+								Source: buildapi.SourceConfig{
+									Git: &buildapi.Git{
 										URL:      "old-url",
 										Revision: "old-revision",
 									},
@@ -330,7 +330,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					WantErr: false,
 					WantUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.SourceResolver{
+							Object: &buildapi.SourceResolver{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:      image.SourceResolverName(),
 									Namespace: namespace,
@@ -341,7 +341,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 										*kmeta.NewControllerRef(image),
 									},
 								},
-								Spec: v1alpha1.SourceResolverSpec{
+								Spec: buildapi.SourceResolverSpec{
 									ServiceAccount: image.Spec.ServiceAccount,
 									Source:         image.Spec.Source,
 								},
@@ -366,7 +366,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					WantErr: false,
 					WantUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.SourceResolver{
+							Object: &buildapi.SourceResolver{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:      image.SourceResolverName(),
 									Namespace: namespace,
@@ -378,7 +378,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 										"another/label": "label",
 									},
 								},
-								Spec: v1alpha1.SourceResolverSpec{
+								Spec: buildapi.SourceResolverSpec{
 									ServiceAccount: image.Spec.ServiceAccount,
 									Source:         image.Spec.Source,
 								},
@@ -427,10 +427,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Image{
+							Object: &buildapi.Image{
 								ObjectMeta: image.ObjectMeta,
 								Spec:       image.Spec,
-								Status: v1alpha1.ImageStatus{
+								Status: buildapi.ImageStatus{
 									BuildCacheName: image.CacheName(),
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
@@ -594,10 +594,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Image{
+							Object: &buildapi.Image{
 								ObjectMeta: image.ObjectMeta,
 								Spec:       image.Spec,
-								Status: v1alpha1.ImageStatus{
+								Status: buildapi.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions:         conditionReadyUnknown(),
@@ -634,10 +634,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					WantErr: false,
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Image{
+							Object: &buildapi.Image{
 								ObjectMeta: image.ObjectMeta,
 								Spec:       image.Spec,
-								Status: v1alpha1.ImageStatus{
+								Status: buildapi.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions: corev1alpha1.Conditions{
@@ -646,9 +646,9 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 												Status: corev1.ConditionUnknown,
 											},
 											{
-												Type:    v1alpha1.ConditionBuilderReady,
+												Type:    buildapi.ConditionBuilderReady,
 												Status:  corev1.ConditionFalse,
-												Reason:  v1alpha1.BuilderNotReady,
+												Reason:  buildapi.BuilderNotReady,
 												Message: "Builder builder-name is not ready",
 											},
 										},
@@ -671,7 +671,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantErr: false,
 					WantCreates: []runtime.Object{
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: metav1.ObjectMeta{
 								GenerateName: imageName + "-build-1-",
 								Namespace:    namespace,
@@ -679,14 +679,14 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel:     "1",
-									v1alpha1.ImageLabel:           imageName,
-									v1alpha1.ImageGenerationLabel: generation(image),
+									buildapi.BuildNumberLabel:     "1",
+									buildapi.ImageLabel:           imageName,
+									buildapi.ImageGenerationLabel: generation(image),
 									someLabelKey:                  someValueToPassThrough,
 								},
 								Annotations: map[string]string{
-									v1alpha1.BuildReasonAnnotation: v1alpha1.BuildReasonConfig,
-									v1alpha1.BuildChangesAnnotation: testhelpers.CompactJSON(`
+									buildapi.BuildReasonAnnotation: buildapi.BuildReasonConfig,
+									buildapi.BuildChangesAnnotation: testhelpers.CompactJSON(`
 [
   {
     "reason": "CONFIG",
@@ -707,14 +707,14 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 ]`),
 								},
 							},
-							Spec: v1alpha1.BuildSpec{
+							Spec: buildapi.BuildSpec{
 								Tags: []string{image.Spec.Tag},
-								Builder: v1alpha1.BuildBuilderSpec{
+								Builder: buildapi.BuildBuilderSpec{
 									Image: builder.Status.LatestImage,
 								},
 								ServiceAccount: image.Spec.ServiceAccount,
-								Source: v1alpha1.SourceConfig{
-									Git: &v1alpha1.Git{
+								Source: buildapi.SourceConfig{
+									Git: &buildapi.Git{
 										URL:      sourceResolver.Status.Source.Git.URL,
 										Revision: sourceResolver.Status.Source.Git.Revision,
 									},
@@ -724,10 +724,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Image{
+							Object: &buildapi.Image{
 								ObjectMeta: image.ObjectMeta,
 								Spec:       image.Spec,
-								Status: v1alpha1.ImageStatus{
+								Status: buildapi.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions:         conditionBuildExecuting("image-name-build-1-00001"),
@@ -745,7 +745,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 
 			it("schedules a build with a cluster builder", func() {
 				image.Spec.Builder = corev1.ObjectReference{
-					Kind: v1alpha1.ClusterBuilderKind,
+					Kind: buildapi.ClusterBuilderKind,
 					Name: clusterBuilderName,
 				}
 
@@ -760,7 +760,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantErr: false,
 					WantCreates: []runtime.Object{
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: metav1.ObjectMeta{
 								GenerateName: imageName + "-build-1-",
 								Namespace:    namespace,
@@ -768,14 +768,14 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel:     "1",
-									v1alpha1.ImageLabel:           imageName,
-									v1alpha1.ImageGenerationLabel: generation(image),
+									buildapi.BuildNumberLabel:     "1",
+									buildapi.ImageLabel:           imageName,
+									buildapi.ImageGenerationLabel: generation(image),
 									someLabelKey:                  someValueToPassThrough,
 								},
 								Annotations: map[string]string{
-									v1alpha1.BuildReasonAnnotation: v1alpha1.BuildReasonConfig,
-									v1alpha1.BuildChangesAnnotation: testhelpers.CompactJSON(`
+									buildapi.BuildReasonAnnotation: buildapi.BuildReasonConfig,
+									buildapi.BuildChangesAnnotation: testhelpers.CompactJSON(`
 [
   {
     "reason": "CONFIG",
@@ -796,14 +796,14 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 ]`),
 								},
 							},
-							Spec: v1alpha1.BuildSpec{
+							Spec: buildapi.BuildSpec{
 								Tags: []string{image.Spec.Tag},
-								Builder: v1alpha1.BuildBuilderSpec{
+								Builder: buildapi.BuildBuilderSpec{
 									Image: clusterBuilder.Status.LatestImage,
 								},
 								ServiceAccount: image.Spec.ServiceAccount,
-								Source: v1alpha1.SourceConfig{
-									Git: &v1alpha1.Git{
+								Source: buildapi.SourceConfig{
+									Git: &buildapi.Git{
 										URL:      sourceResolver.Status.Source.Git.URL,
 										Revision: sourceResolver.Status.Source.Git.Revision,
 									},
@@ -813,10 +813,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Image{
+							Object: &buildapi.Image{
 								ObjectMeta: image.ObjectMeta,
 								Spec:       image.Spec,
-								Status: v1alpha1.ImageStatus{
+								Status: buildapi.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions:         conditionBuildExecuting("image-name-build-1-00001"),
@@ -834,7 +834,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 
 			it("schedules a build with a builder", func() {
 				image.Spec.Builder = corev1.ObjectReference{
-					Kind: v1alpha1.BuilderKind,
+					Kind: buildapi.BuilderKind,
 					Name: builderName,
 				}
 
@@ -849,7 +849,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantErr: false,
 					WantCreates: []runtime.Object{
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: metav1.ObjectMeta{
 								GenerateName: imageName + "-build-1-",
 								Namespace:    namespace,
@@ -857,14 +857,14 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel:     "1",
-									v1alpha1.ImageLabel:           imageName,
-									v1alpha1.ImageGenerationLabel: generation(image),
+									buildapi.BuildNumberLabel:     "1",
+									buildapi.ImageLabel:           imageName,
+									buildapi.ImageGenerationLabel: generation(image),
 									someLabelKey:                  someValueToPassThrough,
 								},
 								Annotations: map[string]string{
-									v1alpha1.BuildReasonAnnotation: v1alpha1.BuildReasonConfig,
-									v1alpha1.BuildChangesAnnotation: testhelpers.CompactJSON(`
+									buildapi.BuildReasonAnnotation: buildapi.BuildReasonConfig,
+									buildapi.BuildChangesAnnotation: testhelpers.CompactJSON(`
 [
   {
     "reason": "CONFIG",
@@ -885,14 +885,14 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 ]`),
 								},
 							},
-							Spec: v1alpha1.BuildSpec{
+							Spec: buildapi.BuildSpec{
 								Tags: []string{image.Spec.Tag},
-								Builder: v1alpha1.BuildBuilderSpec{
+								Builder: buildapi.BuildBuilderSpec{
 									Image: builder.Status.LatestImage,
 								},
 								ServiceAccount: image.Spec.ServiceAccount,
-								Source: v1alpha1.SourceConfig{
-									Git: &v1alpha1.Git{
+								Source: buildapi.SourceConfig{
+									Git: &buildapi.Git{
 										URL:      sourceResolver.Status.Source.Git.URL,
 										Revision: sourceResolver.Status.Source.Git.Revision,
 									},
@@ -902,10 +902,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Image{
+							Object: &buildapi.Image{
 								ObjectMeta: image.ObjectMeta,
 								Spec:       image.Spec,
-								Status: v1alpha1.ImageStatus{
+								Status: buildapi.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions:         conditionBuildExecuting("image-name-build-1-00001"),
@@ -923,7 +923,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 
 			it("schedules a build with a cluster builder", func() {
 				image.Spec.Builder = corev1.ObjectReference{
-					Kind: v1alpha1.ClusterBuilderKind,
+					Kind: buildapi.ClusterBuilderKind,
 					Name: clusterBuilderName,
 				}
 
@@ -939,7 +939,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantErr: false,
 					WantCreates: []runtime.Object{
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: metav1.ObjectMeta{
 								GenerateName: imageName + "-build-1-",
 								Namespace:    namespace,
@@ -947,14 +947,14 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel:     "1",
-									v1alpha1.ImageLabel:           imageName,
-									v1alpha1.ImageGenerationLabel: generation(image),
+									buildapi.BuildNumberLabel:     "1",
+									buildapi.ImageLabel:           imageName,
+									buildapi.ImageGenerationLabel: generation(image),
 									someLabelKey:                  someValueToPassThrough,
 								},
 								Annotations: map[string]string{
-									v1alpha1.BuildReasonAnnotation: v1alpha1.BuildReasonConfig,
-									v1alpha1.BuildChangesAnnotation: testhelpers.CompactJSON(`
+									buildapi.BuildReasonAnnotation: buildapi.BuildReasonConfig,
+									buildapi.BuildChangesAnnotation: testhelpers.CompactJSON(`
 [
   {
     "reason": "CONFIG",
@@ -975,14 +975,14 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 ]`),
 								},
 							},
-							Spec: v1alpha1.BuildSpec{
+							Spec: buildapi.BuildSpec{
 								Tags: []string{image.Spec.Tag},
-								Builder: v1alpha1.BuildBuilderSpec{
+								Builder: buildapi.BuildBuilderSpec{
 									Image: clusterBuilder.Status.LatestImage,
 								},
 								ServiceAccount: image.Spec.ServiceAccount,
-								Source: v1alpha1.SourceConfig{
-									Git: &v1alpha1.Git{
+								Source: buildapi.SourceConfig{
+									Git: &buildapi.Git{
 										URL:      sourceResolver.Status.Source.Git.URL,
 										Revision: sourceResolver.Status.Source.Git.Revision,
 									},
@@ -992,10 +992,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Image{
+							Object: &buildapi.Image{
 								ObjectMeta: image.ObjectMeta,
 								Spec:       image.Spec,
-								Status: v1alpha1.ImageStatus{
+								Status: buildapi.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions:         conditionBuildExecuting("image-name-build-1-00001"),
@@ -1027,7 +1027,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantErr: false,
 					WantCreates: []runtime.Object{
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: metav1.ObjectMeta{
 								GenerateName: imageName + "-build-1-",
 								Namespace:    namespace,
@@ -1035,14 +1035,14 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel:     "1",
-									v1alpha1.ImageLabel:           imageName,
-									v1alpha1.ImageGenerationLabel: generation(image),
+									buildapi.BuildNumberLabel:     "1",
+									buildapi.ImageLabel:           imageName,
+									buildapi.ImageGenerationLabel: generation(image),
 									someLabelKey:                  someValueToPassThrough,
 								},
 								Annotations: map[string]string{
-									v1alpha1.BuildReasonAnnotation: v1alpha1.BuildReasonConfig,
-									v1alpha1.BuildChangesAnnotation: testhelpers.CompactJSON(`
+									buildapi.BuildReasonAnnotation: buildapi.BuildReasonConfig,
+									buildapi.BuildChangesAnnotation: testhelpers.CompactJSON(`
 [
   {
     "reason": "CONFIG",
@@ -1063,14 +1063,14 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 ]`),
 								},
 							},
-							Spec: v1alpha1.BuildSpec{
+							Spec: buildapi.BuildSpec{
 								Tags: []string{image.Spec.Tag},
-								Builder: v1alpha1.BuildBuilderSpec{
+								Builder: buildapi.BuildBuilderSpec{
 									Image: builder.Status.LatestImage,
 								},
 								ServiceAccount: image.Spec.ServiceAccount,
-								Source: v1alpha1.SourceConfig{
-									Git: &v1alpha1.Git{
+								Source: buildapi.SourceConfig{
+									Git: &buildapi.Git{
 										URL:      sourceResolver.Status.Source.Git.URL,
 										Revision: sourceResolver.Status.Source.Git.Revision,
 									},
@@ -1081,10 +1081,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Image{
+							Object: &buildapi.Image{
 								ObjectMeta: image.ObjectMeta,
 								Spec:       image.Spec,
-								Status: v1alpha1.ImageStatus{
+								Status: buildapi.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions:         conditionBuildExecuting("image-name-build-1-00001"),
@@ -1112,7 +1112,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 						image,
 						builder,
 						sourceResolver,
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "image-name-build-1-00001",
 								Namespace: namespace,
@@ -1120,26 +1120,26 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel: "1",
-									v1alpha1.ImageLabel:       imageName,
+									buildapi.BuildNumberLabel: "1",
+									buildapi.ImageLabel:       imageName,
 								},
 							},
-							Spec: v1alpha1.BuildSpec{
+							Spec: buildapi.BuildSpec{
 								Tags: []string{image.Spec.Tag},
-								Builder: v1alpha1.BuildBuilderSpec{
+								Builder: buildapi.BuildBuilderSpec{
 									Image: builder.Status.LatestImage,
 								},
 								ServiceAccount: "old-service-account",
-								Source: v1alpha1.SourceConfig{
-									Git: &v1alpha1.Git{
+								Source: buildapi.SourceConfig{
+									Git: &buildapi.Git{
 										URL:      "out-of-date-git-url",
 										Revision: "out-of-date-git-revision",
 									},
 								},
 							},
-							Status: v1alpha1.BuildStatus{
+							Status: buildapi.BuildStatus{
 								LatestImage: image.Spec.Tag + "@sha256:just-built",
-								Stack: v1alpha1.BuildStack{
+								Stack: buildapi.BuildStack{
 									RunImage: "some/run@sha256:67e3de2af270bf09c02e9a644aeb7e87e6b3c049abe6766bf6b6c3728a83e7fb",
 									ID:       "io.buildpacks.stacks.bionic",
 								},
@@ -1156,7 +1156,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantErr: false,
 					WantCreates: []runtime.Object{
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: metav1.ObjectMeta{
 								GenerateName: imageName + "-build-2-",
 								Namespace:    namespace,
@@ -1164,17 +1164,17 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel:     "2",
-									v1alpha1.ImageLabel:           imageName,
+									buildapi.BuildNumberLabel:     "2",
+									buildapi.ImageLabel:           imageName,
 									someLabelKey:                  someValueToPassThrough,
-									v1alpha1.ImageGenerationLabel: generation(image),
+									buildapi.ImageGenerationLabel: generation(image),
 								},
 								Annotations: map[string]string{
-									v1alpha1.BuildReasonAnnotation: strings.Join([]string{
-										v1alpha1.BuildReasonCommit,
-										v1alpha1.BuildReasonConfig,
+									buildapi.BuildReasonAnnotation: strings.Join([]string{
+										buildapi.BuildReasonCommit,
+										buildapi.BuildReasonConfig,
 									}, ","),
-									v1alpha1.BuildChangesAnnotation: testhelpers.CompactJSON(`
+									buildapi.BuildChangesAnnotation: testhelpers.CompactJSON(`
 [
   {
     "reason": "COMMIT",
@@ -1205,19 +1205,19 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 ]`),
 								},
 							},
-							Spec: v1alpha1.BuildSpec{
+							Spec: buildapi.BuildSpec{
 								Tags: []string{image.Spec.Tag},
-								Builder: v1alpha1.BuildBuilderSpec{
+								Builder: buildapi.BuildBuilderSpec{
 									Image: builder.Status.LatestImage,
 								},
 								ServiceAccount: image.Spec.ServiceAccount,
-								Source: v1alpha1.SourceConfig{
-									Git: &v1alpha1.Git{
+								Source: buildapi.SourceConfig{
+									Git: &buildapi.Git{
 										URL:      sourceResolver.Status.Source.Git.URL,
 										Revision: sourceResolver.Status.Source.Git.Revision,
 									},
 								},
-								LastBuild: &v1alpha1.LastBuild{
+								LastBuild: &buildapi.LastBuild{
 									Image:   "some/image@sha256:just-built",
 									StackId: "io.buildpacks.stacks.bionic",
 								},
@@ -1226,10 +1226,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Image{
+							Object: &buildapi.Image{
 								ObjectMeta: image.ObjectMeta,
 								Spec:       image.Spec,
-								Status: v1alpha1.ImageStatus{
+								Status: buildapi.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions:         conditionBuildExecuting("image-name-build-2-00001"),
@@ -1251,11 +1251,11 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 				image.Status.LatestBuildRef = "image-name-build-1-00001"
 
 				sourceResolver := image.SourceResolver()
-				sourceResolver.ResolvedSource(v1alpha1.ResolvedSourceConfig{
-					Git: &v1alpha1.ResolvedGitSource{
+				sourceResolver.ResolvedSource(buildapi.ResolvedSourceConfig{
+					Git: &buildapi.ResolvedGitSource{
 						URL:      image.Spec.Source.Git.URL,
 						Revision: "new-commit",
-						Type:     v1alpha1.Branch,
+						Type:     buildapi.Branch,
 					},
 				})
 
@@ -1265,7 +1265,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 						image,
 						builder,
 						sourceResolver,
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "image-name-build-1-00001",
 								Namespace: namespace,
@@ -1273,29 +1273,29 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel: "1",
-									v1alpha1.ImageLabel:       imageName,
+									buildapi.BuildNumberLabel: "1",
+									buildapi.ImageLabel:       imageName,
 								},
 								Annotations: map[string]string{
-									v1alpha1.BuildReasonAnnotation: v1alpha1.BuildReasonCommit,
+									buildapi.BuildReasonAnnotation: buildapi.BuildReasonCommit,
 								},
 							},
-							Spec: v1alpha1.BuildSpec{
+							Spec: buildapi.BuildSpec{
 								Tags: []string{image.Spec.Tag},
-								Builder: v1alpha1.BuildBuilderSpec{
+								Builder: buildapi.BuildBuilderSpec{
 									Image: builder.Status.LatestImage,
 								},
 								ServiceAccount: image.Spec.ServiceAccount,
-								Source: v1alpha1.SourceConfig{
-									Git: &v1alpha1.Git{
+								Source: buildapi.SourceConfig{
+									Git: &buildapi.Git{
 										URL:      image.Spec.Source.Git.URL,
 										Revision: image.Spec.Source.Git.Revision,
 									},
 								},
 							},
-							Status: v1alpha1.BuildStatus{
+							Status: buildapi.BuildStatus{
 								LatestImage: image.Spec.Tag + "@sha256:just-built",
-								Stack: v1alpha1.BuildStack{
+								Stack: buildapi.BuildStack{
 									RunImage: "some/run@sha256:67e3de2af270bf09c02e9a644aeb7e87e6b3c049abe6766bf6b6c3728a83e7fb",
 									ID:       "io.buildpacks.stacks.bionic",
 								},
@@ -1312,7 +1312,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantErr: false,
 					WantCreates: []runtime.Object{
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: metav1.ObjectMeta{
 								GenerateName: imageName + "-build-2-",
 								Namespace:    namespace,
@@ -1320,29 +1320,29 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel:     "2",
-									v1alpha1.ImageLabel:           imageName,
-									v1alpha1.ImageGenerationLabel: generation(image),
+									buildapi.BuildNumberLabel:     "2",
+									buildapi.ImageLabel:           imageName,
+									buildapi.ImageGenerationLabel: generation(image),
 									someLabelKey:                  someValueToPassThrough,
 								},
 								Annotations: map[string]string{
-									v1alpha1.BuildReasonAnnotation:  v1alpha1.BuildReasonCommit,
-									v1alpha1.BuildChangesAnnotation: `[{"reason":"COMMIT","old":"1234567","new":"new-commit"}]`,
+									buildapi.BuildReasonAnnotation:  buildapi.BuildReasonCommit,
+									buildapi.BuildChangesAnnotation: `[{"reason":"COMMIT","old":"1234567","new":"new-commit"}]`,
 								},
 							},
-							Spec: v1alpha1.BuildSpec{
+							Spec: buildapi.BuildSpec{
 								Tags: []string{image.Spec.Tag},
-								Builder: v1alpha1.BuildBuilderSpec{
+								Builder: buildapi.BuildBuilderSpec{
 									Image: builder.Status.LatestImage,
 								},
 								ServiceAccount: image.Spec.ServiceAccount,
-								Source: v1alpha1.SourceConfig{
-									Git: &v1alpha1.Git{
+								Source: buildapi.SourceConfig{
+									Git: &buildapi.Git{
 										URL:      sourceResolver.Status.Source.Git.URL,
 										Revision: sourceResolver.Status.Source.Git.Revision,
 									},
 								},
-								LastBuild: &v1alpha1.LastBuild{
+								LastBuild: &buildapi.LastBuild{
 									Image:   "some/image@sha256:just-built",
 									StackId: "io.buildpacks.stacks.bionic",
 								},
@@ -1351,10 +1351,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Image{
+							Object: &buildapi.Image{
 								ObjectMeta: image.ObjectMeta,
 								Spec:       image.Spec,
-								Status: v1alpha1.ImageStatus{
+								Status: buildapi.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions:         conditionBuildExecuting("image-name-build-2-00001"),
@@ -1381,12 +1381,12 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					Key: key,
 					Objects: []runtime.Object{
 						image,
-						&v1alpha1.Builder{
+						&buildapi.Builder{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      builderName,
 								Namespace: namespace,
 							},
-							Status: v1alpha1.BuilderStatus{
+							Status: buildapi.BuilderStatus{
 								Status: corev1alpha1.Status{
 									Conditions: corev1alpha1.Conditions{
 										{
@@ -1396,11 +1396,11 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									},
 								},
 								LatestImage: updatedBuilderImage,
-								Stack: v1alpha1.BuildStack{
+								Stack: buildapi.BuildStack{
 									RunImage: "some/run@sha256:67e3de2af270bf09c02e9a644aeb7e87e6b3c049abe6766bf6b6c3728a83e7fb",
 									ID:       "io.buildpacks.stacks.bionic",
 								},
-								BuilderMetadata: v1alpha1.BuildpackMetadataList{
+								BuilderMetadata: buildapi.BuildpackMetadataList{
 									{
 										Id:      "io.buildpack",
 										Version: "new-version",
@@ -1409,7 +1409,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 							},
 						},
 						sourceResolver,
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "image-name-build-1-00001",
 								Namespace: namespace,
@@ -1417,24 +1417,24 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel: "1",
-									v1alpha1.ImageLabel:       imageName,
+									buildapi.BuildNumberLabel: "1",
+									buildapi.ImageLabel:       imageName,
 								},
 							},
-							Spec: v1alpha1.BuildSpec{
+							Spec: buildapi.BuildSpec{
 								Tags: []string{image.Spec.Tag},
-								Builder: v1alpha1.BuildBuilderSpec{
+								Builder: buildapi.BuildBuilderSpec{
 									Image: updatedBuilderImage,
 								},
 								ServiceAccount: image.Spec.ServiceAccount,
-								Source: v1alpha1.SourceConfig{
-									Git: &v1alpha1.Git{
+								Source: buildapi.SourceConfig{
+									Git: &buildapi.Git{
 										URL:      sourceResolver.Status.Source.Git.URL,
 										Revision: sourceResolver.Status.Source.Git.Revision,
 									},
 								},
 							},
-							Status: v1alpha1.BuildStatus{
+							Status: buildapi.BuildStatus{
 								LatestImage: image.Spec.Tag + "@sha256:just-built",
 								Status: corev1alpha1.Status{
 									Conditions: corev1alpha1.Conditions{
@@ -1444,11 +1444,11 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 										},
 									},
 								},
-								Stack: v1alpha1.BuildStack{
+								Stack: buildapi.BuildStack{
 									RunImage: "some/run@sha256:67e3de2af270bf09c02e9a644aeb7e87e6b3c049abe6766bf6b6c3728a83e7fb",
 									ID:       "io.buildpacks.stacks.bionic",
 								},
-								BuildMetadata: v1alpha1.BuildpackMetadataList{
+								BuildMetadata: buildapi.BuildpackMetadataList{
 									{
 										Id:      "io.buildpack",
 										Version: "old-version",
@@ -1459,7 +1459,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantErr: false,
 					WantCreates: []runtime.Object{
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: metav1.ObjectMeta{
 								GenerateName: imageName + "-build-2-",
 								Namespace:    namespace,
@@ -1467,14 +1467,14 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel:     "2",
-									v1alpha1.ImageLabel:           imageName,
-									v1alpha1.ImageGenerationLabel: generation(image),
+									buildapi.BuildNumberLabel:     "2",
+									buildapi.ImageLabel:           imageName,
+									buildapi.ImageGenerationLabel: generation(image),
 									someLabelKey:                  someValueToPassThrough,
 								},
 								Annotations: map[string]string{
-									v1alpha1.BuildReasonAnnotation: v1alpha1.BuildReasonBuildpack,
-									v1alpha1.BuildChangesAnnotation: testhelpers.CompactJSON(`
+									buildapi.BuildReasonAnnotation: buildapi.BuildReasonBuildpack,
+									buildapi.BuildChangesAnnotation: testhelpers.CompactJSON(`
 [
   {
     "reason": "BUILDPACK",
@@ -1489,19 +1489,19 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 ]`),
 								},
 							},
-							Spec: v1alpha1.BuildSpec{
+							Spec: buildapi.BuildSpec{
 								Tags: []string{image.Spec.Tag},
-								Builder: v1alpha1.BuildBuilderSpec{
+								Builder: buildapi.BuildBuilderSpec{
 									Image: updatedBuilderImage,
 								},
 								ServiceAccount: image.Spec.ServiceAccount,
-								Source: v1alpha1.SourceConfig{
-									Git: &v1alpha1.Git{
+								Source: buildapi.SourceConfig{
+									Git: &buildapi.Git{
 										URL:      sourceResolver.Status.Source.Git.URL,
 										Revision: sourceResolver.Status.Source.Git.Revision,
 									},
 								},
-								LastBuild: &v1alpha1.LastBuild{
+								LastBuild: &buildapi.LastBuild{
 									Image:   "some/image@sha256:just-built",
 									StackId: "io.buildpacks.stacks.bionic",
 								},
@@ -1510,10 +1510,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Image{
+							Object: &buildapi.Image{
 								ObjectMeta: image.ObjectMeta,
 								Spec:       image.Spec,
-								Status: v1alpha1.ImageStatus{
+								Status: buildapi.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions:         conditionBuildExecuting("image-name-build-2-00001"),
@@ -1540,12 +1540,12 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					Key: key,
 					Objects: []runtime.Object{
 						image,
-						&v1alpha1.Builder{
+						&buildapi.Builder{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      builderName,
 								Namespace: namespace,
 							},
-							Status: v1alpha1.BuilderStatus{
+							Status: buildapi.BuilderStatus{
 								Status: corev1alpha1.Status{
 									Conditions: corev1alpha1.Conditions{
 										{
@@ -1555,11 +1555,11 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									},
 								},
 								LatestImage: updatedBuilderImage,
-								Stack: v1alpha1.BuildStack{
+								Stack: buildapi.BuildStack{
 									RunImage: "gcr.io/test-project/install/run@sha256:01ea3600f15a73f0ad445351c681eb0377738f5964cbcd2bab0cfec9ca891a08",
 									ID:       "io.buildpacks.stacks.bionic",
 								},
-								BuilderMetadata: v1alpha1.BuildpackMetadataList{
+								BuilderMetadata: buildapi.BuildpackMetadataList{
 									{
 										Id:      "io.buildpack",
 										Version: "version",
@@ -1568,7 +1568,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 							},
 						},
 						sourceResolver,
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "image-name-build-1-00001",
 								Namespace: namespace,
@@ -1576,24 +1576,24 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel: "1",
-									v1alpha1.ImageLabel:       imageName,
+									buildapi.BuildNumberLabel: "1",
+									buildapi.ImageLabel:       imageName,
 								},
 							},
-							Spec: v1alpha1.BuildSpec{
+							Spec: buildapi.BuildSpec{
 								Tags: []string{image.Spec.Tag},
-								Builder: v1alpha1.BuildBuilderSpec{
+								Builder: buildapi.BuildBuilderSpec{
 									Image: updatedBuilderImage,
 								},
 								ServiceAccount: image.Spec.ServiceAccount,
-								Source: v1alpha1.SourceConfig{
-									Git: &v1alpha1.Git{
+								Source: buildapi.SourceConfig{
+									Git: &buildapi.Git{
 										URL:      sourceResolver.Status.Source.Git.URL,
 										Revision: sourceResolver.Status.Source.Git.Revision,
 									},
 								},
 							},
-							Status: v1alpha1.BuildStatus{
+							Status: buildapi.BuildStatus{
 								LatestImage: image.Spec.Tag + "@sha256:just-built",
 								Status: corev1alpha1.Status{
 									Conditions: corev1alpha1.Conditions{
@@ -1603,11 +1603,11 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 										},
 									},
 								},
-								Stack: v1alpha1.BuildStack{
+								Stack: buildapi.BuildStack{
 									RunImage: "gcr.io/test-project/install/run@sha256:42841631725942db48b7ba8b788b97374a2ada34c84ee02ca5e02ef3d4b0dfca",
 									ID:       "io.buildpacks.stacks.bionic",
 								},
-								BuildMetadata: v1alpha1.BuildpackMetadataList{
+								BuildMetadata: buildapi.BuildpackMetadataList{
 									{
 										Id:      "io.buildpack",
 										Version: "version",
@@ -1618,7 +1618,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantErr: false,
 					WantCreates: []runtime.Object{
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: metav1.ObjectMeta{
 								GenerateName: imageName + "-build-2-",
 								Namespace:    namespace,
@@ -1626,14 +1626,14 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel:     "2",
-									v1alpha1.ImageLabel:           imageName,
-									v1alpha1.ImageGenerationLabel: generation(image),
+									buildapi.BuildNumberLabel:     "2",
+									buildapi.ImageLabel:           imageName,
+									buildapi.ImageGenerationLabel: generation(image),
 									someLabelKey:                  someValueToPassThrough,
 								},
 								Annotations: map[string]string{
-									v1alpha1.BuildReasonAnnotation: v1alpha1.BuildReasonStack,
-									v1alpha1.BuildChangesAnnotation: testhelpers.CompactJSON(`
+									buildapi.BuildReasonAnnotation: buildapi.BuildReasonStack,
+									buildapi.BuildChangesAnnotation: testhelpers.CompactJSON(`
 [
   {
     "reason": "STACK",
@@ -1643,19 +1643,19 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 ]`),
 								},
 							},
-							Spec: v1alpha1.BuildSpec{
+							Spec: buildapi.BuildSpec{
 								Tags: []string{image.Spec.Tag},
-								Builder: v1alpha1.BuildBuilderSpec{
+								Builder: buildapi.BuildBuilderSpec{
 									Image: updatedBuilderImage,
 								},
 								ServiceAccount: image.Spec.ServiceAccount,
-								Source: v1alpha1.SourceConfig{
-									Git: &v1alpha1.Git{
+								Source: buildapi.SourceConfig{
+									Git: &buildapi.Git{
 										URL:      sourceResolver.Status.Source.Git.URL,
 										Revision: sourceResolver.Status.Source.Git.Revision,
 									},
 								},
-								LastBuild: &v1alpha1.LastBuild{
+								LastBuild: &buildapi.LastBuild{
 									Image:   "some/image@sha256:just-built",
 									StackId: "io.buildpacks.stacks.bionic",
 								},
@@ -1664,17 +1664,17 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Image{
+							Object: &buildapi.Image{
 								ObjectMeta: image.ObjectMeta,
 								Spec:       image.Spec,
-								Status: v1alpha1.ImageStatus{
+								Status: buildapi.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions:         conditionBuildExecuting("image-name-build-2-00001"),
 									},
 									LatestBuildRef:             "image-name-build-2-00001", // GenerateNameReactor
 									LatestBuildImageGeneration: originalGeneration,
-									LatestBuildReason:          v1alpha1.BuildReasonStack,
+									LatestBuildReason:          buildapi.BuildReasonStack,
 									LatestImage:                image.Spec.Tag + "@sha256:just-built",
 									BuildCounter:               2,
 								},
@@ -1695,7 +1695,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 						image,
 						builder,
 						sourceResolver,
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "image-name-build-1-00001",
 								Namespace: namespace,
@@ -1703,28 +1703,28 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel: "2",
-									v1alpha1.ImageLabel:       imageName,
+									buildapi.BuildNumberLabel: "2",
+									buildapi.ImageLabel:       imageName,
 								},
 							},
-							Spec: v1alpha1.BuildSpec{
+							Spec: buildapi.BuildSpec{
 								Tags: []string{image.Spec.Tag},
-								Builder: v1alpha1.BuildBuilderSpec{
+								Builder: buildapi.BuildBuilderSpec{
 									Image: builder.Status.LatestImage,
 								},
 								ServiceAccount: "old-service-account",
-								Source: v1alpha1.SourceConfig{
-									Git: &v1alpha1.Git{
+								Source: buildapi.SourceConfig{
+									Git: &buildapi.Git{
 										URL:      "out-of-date-git-url",
 										Revision: "out-of-date-git-revision",
 									},
 								},
-								LastBuild: &v1alpha1.LastBuild{
+								LastBuild: &buildapi.LastBuild{
 									Image:   image.Spec.Tag + "@sha256:from-build-before-this-build",
 									StackId: "io.buildpacks.stacks.bionic",
 								},
 							},
-							Status: v1alpha1.BuildStatus{
+							Status: buildapi.BuildStatus{
 								Status: corev1alpha1.Status{
 									Conditions: corev1alpha1.Conditions{
 										{
@@ -1738,7 +1738,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantErr: false,
 					WantCreates: []runtime.Object{
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: metav1.ObjectMeta{
 								GenerateName: imageName + "-build-3-",
 								Namespace:    namespace,
@@ -1746,17 +1746,17 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel:     "3",
-									v1alpha1.ImageLabel:           imageName,
-									v1alpha1.ImageGenerationLabel: generation(image),
+									buildapi.BuildNumberLabel:     "3",
+									buildapi.ImageLabel:           imageName,
+									buildapi.ImageGenerationLabel: generation(image),
 									someLabelKey:                  someValueToPassThrough,
 								},
 								Annotations: map[string]string{
-									v1alpha1.BuildReasonAnnotation: strings.Join([]string{
-										v1alpha1.BuildReasonCommit,
-										v1alpha1.BuildReasonConfig,
+									buildapi.BuildReasonAnnotation: strings.Join([]string{
+										buildapi.BuildReasonCommit,
+										buildapi.BuildReasonConfig,
 									}, ","),
-									v1alpha1.BuildChangesAnnotation: testhelpers.CompactJSON(`
+									buildapi.BuildChangesAnnotation: testhelpers.CompactJSON(`
 [
   {
     "reason": "COMMIT",
@@ -1787,19 +1787,19 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 ]`),
 								},
 							},
-							Spec: v1alpha1.BuildSpec{
+							Spec: buildapi.BuildSpec{
 								Tags: []string{image.Spec.Tag},
-								Builder: v1alpha1.BuildBuilderSpec{
+								Builder: buildapi.BuildBuilderSpec{
 									Image: builder.Status.LatestImage,
 								},
 								ServiceAccount: image.Spec.ServiceAccount,
-								Source: v1alpha1.SourceConfig{
-									Git: &v1alpha1.Git{
+								Source: buildapi.SourceConfig{
+									Git: &buildapi.Git{
 										URL:      sourceResolver.Status.Source.Git.URL,
 										Revision: sourceResolver.Status.Source.Git.Revision,
 									},
 								},
-								LastBuild: &v1alpha1.LastBuild{
+								LastBuild: &buildapi.LastBuild{
 									Image:   "some/image@sha256:from-build-before-this-build",
 									StackId: "io.buildpacks.stacks.bionic",
 								},
@@ -1808,10 +1808,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					},
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Image{
+							Object: &buildapi.Image{
 								ObjectMeta: image.ObjectMeta,
 								Spec:       image.Spec,
-								Status: v1alpha1.ImageStatus{
+								Status: buildapi.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions:         conditionBuildExecuting("image-name-build-3-00001"),
@@ -1838,7 +1838,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 						image,
 						builder,
 						sourceResolver,
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "image-name-build-100001",
 								Namespace: namespace,
@@ -1846,24 +1846,24 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel: "1",
-									v1alpha1.ImageLabel:       imageName,
+									buildapi.BuildNumberLabel: "1",
+									buildapi.ImageLabel:       imageName,
 								},
 							},
-							Spec: v1alpha1.BuildSpec{
+							Spec: buildapi.BuildSpec{
 								Tags: []string{image.Spec.Tag},
-								Builder: v1alpha1.BuildBuilderSpec{
+								Builder: buildapi.BuildBuilderSpec{
 									Image: builder.Status.LatestImage,
 								},
 								ServiceAccount: "old-service-account",
-								Source: v1alpha1.SourceConfig{
-									Git: &v1alpha1.Git{
+								Source: buildapi.SourceConfig{
+									Git: &buildapi.Git{
 										URL:      "out-of-date-git-url",
 										Revision: "out-of-date-git-revision",
 									},
 								},
 							},
-							Status: v1alpha1.BuildStatus{
+							Status: buildapi.BuildStatus{
 								Status: corev1alpha1.Status{
 									Conditions: corev1alpha1.Conditions{
 										{
@@ -1893,7 +1893,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 						image,
 						builder,
 						sourceResolver,
-						&v1alpha1.Build{
+						&buildapi.Build{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      image.Status.LatestBuildRef,
 								Namespace: namespace,
@@ -1901,26 +1901,26 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 									*kmeta.NewControllerRef(image),
 								},
 								Labels: map[string]string{
-									v1alpha1.BuildNumberLabel: "1",
-									v1alpha1.ImageLabel:       imageName,
+									buildapi.BuildNumberLabel: "1",
+									buildapi.ImageLabel:       imageName,
 								},
 							},
-							Spec: v1alpha1.BuildSpec{
+							Spec: buildapi.BuildSpec{
 								Tags: []string{image.Spec.Tag},
-								Builder: v1alpha1.BuildBuilderSpec{
+								Builder: buildapi.BuildBuilderSpec{
 									Image: builder.Status.LatestImage,
 								},
 								ServiceAccount: image.Spec.ServiceAccount,
-								Source: v1alpha1.SourceConfig{
-									Git: &v1alpha1.Git{
+								Source: buildapi.SourceConfig{
+									Git: &buildapi.Git{
 										URL:      sourceResolver.Status.Source.Git.URL,
 										Revision: sourceResolver.Status.Source.Git.Revision,
 									},
 								},
 							},
-							Status: v1alpha1.BuildStatus{
+							Status: buildapi.BuildStatus{
 								LatestImage: image.Status.LatestImage,
-								Stack: v1alpha1.BuildStack{
+								Stack: buildapi.BuildStack{
 									RunImage: "some/run@sha256:67e3de2af270bf09c02e9a644aeb7e87e6b3c049abe6766bf6b6c3728a83e7fb",
 									ID:       "io.buildpacks.stacks.bionic",
 								},
@@ -1931,7 +1931,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 											Status: corev1.ConditionTrue,
 										},
 										{
-											Type:   v1alpha1.ConditionBuilderReady,
+											Type:   buildapi.ConditionBuilderReady,
 											Status: corev1.ConditionTrue,
 										},
 									},
@@ -1961,10 +1961,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					WantErr: false,
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Image{
+							Object: &buildapi.Image{
 								ObjectMeta: image.ObjectMeta,
 								Spec:       image.Spec,
-								Status: v1alpha1.ImageStatus{
+								Status: buildapi.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions: corev1alpha1.Conditions{
@@ -1973,7 +1973,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 												Status: corev1.ConditionTrue,
 											},
 											{
-												Type:   v1alpha1.ConditionBuilderReady,
+												Type:   buildapi.ConditionBuilderReady,
 												Status: corev1.ConditionTrue,
 											},
 										},
@@ -2007,10 +2007,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					WantErr: false,
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Image{
+							Object: &buildapi.Image{
 								ObjectMeta: image.ObjectMeta,
 								Spec:       image.Spec,
-								Status: v1alpha1.ImageStatus{
+								Status: buildapi.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions: corev1alpha1.Conditions{
@@ -2019,7 +2019,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 												Status: corev1.ConditionUnknown,
 											},
 											{
-												Type:   v1alpha1.ConditionBuilderReady,
+												Type:   buildapi.ConditionBuilderReady,
 												Status: corev1.ConditionTrue,
 											},
 										},
@@ -2054,10 +2054,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 					WantErr: false,
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.Image{
+							Object: &buildapi.Image{
 								ObjectMeta: image.ObjectMeta,
 								Spec:       image.Spec,
-								Status: v1alpha1.ImageStatus{
+								Status: buildapi.ImageStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions: corev1alpha1.Conditions{
@@ -2066,9 +2066,9 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 												Status: corev1.ConditionUnknown,
 											},
 											{
-												Type:    v1alpha1.ConditionBuilderReady,
+												Type:    buildapi.ConditionBuilderReady,
 												Status:  corev1.ConditionFalse,
-												Reason:  v1alpha1.BuilderNotReady,
+												Reason:  buildapi.BuilderNotReady,
 												Message: "Builder builder-name is not ready",
 											},
 										},
@@ -2175,51 +2175,51 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 	})
 }
 
-func generation(i *v1alpha1.Image) string {
+func generation(i *buildapi.Image) string {
 	return strconv.Itoa(int(i.Generation))
 }
 
-func resolvedSourceResolver(image *v1alpha1.Image) *v1alpha1.SourceResolver {
+func resolvedSourceResolver(image *buildapi.Image) *buildapi.SourceResolver {
 	sr := image.SourceResolver()
-	sr.ResolvedSource(v1alpha1.ResolvedSourceConfig{
-		Git: &v1alpha1.ResolvedGitSource{
+	sr.ResolvedSource(buildapi.ResolvedSourceConfig{
+		Git: &buildapi.ResolvedGitSource{
 			URL:      image.Spec.Source.Git.URL + "-resolved",
 			Revision: image.Spec.Source.Git.Revision + "-resolved",
-			Type:     v1alpha1.Branch,
+			Type:     buildapi.Branch,
 		},
 	})
 	return sr
 }
 
-func unresolvedSourceResolver(image *v1alpha1.Image) *v1alpha1.SourceResolver {
+func unresolvedSourceResolver(image *buildapi.Image) *buildapi.SourceResolver {
 	return image.SourceResolver()
 }
 
-func notReadyBuilder(builder *v1alpha1.Builder) runtime.Object {
+func notReadyBuilder(builder *buildapi.Builder) runtime.Object {
 	builder.Status.Conditions = corev1alpha1.Conditions{}
 	return builder
 }
 
-func failedBuilds(image *v1alpha1.Image, sourceResolver *v1alpha1.SourceResolver, count int) []runtime.Object {
+func failedBuilds(image *buildapi.Image, sourceResolver *buildapi.SourceResolver, count int) []runtime.Object {
 	return builds(image, sourceResolver, count, corev1alpha1.Condition{
 		Type:   corev1alpha1.ConditionSucceeded,
 		Status: corev1.ConditionFalse,
 	})
 }
 
-func successfulBuilds(image *v1alpha1.Image, sourceResolver *v1alpha1.SourceResolver, count int) []runtime.Object {
+func successfulBuilds(image *buildapi.Image, sourceResolver *buildapi.SourceResolver, count int) []runtime.Object {
 	return builds(image, sourceResolver, count, corev1alpha1.Condition{
 		Type:   corev1alpha1.ConditionSucceeded,
 		Status: corev1.ConditionTrue,
 	})
 }
 
-func builds(image *v1alpha1.Image, sourceResolver *v1alpha1.SourceResolver, count int, condition corev1alpha1.Condition) []runtime.Object {
+func builds(image *buildapi.Image, sourceResolver *buildapi.SourceResolver, count int, condition corev1alpha1.Condition) []runtime.Object {
 	var builds []runtime.Object
 	const runImageRef = "some/run@sha256:67e3de2af270bf09c02e9a644aeb7e87e6b3c049abe6766bf6b6c3728a83e7fb"
 
 	for i := 1; i <= count; i++ {
-		builds = append(builds, &v1alpha1.Build{
+		builds = append(builds, &buildapi.Build{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("%s-build-%d", image.Name, i),
 				Namespace: image.Namespace,
@@ -2227,27 +2227,27 @@ func builds(image *v1alpha1.Image, sourceResolver *v1alpha1.SourceResolver, coun
 					*kmeta.NewControllerRef(image),
 				},
 				Labels: map[string]string{
-					v1alpha1.BuildNumberLabel: fmt.Sprintf("%d", i),
-					v1alpha1.ImageLabel:       image.Name,
+					buildapi.BuildNumberLabel: fmt.Sprintf("%d", i),
+					buildapi.ImageLabel:       image.Name,
 				},
 				CreationTimestamp: metav1.NewTime(time.Now().Add(time.Duration(i) * time.Minute)),
 			},
-			Spec: v1alpha1.BuildSpec{
+			Spec: buildapi.BuildSpec{
 				Tags: []string{image.Spec.Tag},
-				Builder: v1alpha1.BuildBuilderSpec{
+				Builder: buildapi.BuildBuilderSpec{
 					Image: "builder-image/foo@sha256:112312",
 				},
 				ServiceAccount: image.Spec.ServiceAccount,
-				Source: v1alpha1.SourceConfig{
-					Git: &v1alpha1.Git{
+				Source: buildapi.SourceConfig{
+					Git: &buildapi.Git{
 						URL:      sourceResolver.Status.Source.Git.URL,
 						Revision: sourceResolver.Status.Source.Git.Revision,
 					},
 				},
 			},
-			Status: v1alpha1.BuildStatus{
+			Status: buildapi.BuildStatus{
 				LatestImage: fmt.Sprintf("%s@sha256:build-%d", image.Spec.Tag, i),
-				Stack: v1alpha1.BuildStack{
+				Stack: buildapi.BuildStack{
 					RunImage: runImageRef,
 					ID:       "io.buildpacks.stacks.bionic",
 				},
@@ -2278,7 +2278,7 @@ func conditionReadyUnknown() corev1alpha1.Conditions {
 			Status: corev1.ConditionUnknown,
 		},
 		{
-			Type:   v1alpha1.ConditionBuilderReady,
+			Type:   buildapi.ConditionBuilderReady,
 			Status: corev1.ConditionTrue,
 		},
 	}
@@ -2292,7 +2292,7 @@ func conditionBuildExecuting(buildName string) corev1alpha1.Conditions {
 			Message: fmt.Sprintf("%s is executing", buildName),
 		},
 		{
-			Type:   v1alpha1.ConditionBuilderReady,
+			Type:   buildapi.ConditionBuilderReady,
 			Status: corev1.ConditionTrue,
 		},
 	}
@@ -2305,7 +2305,7 @@ func conditionReady() corev1alpha1.Conditions {
 			Status: corev1.ConditionTrue,
 		},
 		{
-			Type:   v1alpha1.ConditionBuilderReady,
+			Type:   buildapi.ConditionBuilderReady,
 			Status: corev1.ConditionTrue,
 		},
 	}
@@ -2318,7 +2318,7 @@ func conditionNotReady() corev1alpha1.Conditions {
 			Status: corev1.ConditionFalse,
 		},
 		{
-			Type:   v1alpha1.ConditionBuilderReady,
+			Type:   buildapi.ConditionBuilderReady,
 			Status: corev1.ConditionTrue,
 		},
 	}

--- a/pkg/reconciler/image/reconcile_build.go
+++ b/pkg/reconciler/image/reconcile_build.go
@@ -9,19 +9,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 )
 
-func (c *Reconciler) reconcileBuild(ctx context.Context, image *v1alpha1.Image, latestBuild *v1alpha1.Build, sourceResolver *v1alpha1.SourceResolver, builder v1alpha1.BuilderResource, buildCacheName string) (v1alpha1.ImageStatus, error) {
+func (c *Reconciler) reconcileBuild(ctx context.Context, image *buildapi.Image, latestBuild *buildapi.Build, sourceResolver *buildapi.SourceResolver, builder buildapi.BuilderResource, buildCacheName string) (buildapi.ImageStatus, error) {
 	currentBuildNumber, err := buildCounter(latestBuild)
 	if err != nil {
-		return v1alpha1.ImageStatus{}, err
+		return buildapi.ImageStatus{}, err
 	}
 
 	result, err := isBuildRequired(image, latestBuild, sourceResolver, builder)
 	if err != nil {
-		return v1alpha1.ImageStatus{}, errors.Wrap(err, "error determining if an image build is needed")
+		return buildapi.ImageStatus{}, errors.Wrap(err, "error determining if an image build is needed")
 	}
 
 	switch result.ConditionStatus {
@@ -31,10 +31,10 @@ func (c *Reconciler) reconcileBuild(ctx context.Context, image *v1alpha1.Image, 
 		build := image.Build(sourceResolver, builder, latestBuild, result.ReasonsStr, result.ChangesStr, buildCacheName, nextBuildNumber)
 		build, err = c.Client.KpackV1alpha1().Builds(build.Namespace).Create(ctx, build, metav1.CreateOptions{})
 		if err != nil {
-			return v1alpha1.ImageStatus{}, err
+			return buildapi.ImageStatus{}, err
 		}
 
-		return v1alpha1.ImageStatus{
+		return buildapi.ImageStatus{
 			Status: corev1alpha1.Status{
 				Conditions: scheduledBuildCondition(build),
 			},
@@ -49,7 +49,7 @@ func (c *Reconciler) reconcileBuild(ctx context.Context, image *v1alpha1.Image, 
 	case corev1.ConditionUnknown:
 		fallthrough
 	case corev1.ConditionFalse:
-		return v1alpha1.ImageStatus{
+		return buildapi.ImageStatus{
 			Status: corev1alpha1.Status{
 				Conditions: noScheduledBuild(result.ConditionStatus, builder, latestBuild),
 			},
@@ -62,11 +62,11 @@ func (c *Reconciler) reconcileBuild(ctx context.Context, image *v1alpha1.Image, 
 			BuildCacheName:             buildCacheName,
 		}, nil
 	default:
-		return v1alpha1.ImageStatus{}, errors.Errorf("unexpected build needed condition %s", result.ConditionStatus)
+		return buildapi.ImageStatus{}, errors.Errorf("unexpected build needed condition %s", result.ConditionStatus)
 	}
 }
 
-func noScheduledBuild(buildNeeded corev1.ConditionStatus, builder v1alpha1.BuilderResource, build *v1alpha1.Build) corev1alpha1.Conditions {
+func noScheduledBuild(buildNeeded corev1.ConditionStatus, builder buildapi.BuilderResource, build *buildapi.Build) corev1alpha1.Conditions {
 	if buildNeeded == corev1.ConditionUnknown {
 		return corev1alpha1.Conditions{
 			{
@@ -96,24 +96,24 @@ func unknownIfNil(condition *corev1alpha1.Condition) corev1.ConditionStatus {
 	return condition.Status
 }
 
-func builderCondition(builder v1alpha1.BuilderResource) corev1alpha1.Condition {
+func builderCondition(builder buildapi.BuilderResource) corev1alpha1.Condition {
 	if !builder.Ready() {
 		return corev1alpha1.Condition{
-			Type:               v1alpha1.ConditionBuilderReady,
+			Type:               buildapi.ConditionBuilderReady,
 			Status:             corev1.ConditionFalse,
-			Reason:             v1alpha1.BuilderNotReady,
+			Reason:             buildapi.BuilderNotReady,
 			Message:            fmt.Sprintf("Builder %s is not ready", builder.GetName()),
 			LastTransitionTime: corev1alpha1.VolatileTime{Inner: metav1.Now()},
 		}
 	}
 	return corev1alpha1.Condition{
-		Type:               v1alpha1.ConditionBuilderReady,
+		Type:               buildapi.ConditionBuilderReady,
 		Status:             corev1.ConditionTrue,
 		LastTransitionTime: corev1alpha1.VolatileTime{Inner: metav1.Now()},
 	}
 }
 
-func scheduledBuildCondition(build *v1alpha1.Build) corev1alpha1.Conditions {
+func scheduledBuildCondition(build *buildapi.Build) corev1alpha1.Conditions {
 	return corev1alpha1.Conditions{
 		{
 			Type:               corev1alpha1.ConditionReady,
@@ -122,18 +122,18 @@ func scheduledBuildCondition(build *v1alpha1.Build) corev1alpha1.Conditions {
 			Message:            fmt.Sprintf("%s is executing", build.Name),
 		},
 		{
-			Type:               v1alpha1.ConditionBuilderReady,
+			Type:               buildapi.ConditionBuilderReady,
 			Status:             corev1.ConditionTrue,
 			LastTransitionTime: corev1alpha1.VolatileTime{Inner: metav1.Now()},
 		},
 	}
 }
 
-func buildCounter(build *v1alpha1.Build) (int64, error) {
+func buildCounter(build *buildapi.Build) (int64, error) {
 	if build == nil {
 		return 0, nil
 	}
 
-	buildNumber := build.Labels[v1alpha1.BuildNumberLabel]
+	buildNumber := build.Labels[buildapi.BuildNumberLabel]
 	return strconv.ParseInt(buildNumber, 10, 64)
 }

--- a/pkg/reconciler/sourceresolver/enqueuer.go
+++ b/pkg/reconciler/sourceresolver/enqueuer.go
@@ -3,7 +3,7 @@ package sourceresolver
 import (
 	"time"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 type workQueueEnqueuer struct {
@@ -11,7 +11,7 @@ type workQueueEnqueuer struct {
 	delay        time.Duration
 }
 
-func (e *workQueueEnqueuer) Enqueue(sr *v1alpha1.SourceResolver) error {
+func (e *workQueueEnqueuer) Enqueue(sr *buildapi.SourceResolver) error {
 	e.enqueueAfter(sr, 1*time.Minute)
 	return nil
 }

--- a/pkg/reconciler/sourceresolver/enqueuer_test.go
+++ b/pkg/reconciler/sourceresolver/enqueuer_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 func TestEnqueueAfter(t *testing.T) {
-	sourceResolver := &v1alpha1.SourceResolver{
+	sourceResolver := &buildapi.SourceResolver{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "name",
 		},

--- a/pkg/reconciler/sourceresolver/sourceresolver_test.go
+++ b/pkg/reconciler/sourceresolver/sourceresolver_test.go
@@ -14,7 +14,7 @@ import (
 	"knative.dev/pkg/controller"
 	rtesting "knative.dev/pkg/reconciler/testing"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 	"github.com/pivotal/kpack/pkg/client/clientset/versioned/fake"
 	"github.com/pivotal/kpack/pkg/reconciler/sourceresolver"
@@ -67,16 +67,16 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 
 	when("#Reconcile", func() {
 		when("a git based source config", func() {
-			sourceResolver := &v1alpha1.SourceResolver{
+			sourceResolver := &buildapi.SourceResolver{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       sourceResolverName,
 					Namespace:  namespace,
 					Generation: originalGeneration,
 				},
-				Spec: v1alpha1.SourceResolverSpec{
+				Spec: buildapi.SourceResolverSpec{
 					ServiceAccount: serviceAccount,
-					Source: v1alpha1.SourceConfig{
-						Git: &v1alpha1.Git{
+					Source: buildapi.SourceConfig{
+						Git: &buildapi.Git{
 							URL:      "https://github.com/build-me",
 							Revision: "1234",
 						},
@@ -84,11 +84,11 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 				},
 			}
 
-			resolvedSource := v1alpha1.ResolvedSourceConfig{
-				Git: &v1alpha1.ResolvedGitSource{
+			resolvedSource := buildapi.ResolvedSourceConfig{
+				Git: &buildapi.ResolvedGitSource{
 					URL:      "https://example.com/something",
 					Revision: "abcdef",
-					Type:     v1alpha1.Branch,
+					Type:     buildapi.Branch,
 				},
 			}
 
@@ -107,10 +107,10 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 					WantErr: false,
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.SourceResolver{
+							Object: &buildapi.SourceResolver{
 								ObjectMeta: sourceResolver.ObjectMeta,
 								Spec:       sourceResolver.Spec,
-								Status: v1alpha1.SourceResolverStatus{
+								Status: buildapi.SourceResolverStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: 2,
 										Conditions:         sourceResolver.Status.Conditions,
@@ -136,11 +136,11 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			when("a branch is the source", func() {
-				resolvedSource := v1alpha1.ResolvedSourceConfig{
-					Git: &v1alpha1.ResolvedGitSource{
+				resolvedSource := buildapi.ResolvedSourceConfig{
+					Git: &buildapi.ResolvedGitSource{
 						URL:      "https://example.com/something",
 						Revision: "abcdef",
-						Type:     v1alpha1.Branch,
+						Type:     buildapi.Branch,
 					},
 				}
 
@@ -156,10 +156,10 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 						WantErr: false,
 						WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 							{
-								Object: &v1alpha1.SourceResolver{
+								Object: &buildapi.SourceResolver{
 									ObjectMeta: sourceResolver.ObjectMeta,
 									Spec:       sourceResolver.Spec,
-									Status: v1alpha1.SourceResolverStatus{
+									Status: buildapi.SourceResolverStatus{
 										Status: corev1alpha1.Status{
 											ObservedGeneration: originalGeneration,
 											Conditions: corev1alpha1.Conditions{
@@ -168,16 +168,16 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 													Status: corev1.ConditionTrue,
 												},
 												{
-													Type:   v1alpha1.ActivePolling,
+													Type:   buildapi.ActivePolling,
 													Status: corev1.ConditionTrue,
 												},
 											},
 										},
-										Source: v1alpha1.ResolvedSourceConfig{
-											Git: &v1alpha1.ResolvedGitSource{
+										Source: buildapi.ResolvedSourceConfig{
+											Git: &buildapi.ResolvedGitSource{
 												URL:      "https://example.com/something",
 												Revision: "abcdef",
-												Type:     v1alpha1.Branch,
+												Type:     buildapi.Branch,
 											},
 										},
 									},
@@ -194,11 +194,11 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			when("a specific commit sha is the source", func() {
-				resolvedSource := v1alpha1.ResolvedSourceConfig{
-					Git: &v1alpha1.ResolvedGitSource{
+				resolvedSource := buildapi.ResolvedSourceConfig{
+					Git: &buildapi.ResolvedGitSource{
 						URL:      "https://example.com/something",
 						Revision: "abcdef",
-						Type:     v1alpha1.Commit,
+						Type:     buildapi.Commit,
 					},
 				}
 
@@ -214,10 +214,10 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 						WantErr: false,
 						WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 							{
-								Object: &v1alpha1.SourceResolver{
+								Object: &buildapi.SourceResolver{
 									ObjectMeta: sourceResolver.ObjectMeta,
 									Spec:       sourceResolver.Spec,
-									Status: v1alpha1.SourceResolverStatus{
+									Status: buildapi.SourceResolverStatus{
 										Status: corev1alpha1.Status{
 											ObservedGeneration: originalGeneration,
 											Conditions: corev1alpha1.Conditions{
@@ -226,16 +226,16 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 													Status: corev1.ConditionTrue,
 												},
 												{
-													Type:   v1alpha1.ActivePolling,
+													Type:   buildapi.ActivePolling,
 													Status: corev1.ConditionFalse,
 												},
 											},
 										},
-										Source: v1alpha1.ResolvedSourceConfig{
-											Git: &v1alpha1.ResolvedGitSource{
+										Source: buildapi.ResolvedSourceConfig{
+											Git: &buildapi.ResolvedGitSource{
 												URL:      "https://example.com/something",
 												Revision: "abcdef",
-												Type:     v1alpha1.Commit,
+												Type:     buildapi.Commit,
 											},
 										},
 									},
@@ -249,11 +249,11 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			when("git resolves to unknown", func() {
-				resolvedSource := v1alpha1.ResolvedSourceConfig{
-					Git: &v1alpha1.ResolvedGitSource{
+				resolvedSource := buildapi.ResolvedSourceConfig{
+					Git: &buildapi.ResolvedGitSource{
 						URL:      "https://example.com/something",
 						Revision: "abcdef",
-						Type:     v1alpha1.Unknown,
+						Type:     buildapi.Unknown,
 					},
 				}
 
@@ -271,10 +271,10 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 						WantErr: false,
 						WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 							{
-								Object: &v1alpha1.SourceResolver{
+								Object: &buildapi.SourceResolver{
 									ObjectMeta: sourceResolver.ObjectMeta,
 									Spec:       sourceResolver.Spec,
-									Status: v1alpha1.SourceResolverStatus{
+									Status: buildapi.SourceResolverStatus{
 										Status: corev1alpha1.Status{
 											ObservedGeneration: 1,
 											Conditions: corev1alpha1.Conditions{
@@ -283,16 +283,16 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 													Status: corev1.ConditionTrue,
 												},
 												{
-													Type:   v1alpha1.ActivePolling,
+													Type:   buildapi.ActivePolling,
 													Status: corev1.ConditionFalse,
 												},
 											},
 										},
-										Source: v1alpha1.ResolvedSourceConfig{
-											Git: &v1alpha1.ResolvedGitSource{
+										Source: buildapi.ResolvedSourceConfig{
+											Git: &buildapi.ResolvedGitSource{
 												URL:      "https://example.com/something",
 												Revision: "abcdef",
-												Type:     v1alpha1.Unknown,
+												Type:     buildapi.Unknown,
 											},
 										},
 									},
@@ -303,11 +303,11 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it("ignores unknown when source has been previously resolved", func() {
-					alreadyResolvedSource := v1alpha1.ResolvedSourceConfig{
-						Git: &v1alpha1.ResolvedGitSource{
+					alreadyResolvedSource := buildapi.ResolvedSourceConfig{
+						Git: &buildapi.ResolvedGitSource{
 							URL:      "https://example.com/something",
 							Revision: "abcdef",
-							Type:     v1alpha1.Commit,
+							Type:     buildapi.Commit,
 						},
 					}
 
@@ -325,24 +325,24 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("a blob based source config", func() {
-			sourceResolver := &v1alpha1.SourceResolver{
+			sourceResolver := &buildapi.SourceResolver{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       sourceResolverName,
 					Namespace:  namespace,
 					Generation: originalGeneration,
 				},
-				Spec: v1alpha1.SourceResolverSpec{
+				Spec: buildapi.SourceResolverSpec{
 					ServiceAccount: serviceAccount,
-					Source: v1alpha1.SourceConfig{
-						Blob: &v1alpha1.Blob{
+					Source: buildapi.SourceConfig{
+						Blob: &buildapi.Blob{
 							URL: "https://some-blobstore.example.com/some-blob",
 						},
 					},
 				},
 			}
 
-			resolvedSource := v1alpha1.ResolvedSourceConfig{
-				Blob: &v1alpha1.ResolvedBlobSource{
+			resolvedSource := buildapi.ResolvedSourceConfig{
+				Blob: &buildapi.ResolvedBlobSource{
 					URL: "https://some-blobstore.example.com/some-blob",
 				},
 			}
@@ -359,10 +359,10 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 					WantErr: false,
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.SourceResolver{
+							Object: &buildapi.SourceResolver{
 								ObjectMeta: sourceResolver.ObjectMeta,
 								Spec:       sourceResolver.Spec,
-								Status: v1alpha1.SourceResolverStatus{
+								Status: buildapi.SourceResolverStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions: corev1alpha1.Conditions{
@@ -371,13 +371,13 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 												Status: corev1.ConditionTrue,
 											},
 											{
-												Type:   v1alpha1.ActivePolling,
+												Type:   buildapi.ActivePolling,
 												Status: corev1.ConditionFalse,
 											},
 										},
 									},
-									Source: v1alpha1.ResolvedSourceConfig{
-										Blob: &v1alpha1.ResolvedBlobSource{
+									Source: buildapi.ResolvedSourceConfig{
+										Blob: &buildapi.ResolvedBlobSource{
 											URL: "https://some-blobstore.example.com/some-blob",
 										},
 									},
@@ -390,24 +390,24 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("a registry based source config", func() {
-			sourceResolver := &v1alpha1.SourceResolver{
+			sourceResolver := &buildapi.SourceResolver{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       sourceResolverName,
 					Namespace:  namespace,
 					Generation: originalGeneration,
 				},
-				Spec: v1alpha1.SourceResolverSpec{
+				Spec: buildapi.SourceResolverSpec{
 					ServiceAccount: serviceAccount,
-					Source: v1alpha1.SourceConfig{
-						Registry: &v1alpha1.Registry{
+					Source: buildapi.SourceConfig{
+						Registry: &buildapi.Registry{
 							Image: "some-registry.io/some-image@sha256:abcdef123456",
 						},
 					},
 				},
 			}
 
-			resolvedSource := v1alpha1.ResolvedSourceConfig{
-				Registry: &v1alpha1.ResolvedRegistrySource{
+			resolvedSource := buildapi.ResolvedSourceConfig{
+				Registry: &buildapi.ResolvedRegistrySource{
 					Image: "some-registry.io/some-image@sha256:abcdef123456",
 				},
 			}
@@ -424,10 +424,10 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 					WantErr: false,
 					WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 						{
-							Object: &v1alpha1.SourceResolver{
+							Object: &buildapi.SourceResolver{
 								ObjectMeta: sourceResolver.ObjectMeta,
 								Spec:       sourceResolver.Spec,
-								Status: v1alpha1.SourceResolverStatus{
+								Status: buildapi.SourceResolverStatus{
 									Status: corev1alpha1.Status{
 										ObservedGeneration: originalGeneration,
 										Conditions: corev1alpha1.Conditions{
@@ -436,13 +436,13 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 												Status: corev1.ConditionTrue,
 											},
 											{
-												Type:   v1alpha1.ActivePolling,
+												Type:   buildapi.ActivePolling,
 												Status: corev1.ConditionFalse,
 											},
 										},
 									},
-									Source: v1alpha1.ResolvedSourceConfig{
-										Registry: &v1alpha1.ResolvedRegistrySource{
+									Source: buildapi.ResolvedSourceConfig{
+										Registry: &buildapi.ResolvedRegistrySource{
 											Image: "some-registry.io/some-image@sha256:abcdef123456",
 										},
 									},
@@ -456,7 +456,7 @@ func testSourceResolver(t *testing.T, when spec.G, it spec.S) {
 	})
 }
 
-func resolvedSourceResolver(sourceResolver *v1alpha1.SourceResolver, resolvedSource v1alpha1.ResolvedSourceConfig) *v1alpha1.SourceResolver {
+func resolvedSourceResolver(sourceResolver *buildapi.SourceResolver, resolvedSource buildapi.ResolvedSourceConfig) *buildapi.SourceResolver {
 	sourceResolver.ResolvedSource(resolvedSource)
 	return sourceResolver
 }

--- a/pkg/reconciler/sourceresolver/sourceresolverfakes/fake_enqueuer.go
+++ b/pkg/reconciler/sourceresolver/sourceresolverfakes/fake_enqueuer.go
@@ -4,15 +4,15 @@ package sourceresolverfakes
 import (
 	"sync"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/reconciler/sourceresolver"
 )
 
 type FakeEnqueuer struct {
-	EnqueueStub        func(*v1alpha1.SourceResolver) error
+	EnqueueStub        func(*buildapi.SourceResolver) error
 	enqueueMutex       sync.RWMutex
 	enqueueArgsForCall []struct {
-		arg1 *v1alpha1.SourceResolver
+		arg1 *buildapi.SourceResolver
 	}
 	enqueueReturns struct {
 		result1 error
@@ -24,11 +24,11 @@ type FakeEnqueuer struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeEnqueuer) Enqueue(arg1 *v1alpha1.SourceResolver) error {
+func (fake *FakeEnqueuer) Enqueue(arg1 *buildapi.SourceResolver) error {
 	fake.enqueueMutex.Lock()
 	ret, specificReturn := fake.enqueueReturnsOnCall[len(fake.enqueueArgsForCall)]
 	fake.enqueueArgsForCall = append(fake.enqueueArgsForCall, struct {
-		arg1 *v1alpha1.SourceResolver
+		arg1 *buildapi.SourceResolver
 	}{arg1})
 	stub := fake.EnqueueStub
 	fakeReturns := fake.enqueueReturns
@@ -49,13 +49,13 @@ func (fake *FakeEnqueuer) EnqueueCallCount() int {
 	return len(fake.enqueueArgsForCall)
 }
 
-func (fake *FakeEnqueuer) EnqueueCalls(stub func(*v1alpha1.SourceResolver) error) {
+func (fake *FakeEnqueuer) EnqueueCalls(stub func(*buildapi.SourceResolver) error) {
 	fake.enqueueMutex.Lock()
 	defer fake.enqueueMutex.Unlock()
 	fake.EnqueueStub = stub
 }
 
-func (fake *FakeEnqueuer) EnqueueArgsForCall(i int) *v1alpha1.SourceResolver {
+func (fake *FakeEnqueuer) EnqueueArgsForCall(i int) *buildapi.SourceResolver {
 	fake.enqueueMutex.RLock()
 	defer fake.enqueueMutex.RUnlock()
 	argsForCall := fake.enqueueArgsForCall[i]

--- a/pkg/reconciler/sourceresolver/sourceresolverfakes/fake_resolver.go
+++ b/pkg/reconciler/sourceresolver/sourceresolverfakes/fake_resolver.go
@@ -5,15 +5,15 @@ import (
 	"context"
 	"sync"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/reconciler/sourceresolver"
 )
 
 type FakeResolver struct {
-	CanResolveStub        func(*v1alpha1.SourceResolver) bool
+	CanResolveStub        func(*buildapi.SourceResolver) bool
 	canResolveMutex       sync.RWMutex
 	canResolveArgsForCall []struct {
-		arg1 *v1alpha1.SourceResolver
+		arg1 *buildapi.SourceResolver
 	}
 	canResolveReturns struct {
 		result1 bool
@@ -21,29 +21,29 @@ type FakeResolver struct {
 	canResolveReturnsOnCall map[int]struct {
 		result1 bool
 	}
-	ResolveStub        func(context.Context, *v1alpha1.SourceResolver) (v1alpha1.ResolvedSourceConfig, error)
+	ResolveStub        func(context.Context, *buildapi.SourceResolver) (buildapi.ResolvedSourceConfig, error)
 	resolveMutex       sync.RWMutex
 	resolveArgsForCall []struct {
 		arg1 context.Context
-		arg2 *v1alpha1.SourceResolver
+		arg2 *buildapi.SourceResolver
 	}
 	resolveReturns struct {
-		result1 v1alpha1.ResolvedSourceConfig
+		result1 buildapi.ResolvedSourceConfig
 		result2 error
 	}
 	resolveReturnsOnCall map[int]struct {
-		result1 v1alpha1.ResolvedSourceConfig
+		result1 buildapi.ResolvedSourceConfig
 		result2 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeResolver) CanResolve(arg1 *v1alpha1.SourceResolver) bool {
+func (fake *FakeResolver) CanResolve(arg1 *buildapi.SourceResolver) bool {
 	fake.canResolveMutex.Lock()
 	ret, specificReturn := fake.canResolveReturnsOnCall[len(fake.canResolveArgsForCall)]
 	fake.canResolveArgsForCall = append(fake.canResolveArgsForCall, struct {
-		arg1 *v1alpha1.SourceResolver
+		arg1 *buildapi.SourceResolver
 	}{arg1})
 	stub := fake.CanResolveStub
 	fakeReturns := fake.canResolveReturns
@@ -64,13 +64,13 @@ func (fake *FakeResolver) CanResolveCallCount() int {
 	return len(fake.canResolveArgsForCall)
 }
 
-func (fake *FakeResolver) CanResolveCalls(stub func(*v1alpha1.SourceResolver) bool) {
+func (fake *FakeResolver) CanResolveCalls(stub func(*buildapi.SourceResolver) bool) {
 	fake.canResolveMutex.Lock()
 	defer fake.canResolveMutex.Unlock()
 	fake.CanResolveStub = stub
 }
 
-func (fake *FakeResolver) CanResolveArgsForCall(i int) *v1alpha1.SourceResolver {
+func (fake *FakeResolver) CanResolveArgsForCall(i int) *buildapi.SourceResolver {
 	fake.canResolveMutex.RLock()
 	defer fake.canResolveMutex.RUnlock()
 	argsForCall := fake.canResolveArgsForCall[i]
@@ -100,12 +100,12 @@ func (fake *FakeResolver) CanResolveReturnsOnCall(i int, result1 bool) {
 	}{result1}
 }
 
-func (fake *FakeResolver) Resolve(arg1 context.Context, arg2 *v1alpha1.SourceResolver) (v1alpha1.ResolvedSourceConfig, error) {
+func (fake *FakeResolver) Resolve(arg1 context.Context, arg2 *buildapi.SourceResolver) (buildapi.ResolvedSourceConfig, error) {
 	fake.resolveMutex.Lock()
 	ret, specificReturn := fake.resolveReturnsOnCall[len(fake.resolveArgsForCall)]
 	fake.resolveArgsForCall = append(fake.resolveArgsForCall, struct {
 		arg1 context.Context
-		arg2 *v1alpha1.SourceResolver
+		arg2 *buildapi.SourceResolver
 	}{arg1, arg2})
 	stub := fake.ResolveStub
 	fakeReturns := fake.resolveReturns
@@ -126,41 +126,41 @@ func (fake *FakeResolver) ResolveCallCount() int {
 	return len(fake.resolveArgsForCall)
 }
 
-func (fake *FakeResolver) ResolveCalls(stub func(context.Context, *v1alpha1.SourceResolver) (v1alpha1.ResolvedSourceConfig, error)) {
+func (fake *FakeResolver) ResolveCalls(stub func(context.Context, *buildapi.SourceResolver) (buildapi.ResolvedSourceConfig, error)) {
 	fake.resolveMutex.Lock()
 	defer fake.resolveMutex.Unlock()
 	fake.ResolveStub = stub
 }
 
-func (fake *FakeResolver) ResolveArgsForCall(i int) (context.Context, *v1alpha1.SourceResolver) {
+func (fake *FakeResolver) ResolveArgsForCall(i int) (context.Context, *buildapi.SourceResolver) {
 	fake.resolveMutex.RLock()
 	defer fake.resolveMutex.RUnlock()
 	argsForCall := fake.resolveArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeResolver) ResolveReturns(result1 v1alpha1.ResolvedSourceConfig, result2 error) {
+func (fake *FakeResolver) ResolveReturns(result1 buildapi.ResolvedSourceConfig, result2 error) {
 	fake.resolveMutex.Lock()
 	defer fake.resolveMutex.Unlock()
 	fake.ResolveStub = nil
 	fake.resolveReturns = struct {
-		result1 v1alpha1.ResolvedSourceConfig
+		result1 buildapi.ResolvedSourceConfig
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeResolver) ResolveReturnsOnCall(i int, result1 v1alpha1.ResolvedSourceConfig, result2 error) {
+func (fake *FakeResolver) ResolveReturnsOnCall(i int, result1 buildapi.ResolvedSourceConfig, result2 error) {
 	fake.resolveMutex.Lock()
 	defer fake.resolveMutex.Unlock()
 	fake.ResolveStub = nil
 	if fake.resolveReturnsOnCall == nil {
 		fake.resolveReturnsOnCall = make(map[int]struct {
-			result1 v1alpha1.ResolvedSourceConfig
+			result1 buildapi.ResolvedSourceConfig
 			result2 error
 		})
 	}
 	fake.resolveReturnsOnCall[i] = struct {
-		result1 v1alpha1.ResolvedSourceConfig
+		result1 buildapi.ResolvedSourceConfig
 		result2 error
 	}{result1, result2}
 }

--- a/pkg/reconciler/testhelpers/fake_builder_creator.go
+++ b/pkg/reconciler/testhelpers/fake_builder_creator.go
@@ -3,11 +3,11 @@ package testhelpers
 import (
 	"github.com/google/go-containerregistry/pkg/authn"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 type FakeBuilderCreator struct {
-	Record    v1alpha1.BuilderRecord
+	Record    buildapi.BuilderRecord
 	CreateErr error
 
 	CreateBuilderCalls []CreateBuilderArgs
@@ -15,12 +15,12 @@ type FakeBuilderCreator struct {
 
 type CreateBuilderArgs struct {
 	Keychain     authn.Keychain
-	ClusterStack *v1alpha1.ClusterStack
-	ClusterStore *v1alpha1.ClusterStore
-	BuilderSpec  v1alpha1.BuilderSpec
+	ClusterStack *buildapi.ClusterStack
+	ClusterStore *buildapi.ClusterStore
+	BuilderSpec  buildapi.BuilderSpec
 }
 
-func (f *FakeBuilderCreator) CreateBuilder(keychain authn.Keychain, clusterStore *v1alpha1.ClusterStore, clusterStack *v1alpha1.ClusterStack, builder v1alpha1.BuilderSpec) (v1alpha1.BuilderRecord, error) {
+func (f *FakeBuilderCreator) CreateBuilder(keychain authn.Keychain, clusterStore *buildapi.ClusterStore, clusterStack *buildapi.ClusterStack, builder buildapi.BuilderSpec) (buildapi.BuilderRecord, error) {
 	f.CreateBuilderCalls = append(f.CreateBuilderCalls, CreateBuilderArgs{
 		Keychain:     keychain,
 		ClusterStore: clusterStore,

--- a/pkg/reconciler/testhelpers/fake_buildpack_repository.go
+++ b/pkg/reconciler/testhelpers/fake_buildpack_repository.go
@@ -1,12 +1,12 @@
 package testhelpers
 
 import (
-	v1alpha1 "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/cnb"
 )
 
 type FakeBuildpackRepository struct {
-	ClusterStore *v1alpha1.ClusterStore
+	ClusterStore *buildapi.ClusterStore
 }
 
 func (f FakeBuildpackRepository) FindByIdAndVersion(id, version string) (cnb.RemoteBuildpackInfo, error) {

--- a/pkg/reconciler/testhelpers/listers.go
+++ b/pkg/reconciler/testhelpers/listers.go
@@ -8,9 +8,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/reconciler/testing"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/client/clientset/versioned/fake"
-	v1alpha1Listers "github.com/pivotal/kpack/pkg/client/listers/build/v1alpha1"
+	buildlisters "github.com/pivotal/kpack/pkg/client/listers/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/duckbuilder"
 )
 
@@ -51,32 +51,32 @@ func (l *Listers) GetKubeObjects() []runtime.Object {
 	return l.sorter.ObjectsForSchemeFunc(fakekubeclientset.AddToScheme)
 }
 
-func (l *Listers) GetImageLister() v1alpha1Listers.ImageLister {
-	return v1alpha1Listers.NewImageLister(l.indexerFor(&v1alpha1.Image{}))
+func (l *Listers) GetImageLister() buildlisters.ImageLister {
+	return buildlisters.NewImageLister(l.indexerFor(&buildapi.Image{}))
 }
 
-func (l *Listers) GetBuildLister() v1alpha1Listers.BuildLister {
-	return v1alpha1Listers.NewBuildLister(l.indexerFor(&v1alpha1.Build{}))
+func (l *Listers) GetBuildLister() buildlisters.BuildLister {
+	return buildlisters.NewBuildLister(l.indexerFor(&buildapi.Build{}))
 }
 
-func (l *Listers) GetBuilderLister() v1alpha1Listers.BuilderLister {
-	return v1alpha1Listers.NewBuilderLister(l.indexerFor(&v1alpha1.Builder{}))
+func (l *Listers) GetBuilderLister() buildlisters.BuilderLister {
+	return buildlisters.NewBuilderLister(l.indexerFor(&buildapi.Builder{}))
 }
 
-func (l *Listers) GetClusterBuilderLister() v1alpha1Listers.ClusterBuilderLister {
-	return v1alpha1Listers.NewClusterBuilderLister(l.indexerFor(&v1alpha1.ClusterBuilder{}))
+func (l *Listers) GetClusterBuilderLister() buildlisters.ClusterBuilderLister {
+	return buildlisters.NewClusterBuilderLister(l.indexerFor(&buildapi.ClusterBuilder{}))
 }
 
-func (l *Listers) GetClusterStoreLister() v1alpha1Listers.ClusterStoreLister {
-	return v1alpha1Listers.NewClusterStoreLister(l.indexerFor(&v1alpha1.ClusterStore{}))
+func (l *Listers) GetClusterStoreLister() buildlisters.ClusterStoreLister {
+	return buildlisters.NewClusterStoreLister(l.indexerFor(&buildapi.ClusterStore{}))
 }
 
-func (l *Listers) GetClusterStackLister() v1alpha1Listers.ClusterStackLister {
-	return v1alpha1Listers.NewClusterStackLister(l.indexerFor(&v1alpha1.ClusterStack{}))
+func (l *Listers) GetClusterStackLister() buildlisters.ClusterStackLister {
+	return buildlisters.NewClusterStackLister(l.indexerFor(&buildapi.ClusterStack{}))
 }
 
-func (l *Listers) GetSourceResolverLister() v1alpha1Listers.SourceResolverLister {
-	return v1alpha1Listers.NewSourceResolverLister(l.indexerFor(&v1alpha1.SourceResolver{}))
+func (l *Listers) GetSourceResolverLister() buildlisters.SourceResolverLister {
+	return buildlisters.NewSourceResolverLister(l.indexerFor(&buildapi.SourceResolver{}))
 }
 
 func (l *Listers) GetPersistentVolumeClaimLister() corev1listers.PersistentVolumeClaimLister {

--- a/pkg/registry/resolver.go
+++ b/pkg/registry/resolver.go
@@ -3,15 +3,15 @@ package registry
 import (
 	"context"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 type Resolver struct {
 }
 
-func (*Resolver) Resolve(ctx context.Context, sourceResolver *v1alpha1.SourceResolver) (v1alpha1.ResolvedSourceConfig, error) {
-	return v1alpha1.ResolvedSourceConfig{
-		Registry: &v1alpha1.ResolvedRegistrySource{
+func (*Resolver) Resolve(ctx context.Context, sourceResolver *buildapi.SourceResolver) (buildapi.ResolvedSourceConfig, error) {
+	return buildapi.ResolvedSourceConfig{
+		Registry: &buildapi.ResolvedRegistrySource{
 			Image:            sourceResolver.Spec.Source.Registry.Image,
 			ImagePullSecrets: sourceResolver.Spec.Source.Registry.ImagePullSecrets,
 			SubPath:          sourceResolver.Spec.Source.SubPath,
@@ -19,6 +19,6 @@ func (*Resolver) Resolve(ctx context.Context, sourceResolver *v1alpha1.SourceRes
 	}, nil
 }
 
-func (*Resolver) CanResolve(sourceResolver *v1alpha1.SourceResolver) bool {
+func (*Resolver) CanResolve(sourceResolver *buildapi.SourceResolver) bool {
 	return sourceResolver.IsRegistry()
 }

--- a/pkg/secret/fetcher.go
+++ b/pkg/secret/fetcher.go
@@ -25,7 +25,7 @@ func (f *Fetcher) secretsFromServiceAccount(ctx context.Context, account *corev1
 	var secrets []*corev1.Secret
 	for _, secretRef := range account.Secrets {
 		secret, err := f.Client.CoreV1().Secrets(namespace).Get(ctx, secretRef.Name, metav1.GetOptions{})
-		if err != nil && !k8serrors.IsNotFound(err){
+		if err != nil && !k8serrors.IsNotFound(err) {
 			return nil, err
 		} else if k8serrors.IsNotFound(err) {
 			continue

--- a/pkg/tracker/tracker_test.go
+++ b/pkg/tracker/tracker_test.go
@@ -9,7 +9,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/tracker"
 )
 
@@ -26,7 +26,7 @@ func testTracker(t *testing.T, when spec.G, it spec.S) {
 					wasCalledWith = key
 				}, 5*time.Minute)
 
-				builder := &v1alpha1.Builder{
+				builder := &buildapi.Builder{
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "some-name",
 						Namespace: "some-namespace",
@@ -54,7 +54,7 @@ func testTracker(t *testing.T, when spec.G, it spec.S) {
 					wasCalledWith = key
 				}, 5*time.Minute)
 
-				clusterBuilder := &v1alpha1.ClusterBuilder{
+				clusterBuilder := &buildapi.ClusterBuilder{
 					ObjectMeta: v1.ObjectMeta{
 						Name: "some-name",
 					},

--- a/test/execute_build_test.go
+++ b/test/execute_build_test.go
@@ -28,7 +28,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 	"github.com/pivotal/kpack/pkg/logs"
 	"github.com/pivotal/kpack/pkg/registry"
@@ -134,12 +134,12 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		_, err = clients.client.KpackV1alpha1().ClusterStores().Create(ctx, &v1alpha1.ClusterStore{
+		_, err = clients.client.KpackV1alpha1().ClusterStores().Create(ctx, &buildapi.ClusterStore{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterStoreName,
 			},
-			Spec: v1alpha1.ClusterStoreSpec{
-				Sources: []v1alpha1.StoreImage{
+			Spec: buildapi.ClusterStoreSpec{
+				Sources: []buildapi.StoreImage{
 					{
 						Image: builderImage,
 					},
@@ -151,29 +151,29 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		_, err = clients.client.KpackV1alpha1().ClusterStacks().Create(ctx, &v1alpha1.ClusterStack{
+		_, err = clients.client.KpackV1alpha1().ClusterStacks().Create(ctx, &buildapi.ClusterStack{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterStackName,
 			},
-			Spec: v1alpha1.ClusterStackSpec{
+			Spec: buildapi.ClusterStackSpec{
 				Id: "io.buildpacks.stacks.bionic",
-				BuildImage: v1alpha1.ClusterStackSpecImage{
+				BuildImage: buildapi.ClusterStackSpecImage{
 					Image: "gcr.io/paketo-buildpacks/build:base-cnb",
 				},
-				RunImage: v1alpha1.ClusterStackSpecImage{
+				RunImage: buildapi.ClusterStackSpecImage{
 					Image: "gcr.io/paketo-buildpacks/run:base-cnb",
 				},
 			},
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		builder, err := clients.client.KpackV1alpha1().Builders(testNamespace).Create(ctx, &v1alpha1.Builder{
+		builder, err := clients.client.KpackV1alpha1().Builders(testNamespace).Create(ctx, &buildapi.Builder{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      builderName,
 				Namespace: testNamespace,
 			},
-			Spec: v1alpha1.NamespacedBuilderSpec{
-				BuilderSpec: v1alpha1.BuilderSpec{
+			Spec: buildapi.NamespacedBuilderSpec{
+				BuilderSpec: buildapi.BuilderSpec{
 					Tag: cfg.newImageTag(),
 					Stack: corev1.ObjectReference{
 						Name: clusterStackName,
@@ -183,31 +183,31 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 						Name: clusterStoreName,
 						Kind: "ClusterStore",
 					},
-					Order: []v1alpha1.OrderEntry{
+					Order: []buildapi.OrderEntry{
 						{
-							Group: []v1alpha1.BuildpackRef{
+							Group: []buildapi.BuildpackRef{
 								{
-									BuildpackInfo: v1alpha1.BuildpackInfo{
+									BuildpackInfo: buildapi.BuildpackInfo{
 										Id: "paketo-buildpacks/nodejs",
 									},
 								},
 							},
 						},
 						{
-							Group: []v1alpha1.BuildpackRef{
+							Group: []buildapi.BuildpackRef{
 								{
-									BuildpackInfo: v1alpha1.BuildpackInfo{
+									BuildpackInfo: buildapi.BuildpackInfo{
 										Id: "paketo-buildpacks/bellsoft-liberica",
 									},
 								},
 								{
-									BuildpackInfo: v1alpha1.BuildpackInfo{
+									BuildpackInfo: buildapi.BuildpackInfo{
 										Id: "paketo-buildpacks/gradle",
 									},
 									Optional: true,
 								},
 								{
-									BuildpackInfo: v1alpha1.BuildpackInfo{
+									BuildpackInfo: buildapi.BuildpackInfo{
 										Id: "paketo-buildpacks/executable-jar",
 									},
 								},
@@ -220,12 +220,12 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		clusterBuilder, err := clients.client.KpackV1alpha1().ClusterBuilders().Create(ctx, &v1alpha1.ClusterBuilder{
+		clusterBuilder, err := clients.client.KpackV1alpha1().ClusterBuilders().Create(ctx, &buildapi.ClusterBuilder{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterBuilderName,
 			},
-			Spec: v1alpha1.ClusterBuilderSpec{
-				BuilderSpec: v1alpha1.BuilderSpec{
+			Spec: buildapi.ClusterBuilderSpec{
+				BuilderSpec: buildapi.BuilderSpec{
 					Tag: cfg.newImageTag(),
 					Stack: corev1.ObjectReference{
 						Name: clusterStackName,
@@ -235,31 +235,31 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 						Name: clusterStoreName,
 						Kind: "ClusterStore",
 					},
-					Order: []v1alpha1.OrderEntry{
+					Order: []buildapi.OrderEntry{
 						{
-							Group: []v1alpha1.BuildpackRef{
+							Group: []buildapi.BuildpackRef{
 								{
-									BuildpackInfo: v1alpha1.BuildpackInfo{
+									BuildpackInfo: buildapi.BuildpackInfo{
 										Id: "paketo-buildpacks/nodejs",
 									},
 								},
 							},
 						},
 						{
-							Group: []v1alpha1.BuildpackRef{
+							Group: []buildapi.BuildpackRef{
 								{
-									BuildpackInfo: v1alpha1.BuildpackInfo{
+									BuildpackInfo: buildapi.BuildpackInfo{
 										Id: "paketo-buildpacks/bellsoft-liberica",
 									},
 								},
 								{
-									BuildpackInfo: v1alpha1.BuildpackInfo{
+									BuildpackInfo: buildapi.BuildpackInfo{
 										Id: "paketo-buildpacks/gradle",
 									},
 									Optional: true,
 								},
 								{
-									BuildpackInfo: v1alpha1.BuildpackInfo{
+									BuildpackInfo: buildapi.BuildpackInfo{
 										Id: "paketo-buildpacks/executable-jar",
 									},
 								},
@@ -291,20 +291,20 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 			},
 		}
 
-		imageSources := map[string]v1alpha1.SourceConfig{
+		imageSources := map[string]buildapi.SourceConfig{
 			"test-git-image": {
-				Git: &v1alpha1.Git{
+				Git: &buildapi.Git{
 					URL:      "https://github.com/cloudfoundry-samples/cf-sample-app-nodejs",
 					Revision: "master",
 				},
 			},
 			"test-blob-image": {
-				Blob: &v1alpha1.Blob{
+				Blob: &buildapi.Blob{
 					URL: "https://storage.googleapis.com/build-service/sample-apps/spring-petclinic-2.1.0.BUILD-SNAPSHOT.jar",
 				},
 			},
 			"test-registry-image": {
-				Registry: &v1alpha1.Registry{
+				Registry: &buildapi.Registry{
 					Image: "gcr.io/cf-build-service-public/fixtures/nodejs-source@sha256:76cb2e087b6f1355caa8ed4a5eebb1ad7376e26995a8d49a570cdc10e4976e44",
 				},
 			},
@@ -312,11 +312,11 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 
 		builderConfigs := map[string]corev1.ObjectReference{
 			"custom-builder": {
-				Kind: v1alpha1.BuilderKind,
+				Kind: buildapi.BuilderKind,
 				Name: builderName,
 			},
 			"custom-cluster-builder": {
-				Kind: v1alpha1.ClusterBuilderKind,
+				Kind: buildapi.ClusterBuilderKind,
 				Name: clusterBuilderName,
 			},
 		}
@@ -332,18 +332,18 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 					t.Parallel()
 
 					imageTag := cfg.newImageTag()
-					image, err := clients.client.KpackV1alpha1().Images(testNamespace).Create(ctx, &v1alpha1.Image{
+					image, err := clients.client.KpackV1alpha1().Images(testNamespace).Create(ctx, &buildapi.Image{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: imageName,
 						},
-						Spec: v1alpha1.ImageSpec{
+						Spec: buildapi.ImageSpec{
 							Tag:                  imageTag,
 							Builder:              builder,
 							ServiceAccount:       serviceAccountName,
 							Source:               source,
 							CacheSize:            &cacheSize,
-							ImageTaggingStrategy: v1alpha1.None,
-							Build: &v1alpha1.ImageBuild{
+							ImageTaggingStrategy: buildapi.None,
+							Build: &buildapi.ImageBuild{
 								Resources: expectedResources,
 							},
 						},
@@ -372,26 +372,26 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 		imageName := fmt.Sprintf("%s-%s", "test-git-image", "cluster-builder")
 
 		imageTag := cfg.newImageTag()
-		image, err := clients.client.KpackV1alpha1().Images(testNamespace).Create(ctx, &v1alpha1.Image{
+		image, err := clients.client.KpackV1alpha1().Images(testNamespace).Create(ctx, &buildapi.Image{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: imageName,
 			},
-			Spec: v1alpha1.ImageSpec{
+			Spec: buildapi.ImageSpec{
 				Tag: imageTag,
 				Builder: corev1.ObjectReference{
-					Kind: v1alpha1.ClusterBuilderKind,
+					Kind: buildapi.ClusterBuilderKind,
 					Name: clusterBuilderName,
 				},
 				ServiceAccount: serviceAccountName,
-				Source: v1alpha1.SourceConfig{
-					Git: &v1alpha1.Git{
+				Source: buildapi.SourceConfig{
+					Git: &buildapi.Git{
 						URL:      "https://github.com/cloudfoundry-samples/cf-sample-app-nodejs",
 						Revision: "master",
 					},
 				},
 				CacheSize:            &cacheSize,
-				ImageTaggingStrategy: v1alpha1.None,
-				Build: &v1alpha1.ImageBuild{
+				ImageTaggingStrategy: buildapi.None,
+				Build: &buildapi.ImageBuild{
 					Resources: expectedResources,
 				},
 			},
@@ -407,7 +407,7 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 		require.Len(t, list.Items, 1)
 
 		build := &list.Items[0]
-		build.Annotations[v1alpha1.BuildNeededAnnotation] = "2006-01-02 15:04:05.000000 -0700 MST m=+0.000000000"
+		build.Annotations[buildapi.BuildNeededAnnotation] = "2006-01-02 15:04:05.000000 -0700 MST m=+0.000000000"
 		_, err = clients.client.KpackV1alpha1().Builds(testNamespace).Update(ctx, build, metav1.UpdateOptions{})
 		require.NoError(t, err)
 
@@ -458,7 +458,7 @@ func waitUntilReady(t *testing.T, ctx context.Context, clients *clients, objects
 	}
 }
 
-func validateImageCreate(t *testing.T, clients *clients, image *v1alpha1.Image, expectedResources corev1.ResourceRequirements) {
+func validateImageCreate(t *testing.T, clients *clients, image *buildapi.Image, expectedResources corev1.ResourceRequirements) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -503,15 +503,15 @@ func validateRebase(t *testing.T, ctx context.Context, clients *clients, imageNa
 	build := buildList.Items[0]
 
 	rebaseBuildBuildSpec := build.Spec.DeepCopy()
-	rebaseBuildBuildSpec.LastBuild = &v1alpha1.LastBuild{
+	rebaseBuildBuildSpec.LastBuild = &buildapi.LastBuild{
 		Image:   build.Status.LatestImage,
 		StackId: build.Status.Stack.ID,
 	}
 
-	_, err = clients.client.KpackV1alpha1().Builds(testNamespace).Create(ctx, &v1alpha1.Build{
+	_, err = clients.client.KpackV1alpha1().Builds(testNamespace).Create(ctx, &buildapi.Build{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        rebaseBuildName,
-			Annotations: map[string]string{v1alpha1.BuildReasonAnnotation: v1alpha1.BuildReasonStack},
+			Annotations: map[string]string{buildapi.BuildReasonAnnotation: buildapi.BuildReasonStack},
 		},
 		Spec: *rebaseBuildBuildSpec,
 	}, metav1.CreateOptions{})


### PR DESCRIPTION
Instead of doing those changes for each bump in the build api (`v1alpha2`, `v1beta1`, ...), we introduce a stable alias "buildapi" which points to the api version which is used (currently still `v1alpha1`).

