### PR TITLE
Image spec add new tagging strategy: GitRevision

### DIFF
--- a/pkg/apis/build/v1alpha1/image_types.go
+++ b/pkg/apis/build/v1alpha1/image_types.go
@@ -63,6 +63,7 @@ type ImageTaggingStrategy string
 const (
 	None        ImageTaggingStrategy = "None"
 	BuildNumber ImageTaggingStrategy = "BuildNumber"
+	GitRevision ImageTaggingStrategy = "GitRevision"
 )
 
 // +k8s:openapi-gen=true

--- a/pkg/apis/build/v1alpha1/image_validation.go
+++ b/pkg/apis/build/v1alpha1/image_validation.go
@@ -75,6 +75,7 @@ func (is *ImageSpec) ValidateSpec(ctx context.Context) *apis.FieldError {
 	return is.validateTag(ctx).
 		Also(validateBuilder(is.Builder).ViaField("builder")).
 		Also(is.Source.Validate(ctx).ViaField("source")).
+		Also(is.validateImageTaggingStrategy(ctx)).
 		Also(is.Build.Validate(ctx).ViaField("build")).
 		Also(is.validateCacheSize(ctx)).
 		Also(is.Notary.Validate(ctx).ViaField("notary"))
@@ -87,6 +88,17 @@ func (is *ImageSpec) validateTag(ctx context.Context) *apis.FieldError {
 	}
 
 	return validate.Tag(is.Tag)
+}
+
+func (is *ImageSpec) validateImageTaggingStrategy(_ context.Context) *apis.FieldError {
+	switch is.ImageTaggingStrategy {
+	case GitRevision:
+		if is.Source.Git == nil {
+			diagnostic := fmt.Sprintf("spec.imageTaggingStrategy cannot be %s when not git source", GitRevision)
+			return apis.ErrGeneric(diagnostic)
+		}
+	}
+	return nil
 }
 
 func (is *ImageSpec) validateCacheSize(ctx context.Context) *apis.FieldError {

--- a/pkg/apis/build/v1alpha1/image_validation_test.go
+++ b/pkg/apis/build/v1alpha1/image_validation_test.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -265,6 +266,16 @@ func testImageValidation(t *testing.T, when spec.G, it spec.S) {
 			image.Spec.CacheSize = &cacheSize
 			err := image.Validate(apis.WithinUpdate(ctx, original))
 			assert.EqualError(t, err, "Field cannot be decreased: spec.cacheSize\ncurrent: 5G, requested: 4G")
+		})
+
+		it("GitRevision image tagging strategy / source config not match", func() {
+			image.Spec.ImageTaggingStrategy = GitRevision
+			image.Spec.Source = SourceConfig{
+				Blob: &Blob{
+					URL: "http://blob.com/url",
+				},
+			}
+			assertValidationError(image, ctx, apis.ErrGeneric(fmt.Sprintf("spec.imageTaggingStrategy cannot be %s when not git source", GitRevision)))
 		})
 
 		when("validating the notary config", func() {


### PR DESCRIPTION
Hi,

It may be a common usage that associate the git revision with the container image revision, so I extend the ImageTaggingStrategy with the **GitRevision** option. 

for example, use git with revision `ewfge4w`  as Image source,
when use BuildNumber image tagging strategy:
`docker.io/my-project/myapp:mytag-b1.20210703.151213`
when use **GitRevision** image tagging strategy:
`docker.io/my-project/myapp:mytag-ewfge4w`

Please let me know if any suggestions and comments, I will try to adjust  : 0