### PR TITLE
Add support for project descriptor

### DIFF
--- a/cmd/build-init/main.go
+++ b/cmd/build-init/main.go
@@ -34,8 +34,8 @@ var (
 	blobURL       = flag.String("blob-url", os.Getenv("BLOB_URL"), "The url of the source code blob.")
 	registryImage = flag.String("registry-image", os.Getenv("REGISTRY_IMAGE"), "The registry location of the source code image.")
 	hostName      = flag.String("dns-probe-hostname", os.Getenv("DNS_PROBE_HOSTNAME"), "hostname to dns poll")
-
-	buildChanges = flag.String("build-changes", os.Getenv("BUILD_CHANGES"), "JSON string of build changes and their reason")
+	sourceSubPath = flag.String("source-sub-path", os.Getenv("SOURCE_SUB_PATH"), "the subpath inside the source directory that will be the buildpack workspace")
+	buildChanges  = flag.String("build-changes", os.Getenv("BUILD_CHANGES"), "JSON string of build changes and their reason")
 
 	basicGitCredentials     flaghelpers.CredentialsFlags
 	sshGitCredentials       flaghelpers.CredentialsFlags
@@ -115,6 +115,11 @@ func main() {
 	err = fetchSource(logger, creds)
 	if err != nil {
 		logger.Fatal(err)
+	}
+
+	err = cnb.ProcessProjectDescriptor(filepath.Join(appDir, *sourceSubPath), platformDir)
+	if err != nil {
+		logger.Fatalf("error while processing the project descriptor %s", err)
 	}
 
 	err = cnb.SetupPlatformEnvVars(platformDir, *platformEnvVars)

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 // indirect
 	github.com/pelletier/go-toml v1.8.0 // indirect
 	github.com/pkg/errors v0.9.1
+	github.com/sabhiram/go-gitignore v0.0.0-20201211210132-54b8a0bf510f
 	github.com/sclevine/spec v1.4.0
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/cast v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -818,6 +818,8 @@ github.com/rubiojr/go-vhd v0.0.0-20160810183302-0bfd3b39853c/go.mod h1:DM5xW0nvf
 github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021/go.mod h1:DM5xW0nvfNNm2uytzsvhI3OnX8uzaRAg8UX/CnDqbto=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/sabhiram/go-gitignore v0.0.0-20201211210132-54b8a0bf510f h1:8P2MkG70G76gnZBOPGwmMIgwBb/rESQuwsJ7K8ds4NE=
+github.com/sabhiram/go-gitignore v0.0.0-20201211210132-54b8a0bf510f/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=

--- a/pkg/apis/build/v1alpha1/build_pod.go
+++ b/pkg/apis/build/v1alpha1/build_pod.go
@@ -229,6 +229,10 @@ func (b *Build) BuildPod(images BuildPodImages, secrets []corev1.Secret, taints 
 						Env: append(
 							b.Spec.Source.Source().BuildEnvVars(),
 							corev1.EnvVar{
+								Name:  "SOURCE_SUB_PATH",
+								Value: b.Spec.Source.SubPath,
+							},
+							corev1.EnvVar{
 								Name:  "PLATFORM_ENV_VARS",
 								Value: string(envVars),
 							},

--- a/pkg/cnb/env_vars.go
+++ b/pkg/cnb/env_vars.go
@@ -1,0 +1,29 @@
+package cnb
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+)
+
+func serializeEnvVars(envVars []envVariable, platformDir string) error {
+	var err error
+	folder := path.Join(platformDir, "env")
+	err = os.MkdirAll(folder, os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	for _, envVar := range envVars {
+		err = ioutil.WriteFile(path.Join(folder, envVar.Name), []byte(envVar.Value), os.ModePerm)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type envVariable struct {
+	Name  string `json:"name" toml:"name"`
+	Value string `json:"value" toml:"value"`
+}

--- a/pkg/cnb/platform_env_vars_setup.go
+++ b/pkg/cnb/platform_env_vars_setup.go
@@ -2,9 +2,6 @@ package cnb
 
 import (
 	"encoding/json"
-	"io/ioutil"
-	"os"
-	"path"
 )
 
 func SetupPlatformEnvVars(dir, envVarsJSON string) error {
@@ -13,22 +10,5 @@ func SetupPlatformEnvVars(dir, envVarsJSON string) error {
 	if err != nil {
 		return err
 	}
-	folder := path.Join(dir, "env")
-	err = os.MkdirAll(folder, os.ModePerm)
-	if err != nil {
-		return err
-	}
-
-	for _, envVar := range envVars {
-		err = ioutil.WriteFile(path.Join(folder, envVar.Name), []byte(envVar.Value), os.ModePerm)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-type envVariable struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
+	return serializeEnvVars(envVars, dir)
 }

--- a/pkg/cnb/project_descriptor.go
+++ b/pkg/cnb/project_descriptor.go
@@ -1,0 +1,88 @@
+package cnb
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+	ignore "github.com/sabhiram/go-gitignore"
+)
+
+const fileDescriptorName = "project.toml"
+
+func ProcessProjectDescriptor(appDir, platformDir string) error {
+	var d descriptor
+	file := filepath.Join(appDir, fileDescriptorName)
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("unable to determine if project descriptor file exists: %w", err)
+	}
+	_, err := toml.DecodeFile(file, &d)
+	if err != nil {
+		return err
+	}
+	if err := processFiles(appDir, d); err != nil {
+		return err
+	}
+	return serializeEnvVars(d.Build.Env, platformDir)
+}
+
+func processFiles(appDir string, d descriptor) error {
+	fileFilter, err := getFileFilter(d)
+	if err != nil {
+		return err
+	}
+	if fileFilter == nil {
+		return nil
+	}
+	return filepath.Walk(appDir, func(path string, f os.FileInfo, fileError error) error {
+		if fileError != nil {
+			return fileError
+		}
+		relPath, err := filepath.Rel(appDir, path)
+		if err != nil {
+			return err
+		}
+		// We only want to remove paths that don't match the patterns and are
+		// files otherwise we will end up removing too much.
+		// For eg if the include = ["*jar"]
+		// All the directories will not match the pattern and hence be removed.
+		// On the other hand if a directory is excluded/included,
+		// for eg include = "my-dir" files under "my-dir" will match the pattern and not be removed.
+		if !fileFilter(relPath) && !f.IsDir() {
+			return os.Remove(path)
+		}
+		return nil
+	})
+}
+
+func getFileFilter(d descriptor) (func(string) bool, error) {
+	if d.Build.Exclude != nil && d.Build.Include != nil {
+		return nil, fmt.Errorf("%s: cannot have both include and exclude defined", fileDescriptorName)
+	}
+
+	if len(d.Build.Exclude) > 0 {
+		excludes := ignore.CompileIgnoreLines(d.Build.Exclude...)
+		return func(fileName string) bool {
+			return !excludes.MatchesPath(fileName)
+		}, nil
+	}
+	if len(d.Build.Include) > 0 {
+		includes := ignore.CompileIgnoreLines(d.Build.Include...)
+		return includes.MatchesPath, nil
+	}
+
+	return nil, nil
+}
+
+type build struct {
+	Include []string      `toml:"include"`
+	Exclude []string      `toml:"exclude"`
+	Env     []envVariable `toml:"env"`
+}
+
+type descriptor struct {
+	Build build `toml:"build"`
+}

--- a/pkg/cnb/project_descriptor_test.go
+++ b/pkg/cnb/project_descriptor_test.go
@@ -1,0 +1,177 @@
+package cnb_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pivotal/kpack/pkg/cnb"
+)
+
+func TestProcessProjectDescriptor(t *testing.T) {
+	spec.Run(t, "ProcessProjectDescriptor", testProcessProjectDescriptor)
+}
+
+func testProcessProjectDescriptor(t *testing.T, when spec.G, it spec.S) {
+	var (
+		appDir, platformDir, projectToml string
+	)
+
+	it.Before(func() {
+		var err error
+		appDir, err = ioutil.TempDir("", "appDir")
+		require.NoError(t, err)
+		platformDir, err = ioutil.TempDir("", "platform")
+		require.NoError(t, err)
+		projectToml = filepath.Join(appDir, "project.toml")
+	})
+
+	it.After(func() {
+		os.RemoveAll(appDir)
+		os.RemoveAll(platformDir)
+	})
+
+	when("#process", func() {
+		when("the descriptor has build env vars", func() {
+			it.Before(func() {
+				ioutil.WriteFile(projectToml, []byte(`
+[[build.env]]
+name = "keyA"
+value = "valueA"
+
+[[build.env]]
+name = "keyB"
+value = "valueB"
+
+[[build.env]]
+name = "keyC"
+value = "valueC"
+
+# check that later keys override previous ones
+[[build.env]]
+name = "keyC"
+value = "valueAnotherC"
+
+				`), 0644)
+			})
+			it("writes all env var files to the platform dir", func() {
+				assert.Nil(t, cnb.ProcessProjectDescriptor(appDir, platformDir))
+				checkEnvVar(t, platformDir, "keyA", "valueA")
+				checkEnvVar(t, platformDir, "keyB", "valueB")
+				checkEnvVar(t, platformDir, "keyC", "valueAnotherC")
+			})
+		})
+
+		when("the descriptor has includes and excludes", func() {
+			it.Before(func() {
+				var err error
+				// Create test directories and files:
+				//
+				// ├── cookie.jar
+				// ├── other-cookie.jar
+				// ├── nested-cookie.jar
+				// ├── nested
+				// │   └── nested-cookie.jar
+				// ├── secrets
+				// │   ├── api_keys.json
+				// |   |── user_token
+				// ├── media
+				// │   ├── mountain.jpg
+				// │   └── person.png
+				// └── test.sh
+
+				err = os.Mkdir(filepath.Join(appDir, "secrets"), 0755)
+				assert.Nil(t, err)
+				err = ioutil.WriteFile(filepath.Join(appDir, "secrets", "api_keys.json"), []byte("{}"), 0755)
+				assert.Nil(t, err)
+				err = ioutil.WriteFile(filepath.Join(appDir, "secrets", "user_token"), []byte("token"), 0755)
+				assert.Nil(t, err)
+
+				err = os.Mkdir(filepath.Join(appDir, "nested"), 0755)
+				assert.Nil(t, err)
+				err = ioutil.WriteFile(filepath.Join(appDir, "nested", "nested-cookie.jar"), []byte("chocolate chip"), 0755)
+				assert.Nil(t, err)
+
+				err = ioutil.WriteFile(filepath.Join(appDir, "other-cookie.jar"), []byte("chocolate chip"), 0755)
+				assert.Nil(t, err)
+
+				err = ioutil.WriteFile(filepath.Join(appDir, "nested-cookie.jar"), []byte("chocolate chip"), 0755)
+				assert.Nil(t, err)
+
+				err = os.Mkdir(filepath.Join(appDir, "media"), 0755)
+				assert.Nil(t, err)
+				err = ioutil.WriteFile(filepath.Join(appDir, "media", "mountain.jpg"), []byte("fake image bytes"), 0755)
+				assert.Nil(t, err)
+				err = ioutil.WriteFile(filepath.Join(appDir, "media", "person.png"), []byte("fake image bytes"), 0755)
+				assert.Nil(t, err)
+
+				err = ioutil.WriteFile(filepath.Join(appDir, "cookie.jar"), []byte("chocolate chip"), 0755)
+				assert.Nil(t, err)
+				err = ioutil.WriteFile(filepath.Join(appDir, "test.sh"), []byte("echo test"), 0755)
+				assert.Nil(t, err)
+			})
+
+			when("it has excludes", func() {
+				it.Before(func() {
+					ioutil.WriteFile(projectToml, []byte(`
+[build]
+exclude = ["*.sh", "secrets/", "media/metadata", "/other-cookie.jar" ,"/nested-cookie.jar"]					
+					`), 0644)
+				})
+				it("removes the excluded files", func() {
+					assert.Nil(t, cnb.ProcessProjectDescriptor(appDir, platformDir))
+					assert.NoFileExists(t, filepath.Join(appDir, "api_keys.json"))
+					assert.NoFileExists(t, filepath.Join(appDir, "user_token"))
+					assert.NoFileExists(t, filepath.Join(appDir, "test.sh"))
+					assert.NoFileExists(t, filepath.Join(appDir, "other-cookie.jar"))
+					assert.NoFileExists(t, filepath.Join(appDir, "nested-cookie.jar"))
+					assert.FileExists(t, filepath.Join(appDir, "cookie.jar"))
+					assert.FileExists(t, filepath.Join(appDir, "nested", "nested-cookie.jar"))
+					assert.FileExists(t, filepath.Join(appDir, "media", "mountain.jpg"))
+					assert.FileExists(t, filepath.Join(appDir, "media", "person.png"))
+				})
+			})
+
+			when("it has includes", func() {
+				it.Before(func() {
+					ioutil.WriteFile(projectToml, []byte(`
+[build]
+include = [ "*.jar", "media/mountain.jpg", "/media/person.png", ]
+					`), 0644)
+				})
+
+				it("keeps only the included files", func() {
+					assert.Nil(t, cnb.ProcessProjectDescriptor(appDir, platformDir))
+					assert.NoFileExists(t, filepath.Join(appDir, "api_keys.json"))
+					assert.NoFileExists(t, filepath.Join(appDir, "user_token"))
+					assert.NoFileExists(t, filepath.Join(appDir, "test.sh"))
+					assert.FileExists(t, filepath.Join(appDir, "other-cookie.jar"))
+					assert.FileExists(t, filepath.Join(appDir, "nested-cookie.jar"))
+					assert.FileExists(t, filepath.Join(appDir, "cookie.jar"))
+					assert.FileExists(t, filepath.Join(appDir, "nested", "nested-cookie.jar"))
+					assert.FileExists(t, filepath.Join(appDir, "media", "mountain.jpg"))
+					assert.FileExists(t, filepath.Join(appDir, "media", "person.png"))
+				})
+			})
+
+			when("it has both excludes and includes", func() {
+				it.Before(func() {
+					ioutil.WriteFile(projectToml, []byte(`
+[build]
+include = [ "test", ]
+exclude = ["test", ]
+					`), 0644)
+				})
+				it("throws an error", func() {
+					assert.NotNil(t, cnb.ProcessProjectDescriptor(appDir, platformDir))
+				})
+
+			})
+		})
+	})
+}


### PR DESCRIPTION
This PR adds support for the following attributes of a project descriptor - 

1. Build Env Variables
2. Includes and excludes

The implementation of the project descriptor is pretty similar to the pack implementation.
- The build env vars set by the project descriptor are overridden by the ones set by the user explicitly.
- The includes and excludes use the go-gitignore library which is also used by pack and required by the spec (the spec says that these values are to be interpreted in the same way as gitignore)

Fixes #288 

