### PR TITLE
Add missing builder image labels

### DIFF
--- a/pkg/cnb/builder_builder.go
+++ b/pkg/cnb/builder_builder.go
@@ -152,8 +152,10 @@ func (bb *builderBlder) WriteableImage() (v1.Image, error) {
 	}
 
 	return imagehelpers.SetLabels(image, map[string]interface{}{
-		buildpackOrderLabel:  bb.order,
-		buildpackLayersLabel: buildpackLayerMetadata,
+		buildpackOrderLabel:   bb.order,
+		buildpackLayersLabel:  buildpackLayerMetadata,
+		lifecycleApisLabel:    bb.LifecycleMetadata.APIs,
+		lifecycleVersionLabel: bb.LifecycleMetadata.Version,
 		buildpackMetadataLabel: BuilderImageMetadata{
 			Description: "Custom Builder built with kpack",
 			Stack: StackMetadata{

--- a/pkg/cnb/buildpack_metadata.go
+++ b/pkg/cnb/buildpack_metadata.go
@@ -9,6 +9,8 @@ const (
 	buildpackLayersLabel   = "io.buildpacks.buildpack.layers"
 	buildpackMetadataLabel = "io.buildpacks.builder.metadata"
 	lifecycleMetadataLabel = "io.buildpacks.lifecycle.metadata"
+	lifecycleVersionLabel  = "io.buildpacks.lifecycle.version"
+	lifecycleApisLabel     = "io.buildpacks.lifecycle.apis"
 )
 
 type BuildpackLayerInfo struct {
@@ -61,7 +63,10 @@ type LifecycleMetadata struct {
 
 type LifecycleDescriptor struct {
 	Info LifecycleInfo `toml:"lifecycle"`
-	API  LifecycleAPI  `toml:"api"`
+
+	// Deprecated: Use `LifecycleAPIs` instead
+	API  LifecycleAPI  `toml:"api" json:"api,omitempty"`
+	APIs LifecycleAPIs `toml:"apis" json:"apis,omitempty"`
 }
 
 type LifecycleInfo struct {


### PR DESCRIPTION
- Mentioned as defacto labels in spec rfc https://github.com/buildpacks/rfcs/blob/main/text/0049-multi-api-lifecycle-descriptor.md
  Keep old metadata label for backwards compatibility
- Update lifecycle descriptor schema to match spec