### PR TITLE
Use go version 1.15 for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-go@v1
       with:
-        go-version: '1.13'
+        go-version: '1.15'
     - name: Run tests
       run: make unit-ci
     - name: Report coverage


### PR DESCRIPTION
The final output images are built using go 1.15. CI should also be using the same version.