### PR TITLE
decompose k8ssecret keychain interface

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -141,7 +141,7 @@ func main() {
 	blobResolver := &blob.Resolver{}
 	registryResolver := &registry.Resolver{}
 
-	kpackKeychain, err := keychainFactory.KeychainForSecretRef(ctx, registry.SecretRef{})
+	kpackKeychain, err := keychainFactory.MultiKeychainFromServiceAccountRef(ctx, registry.ServiceAccountRef{})
 	if err != nil {
 		log.Fatalf("could not create empty keychain %s", err)
 	}

--- a/pkg/apis/build/v1alpha1/image_validation.go
+++ b/pkg/apis/build/v1alpha1/image_validation.go
@@ -3,11 +3,13 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
-	"github.com/pivotal/kpack/pkg/apis/validate"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/api/validation"
 	"knative.dev/pkg/apis"
+
+	"github.com/pivotal/kpack/pkg/apis/validate"
 )
 
 type ImageContextKey string

--- a/pkg/buildpod/generator.go
+++ b/pkg/buildpod/generator.go
@@ -121,7 +121,7 @@ func (g *Generator) fetchBuildSecrets(ctx context.Context, build BuildPodable) (
 }
 
 func (g *Generator) fetchBuilderConfig(ctx context.Context, build BuildPodable) (v1alpha1.BuildPodBuilderConfig, error) {
-	keychain, err := g.KeychainFactory.KeychainForSecretRef(ctx, registry.SecretRef{
+	keychain, err := g.KeychainFactory.MultiKeychainFromServiceAccountRef(ctx, registry.ServiceAccountRef{
 		Namespace:        build.GetNamespace(),
 		ImagePullSecrets: build.BuilderSpec().ImagePullSecrets,
 		ServiceAccount:   build.ServiceAccount(),

--- a/pkg/buildpod/generator_test.go
+++ b/pkg/buildpod/generator_test.go
@@ -166,7 +166,7 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 		}
 
 		keychain := &registryfakes.FakeKeychain{}
-		secretRef := registry.SecretRef{
+		secretRef := registry.ServiceAccountRef{
 			ServiceAccount:   serviceAccountName,
 			Namespace:        namespace,
 			ImagePullSecrets: builderPullSecrets,

--- a/pkg/cnb/cnb_metadata.go
+++ b/pkg/cnb/cnb_metadata.go
@@ -37,7 +37,7 @@ type RemoteMetadataRetriever struct {
 }
 
 func (r *RemoteMetadataRetriever) GetBuiltImage(ctx context.Context, build *v1alpha1.Build) (BuiltImage, error) {
-	keychain, err := r.KeychainFactory.KeychainForSecretRef(ctx, registry.SecretRef{
+	keychain, err := r.KeychainFactory.MultiKeychainFromServiceAccountRef(ctx, registry.ServiceAccountRef{
 		ServiceAccount: build.Spec.ServiceAccount,
 		Namespace:      build.Namespace,
 	})

--- a/pkg/cnb/cnb_metadata_test.go
+++ b/pkg/cnb/cnb_metadata_test.go
@@ -45,7 +45,7 @@ func testMetadataRetriever(t *testing.T, when spec.G, it spec.S) {
 			when("images are built with lifecycle 0.5", func() {
 
 				it("retrieves the metadata from the registry", func() {
-					appImageSecretRef := registry.SecretRef{
+					appImageSecretRef := registry.ServiceAccountRef{
 						ServiceAccount: build.Spec.ServiceAccount,
 						Namespace:      build.Namespace,
 					}
@@ -100,7 +100,7 @@ func testMetadataRetriever(t *testing.T, when spec.G, it spec.S) {
 			when("images are built with lifecycle 0.6+", func() {
 
 				it("retrieves the metadata from the registry", func() {
-					appImageSecretRef := registry.SecretRef{
+					appImageSecretRef := registry.ServiceAccountRef{
 						ServiceAccount: build.Spec.ServiceAccount,
 						Namespace:      build.Namespace,
 					}

--- a/pkg/dockercreds/k8sdockercreds/k8s_keychain_test.go
+++ b/pkg/dockercreds/k8sdockercreds/k8s_keychain_test.go
@@ -29,7 +29,7 @@ func testK8sSecretKeychainFactory(t *testing.T, when spec.G, it spec.S) {
 		testNamespace      = "test-namespace"
 	)
 
-	when("#KeychainForSecretRef", func() {
+	when("#MultiKeychainFromServiceAccountRef", func() {
 		it("keychain provides auth from annotated basic auth secrets", func() {
 			fakeClient := fake.NewSimpleClientset(&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -57,7 +57,7 @@ func testK8sSecretKeychainFactory(t *testing.T, when spec.G, it spec.S) {
 			keychainFactory, err := NewSecretKeychainFactory(fakeClient)
 			require.NoError(t, err)
 
-			keychain, err := keychainFactory.KeychainForSecretRef(context.TODO(), registry.SecretRef{
+			keychain, err := keychainFactory.MultiKeychainFromServiceAccountRef(context.TODO(), registry.ServiceAccountRef{
 				ServiceAccount: serviceAccountName,
 				Namespace:      testNamespace,
 			})
@@ -108,7 +108,7 @@ func testK8sSecretKeychainFactory(t *testing.T, when spec.G, it spec.S) {
 			keychainFactory, err := NewSecretKeychainFactory(fakeClient)
 			require.NoError(t, err)
 
-			keychain, err := keychainFactory.KeychainForSecretRef(context.TODO(), registry.SecretRef{
+			keychain, err := keychainFactory.MultiKeychainFromServiceAccountRef(context.TODO(), registry.ServiceAccountRef{
 				ServiceAccount: serviceAccountName,
 				Namespace:      testNamespace,
 			})
@@ -176,7 +176,7 @@ func testK8sSecretKeychainFactory(t *testing.T, when spec.G, it spec.S) {
 				keychainFactory, err := NewSecretKeychainFactory(fakeClient)
 				require.NoError(t, err)
 
-				keychain, err := keychainFactory.KeychainForSecretRef(context.TODO(), registry.SecretRef{
+				keychain, err := keychainFactory.MultiKeychainFromServiceAccountRef(context.TODO(), registry.ServiceAccountRef{
 					ServiceAccount: "",
 					Namespace:      testNamespace,
 				})
@@ -214,7 +214,7 @@ func testK8sSecretKeychainFactory(t *testing.T, when spec.G, it spec.S) {
 			keychainFactory, err := NewSecretKeychainFactory(fakeClient)
 			require.NoError(t, err)
 
-			keychain, err := keychainFactory.KeychainForSecretRef(context.TODO(), registry.SecretRef{
+			keychain, err := keychainFactory.MultiKeychainFromServiceAccountRef(context.TODO(), registry.ServiceAccountRef{
 				ServiceAccount:   serviceAccountName,
 				Namespace:        testNamespace,
 				ImagePullSecrets: []corev1.LocalObjectReference{{"image-pull-secret"}},
@@ -245,7 +245,7 @@ func testK8sSecretKeychainFactory(t *testing.T, when spec.G, it spec.S) {
 			}))
 			require.NoError(t, err)
 
-			keychain, err := keychainFactory.KeychainForSecretRef(context.TODO(), registry.SecretRef{
+			keychain, err := keychainFactory.MultiKeychainFromServiceAccountRef(context.TODO(), registry.ServiceAccountRef{
 				ServiceAccount: serviceAccountName,
 				Namespace:      testNamespace,
 			})
@@ -263,7 +263,7 @@ func testK8sSecretKeychainFactory(t *testing.T, when spec.G, it spec.S) {
 			keychainFactory, err := NewSecretKeychainFactory(fake.NewSimpleClientset())
 			require.NoError(t, err)
 
-			keychain, err := keychainFactory.KeychainForSecretRef(context.TODO(), registry.SecretRef{
+			keychain, err := keychainFactory.MultiKeychainFromServiceAccountRef(context.TODO(), registry.ServiceAccountRef{
 				Namespace: "",
 			})
 			require.NoError(t, err)

--- a/pkg/reconciler/builder/builder.go
+++ b/pkg/reconciler/builder/builder.go
@@ -127,7 +127,7 @@ func (c *Reconciler) reconcileBuilder(ctx context.Context, builder *v1alpha1.Bui
 		return v1alpha1.BuilderRecord{}, errors.Errorf("stack %s is not ready", clusterStack.Name)
 	}
 
-	keychain, err := c.KeychainFactory.KeychainForSecretRef(ctx, registry.SecretRef{
+	keychain, err := c.KeychainFactory.MultiKeychainFromServiceAccountRef(ctx, registry.ServiceAccountRef{
 		ServiceAccount: builder.Spec.ServiceAccount,
 		Namespace:      builder.Namespace,
 	})

--- a/pkg/reconciler/builder/builder_test.go
+++ b/pkg/reconciler/builder/builder_test.go
@@ -127,7 +127,7 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 		},
 	}
 
-	secretRef := registry.SecretRef{
+	secretRef := registry.ServiceAccountRef{
 		ServiceAccount: builder.Spec.ServiceAccount,
 		Namespace:      builder.Namespace,
 	}

--- a/pkg/reconciler/clusterbuilder/clusterbuilder.go
+++ b/pkg/reconciler/clusterbuilder/clusterbuilder.go
@@ -125,7 +125,7 @@ func (c *Reconciler) reconcileBuilder(ctx context.Context, builder *v1alpha1.Clu
 		return v1alpha1.BuilderRecord{}, errors.Errorf("stack %s is not ready", clusterStack.Name)
 	}
 
-	keychain, err := c.KeychainFactory.KeychainForSecretRef(ctx, registry.SecretRef{
+	keychain, err := c.KeychainFactory.MultiKeychainFromServiceAccountRef(ctx, registry.ServiceAccountRef{
 		ServiceAccount: builder.Spec.ServiceAccountRef.Name,
 		Namespace:      builder.Spec.ServiceAccountRef.Namespace,
 	})

--- a/pkg/reconciler/clusterbuilder/clusterbuilder_test.go
+++ b/pkg/reconciler/clusterbuilder/clusterbuilder_test.go
@@ -128,7 +128,7 @@ func testClusterBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 		},
 	}
 
-	secretRef := registry.SecretRef{
+	secretRef := registry.ServiceAccountRef{
 		ServiceAccount: builder.Spec.ServiceAccountRef.Name,
 		Namespace:      builder.Spec.ServiceAccountRef.Namespace,
 	}

--- a/pkg/reconciler/sourceresolver/sourceresolver.go
+++ b/pkg/reconciler/sourceresolver/sourceresolver.go
@@ -43,7 +43,7 @@ func NewController(
 		SourceResolverLister: sourceResolverInformer.Lister(),
 	}
 
-	impl := controller.NewImpl(c, opt.Logger, ReconcilerName)
+	impl := controller.NewImplFull(c, controller.ControllerOptions{WorkQueueName: ReconcilerName, Logger: opt.Logger})
 
 	c.Enqueuer = &workQueueEnqueuer{
 		enqueueAfter: impl.EnqueueAfter,

--- a/pkg/registry/keychain_factory.go
+++ b/pkg/registry/keychain_factory.go
@@ -7,17 +7,17 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-type SecretRef struct {
+type ServiceAccountRef struct {
 	ServiceAccount   string
 	Namespace        string
 	ImagePullSecrets []v1.LocalObjectReference
 }
 
-func (s SecretRef) IsNamespaced() bool {
+func (s ServiceAccountRef) IsNamespaced() bool {
 	return s.Namespace != ""
 }
 
-func (s SecretRef) ServiceAccountOrDefault() string {
+func (s ServiceAccountRef) ServiceAccountOrDefault() string {
 	if s.ServiceAccount == "" {
 		return "default"
 	}
@@ -25,5 +25,5 @@ func (s SecretRef) ServiceAccountOrDefault() string {
 }
 
 type KeychainFactory interface {
-	KeychainForSecretRef(context.Context, SecretRef) (authn.Keychain, error)
+	MultiKeychainFromServiceAccountRef(context.Context, ServiceAccountRef) (authn.Keychain, error)
 }

--- a/pkg/registry/registryfakes/fake_keychain_factory.go
+++ b/pkg/registry/registryfakes/fake_keychain_factory.go
@@ -12,7 +12,7 @@ import (
 )
 
 type keychainContainer struct {
-	SecretRef registry.SecretRef
+	SecretRef registry.ServiceAccountRef
 	Keychain  authn.Keychain
 }
 
@@ -20,14 +20,14 @@ type FakeKeychainFactory struct {
 	keychains []keychainContainer
 }
 
-func (f *FakeKeychainFactory) KeychainForSecretRef(ctx context.Context, secretRef registry.SecretRef) (authn.Keychain, error) {
+func (f *FakeKeychainFactory) MultiKeychainFromServiceAccountRef(ctx context.Context, secretRef registry.ServiceAccountRef) (authn.Keychain, error) {
 	if keychain, ok := f.getKeychainForSecretRef(secretRef); ok {
 		return keychain, nil
 	}
 	return nil, errors.Errorf("unable to find keychain for secret ref: %+v", secretRef)
 }
 
-func (f *FakeKeychainFactory) AddKeychainForSecretRef(t *testing.T, secretRef registry.SecretRef, keychain authn.Keychain) {
+func (f *FakeKeychainFactory) AddKeychainForSecretRef(t *testing.T, secretRef registry.ServiceAccountRef, keychain authn.Keychain) {
 	t.Helper()
 
 	if _, ok := f.getKeychainForSecretRef(secretRef); ok {
@@ -41,7 +41,7 @@ func (f *FakeKeychainFactory) AddKeychainForSecretRef(t *testing.T, secretRef re
 	})
 }
 
-func (f *FakeKeychainFactory) getKeychainForSecretRef(secretRef registry.SecretRef) (authn.Keychain, bool) {
+func (f *FakeKeychainFactory) getKeychainForSecretRef(secretRef registry.ServiceAccountRef) (authn.Keychain, bool) {
 	for _, item := range f.keychains {
 		if equality.Semantic.DeepEqual(item.SecretRef, secretRef) {
 			return item.Keychain, true


### PR DESCRIPTION
- rename methods to be easier to understand
- enable ability to get service account secrets only, ignoring volume secrets

Co-authored-by: Tyler Phelan <tylerp@vmware.com>