### PR TITLE
Utilize release-1.19 of kube-openapi to generate openapi definitions

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -5522,8 +5522,7 @@
           "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
         },
         "name": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "secretRef": {
           "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
@@ -5537,8 +5536,7 @@
       ],
       "properties": {
         "url": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         }
       }
     },
@@ -5557,15 +5555,12 @@
           "type": "string"
         },
         "metadata": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
         },
         "spec": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.BuildSpec"
         },
         "status": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.BuildStatus"
         }
       }
@@ -5579,7 +5574,6 @@
         "imagePullSecrets": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
           },
           "x-kubernetes-list-type": "",
@@ -5602,7 +5596,6 @@
         "items": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.Build"
           }
         },
@@ -5611,7 +5604,6 @@
           "type": "string"
         },
         "metadata": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
         }
       }
@@ -5625,13 +5617,11 @@
         "bindings": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.Binding"
           },
           "x-kubernetes-list-type": ""
         },
         "builder": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.BuildBuilderSpec"
         },
         "cacheName": {
@@ -5640,7 +5630,6 @@
         "env": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/io.k8s.api.core.v1.EnvVar"
           },
           "x-kubernetes-list-type": ""
@@ -5652,21 +5641,18 @@
           "$ref": "#/definitions/kpack.build.v1alpha2.NotaryConfig"
         },
         "resources": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
         },
         "serviceAccount": {
           "type": "string"
         },
         "source": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.SourceConfig"
         },
         "tags": {
           "type": "array",
           "items": {
-            "type": "string",
-            "default": ""
+            "type": "string"
           },
           "x-kubernetes-list-type": ""
         }
@@ -5689,7 +5675,6 @@
         "buildMetadata": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.BuildpackMetadata"
           }
         },
@@ -5697,7 +5682,6 @@
           "description": "Conditions the latest available observations of a resource's current state.",
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.core.v1alpha1.Condition"
           },
           "x-kubernetes-patch-merge-key": "type",
@@ -5715,13 +5699,11 @@
           "type": "string"
         },
         "stack": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.BuildStack"
         },
         "stepStates": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/io.k8s.api.core.v1.ContainerState"
           },
           "x-kubernetes-list-type": ""
@@ -5729,8 +5711,7 @@
         "stepsCompleted": {
           "type": "array",
           "items": {
-            "type": "string",
-            "default": ""
+            "type": "string"
           },
           "x-kubernetes-list-type": ""
         }
@@ -5752,15 +5733,12 @@
           "type": "string"
         },
         "metadata": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
         },
         "spec": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.NamespacedBuilderSpec"
         },
         "status": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.BuilderStatus"
         }
       }
@@ -5779,7 +5757,6 @@
         "items": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.Builder"
           }
         },
@@ -5788,7 +5765,6 @@
           "type": "string"
         },
         "metadata": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
         }
       }
@@ -5799,17 +5775,14 @@
         "order": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.OrderEntry"
           },
           "x-kubernetes-list-type": ""
         },
         "stack": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
         },
         "store": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
         },
         "tag": {
@@ -5823,7 +5796,6 @@
         "builderMetadata": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.BuildpackMetadata"
           }
         },
@@ -5831,7 +5803,6 @@
           "description": "Conditions the latest available observations of a resource's current state.",
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.core.v1alpha1.Condition"
           },
           "x-kubernetes-patch-merge-key": "type",
@@ -5856,7 +5827,6 @@
         "order": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.OrderEntry"
           }
         },
@@ -5864,7 +5834,6 @@
           "type": "string"
         },
         "stack": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.BuildStack"
         }
       }
@@ -5876,8 +5845,7 @@
       ],
       "properties": {
         "id": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "version": {
           "type": "string"
@@ -5895,12 +5863,10 @@
           "type": "string"
         },
         "id": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "version": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         }
       }
     },
@@ -5911,8 +5877,7 @@
       ],
       "properties": {
         "id": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "optional": {
           "type": "boolean"
@@ -5929,14 +5894,12 @@
       ],
       "properties": {
         "id": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "mixins": {
           "type": "array",
           "items": {
-            "type": "string",
-            "default": ""
+            "type": "string"
           },
           "x-kubernetes-list-type": ""
         }
@@ -5972,15 +5935,12 @@
           "type": "string"
         },
         "metadata": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
         },
         "spec": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.ClusterBuilderSpec"
         },
         "status": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.BuilderStatus"
         }
       }
@@ -5999,7 +5959,6 @@
         "items": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.ClusterBuilder"
           }
         },
@@ -6008,7 +5967,6 @@
           "type": "string"
         },
         "metadata": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
         }
       }
@@ -6019,21 +5977,17 @@
         "order": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.OrderEntry"
           },
           "x-kubernetes-list-type": ""
         },
         "serviceAccountRef": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
         },
         "stack": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
         },
         "store": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
         },
         "tag": {
@@ -6057,15 +6011,12 @@
           "type": "string"
         },
         "metadata": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
         },
         "spec": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.ClusterStackSpec"
         },
         "status": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.ClusterStackStatus"
         }
       }
@@ -6084,7 +6035,6 @@
         "items": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.ClusterStack"
           }
         },
@@ -6093,7 +6043,6 @@
           "type": "string"
         },
         "metadata": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
         }
       }
@@ -6102,14 +6051,12 @@
       "type": "object",
       "properties": {
         "buildImage": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.ClusterStackSpecImage"
         },
         "id": {
           "type": "string"
         },
         "runImage": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.ClusterStackSpecImage"
         }
       }
@@ -6126,14 +6073,12 @@
       "type": "object",
       "properties": {
         "buildImage": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.ClusterStackStatusImage"
         },
         "conditions": {
           "description": "Conditions the latest available observations of a resource's current state.",
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.core.v1alpha1.Condition"
           },
           "x-kubernetes-patch-merge-key": "type",
@@ -6149,8 +6094,7 @@
         "mixins": {
           "type": "array",
           "items": {
-            "type": "string",
-            "default": ""
+            "type": "string"
           },
           "x-kubernetes-list-type": ""
         },
@@ -6160,7 +6104,6 @@
           "format": "int64"
         },
         "runImage": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.ClusterStackStatusImage"
         },
         "userId": {
@@ -6196,15 +6139,12 @@
           "type": "string"
         },
         "metadata": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
         },
         "spec": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.ClusterStoreSpec"
         },
         "status": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.ClusterStoreStatus"
         }
       }
@@ -6223,7 +6163,6 @@
         "items": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.ClusterStore"
           }
         },
@@ -6232,7 +6171,6 @@
           "type": "string"
         },
         "metadata": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
         }
       }
@@ -6243,7 +6181,6 @@
         "sources": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.StoreImage"
           },
           "x-kubernetes-list-type": ""
@@ -6256,7 +6193,6 @@
         "buildpacks": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.StoreBuildpack"
           },
           "x-kubernetes-list-type": ""
@@ -6265,7 +6201,6 @@
           "description": "Conditions the latest available observations of a resource's current state.",
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.core.v1alpha1.Condition"
           },
           "x-kubernetes-patch-merge-key": "type",
@@ -6286,12 +6221,10 @@
       ],
       "properties": {
         "revision": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "url": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         }
       }
     },
@@ -6310,15 +6243,12 @@
           "type": "string"
         },
         "metadata": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
         },
         "spec": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.ImageSpec"
         },
         "status": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.ImageStatus"
         }
       }
@@ -6329,7 +6259,6 @@
         "bindings": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.Binding"
           },
           "x-kubernetes-list-type": ""
@@ -6337,13 +6266,11 @@
         "env": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/io.k8s.api.core.v1.EnvVar"
           },
           "x-kubernetes-list-type": ""
         },
         "resources": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
         }
       }
@@ -6363,8 +6290,7 @@
           "type": "string"
         },
         "name": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         }
       }
     },
@@ -6382,7 +6308,6 @@
         "items": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.Image"
           }
         },
@@ -6391,7 +6316,6 @@
           "type": "string"
         },
         "metadata": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
         }
       }
@@ -6407,7 +6331,6 @@
           "$ref": "#/definitions/kpack.build.v1alpha2.ImageBuild"
         },
         "builder": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
         },
         "cacheSize": {
@@ -6427,7 +6350,6 @@
           "type": "string"
         },
         "source": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.SourceConfig"
         },
         "successBuildHistoryLimit": {
@@ -6435,8 +6357,7 @@
           "format": "int64"
         },
         "tag": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         }
       }
     },
@@ -6454,7 +6375,6 @@
           "description": "Conditions the latest available observations of a resource's current state.",
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.core.v1alpha1.Condition"
           },
           "x-kubernetes-patch-merge-key": "type",
@@ -6500,7 +6420,6 @@
         "order": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.OrderEntry"
           },
           "x-kubernetes-list-type": ""
@@ -6509,11 +6428,9 @@
           "type": "string"
         },
         "stack": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
         },
         "store": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
         },
         "tag": {
@@ -6536,8 +6453,7 @@
       ],
       "properties": {
         "name": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         }
       }
     },
@@ -6549,12 +6465,10 @@
       ],
       "properties": {
         "secretRef": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.NotarySecretRef"
         },
         "url": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         }
       }
     },
@@ -6564,7 +6478,6 @@
         "group": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.BuildpackRef"
           },
           "x-kubernetes-list-type": ""
@@ -6578,13 +6491,11 @@
       ],
       "properties": {
         "image": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "imagePullSecrets": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
           },
           "x-kubernetes-list-type": "",
@@ -6603,8 +6514,7 @@
           "type": "string"
         },
         "url": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         }
       }
     },
@@ -6612,7 +6522,6 @@
       "type": "object",
       "properties": {
         "buildImage": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.ClusterStackStatusImage"
         },
         "groupId": {
@@ -6625,13 +6534,11 @@
         "mixins": {
           "type": "array",
           "items": {
-            "type": "string",
-            "default": ""
+            "type": "string"
           },
           "x-kubernetes-list-type": ""
         },
         "runImage": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.ClusterStackStatusImage"
         },
         "userId": {
@@ -6649,19 +6556,16 @@
       ],
       "properties": {
         "revision": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "subPath": {
           "type": "string"
         },
         "type": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "url": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         }
       }
     },
@@ -6672,13 +6576,11 @@
       ],
       "properties": {
         "image": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "imagePullSecrets": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
           },
           "x-kubernetes-list-type": "",
@@ -6736,15 +6638,12 @@
           "type": "string"
         },
         "metadata": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
         },
         "spec": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.SourceResolverSpec"
         },
         "status": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.SourceResolverStatus"
         }
       }
@@ -6763,7 +6662,6 @@
         "items": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.SourceResolver"
           }
         },
@@ -6772,7 +6670,6 @@
           "type": "string"
         },
         "metadata": {
-          "default": {},
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
         }
       }
@@ -6787,7 +6684,6 @@
           "type": "string"
         },
         "source": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.SourceConfig"
         }
       }
@@ -6799,7 +6695,6 @@
           "description": "Conditions the latest available observations of a resource's current state.",
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.core.v1alpha1.Condition"
           },
           "x-kubernetes-patch-merge-key": "type",
@@ -6811,7 +6706,6 @@
           "format": "int64"
         },
         "source": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.ResolvedSourceConfig"
         }
       }
@@ -6826,7 +6720,6 @@
           "type": "string"
         },
         "buildpackage": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.BuildpackageInfo"
         },
         "diffId": {
@@ -6839,13 +6732,11 @@
           "type": "string"
         },
         "id": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "order": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.OrderEntry"
           },
           "x-kubernetes-list-type": ""
@@ -6857,13 +6748,11 @@
         "stacks": {
           "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/kpack.build.v1alpha2.BuildpackStack"
           },
           "x-kubernetes-list-type": ""
         },
         "storeImage": {
-          "default": {},
           "$ref": "#/definitions/kpack.build.v1alpha2.StoreImage"
         },
         "version": {

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -155,9 +155,8 @@ func schema_pkg_apis_build_v1alpha1_Binding(ref common.ReferenceCallback) common
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"metadataRef": {
@@ -187,9 +186,8 @@ func schema_pkg_apis_build_v1alpha1_Blob(ref common.ReferenceCallback) common.Op
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 				},
@@ -221,20 +219,17 @@ func schema_pkg_apis_build_v1alpha1_Build(ref common.ReferenceCallback) common.O
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildSpec"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildStatus"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildStatus"),
 						},
 					},
 				},
@@ -271,8 +266,7 @@ func schema_pkg_apis_build_v1alpha1_BuildBuilderSpec(ref common.ReferenceCallbac
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/api/core/v1.LocalObjectReference"),
+										Ref: ref("k8s.io/api/core/v1.LocalObjectReference"),
 									},
 								},
 							},
@@ -308,8 +302,7 @@ func schema_pkg_apis_build_v1alpha1_BuildList(ref common.ReferenceCallback) comm
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -318,8 +311,7 @@ func schema_pkg_apis_build_v1alpha1_BuildList(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Build"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Build"),
 									},
 								},
 							},
@@ -351,9 +343,8 @@ func schema_pkg_apis_build_v1alpha1_BuildSpec(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -361,8 +352,7 @@ func schema_pkg_apis_build_v1alpha1_BuildSpec(ref common.ReferenceCallback) comm
 					},
 					"builder": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildBuilderSpec"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildBuilderSpec"),
 						},
 					},
 					"serviceAccount": {
@@ -373,8 +363,7 @@ func schema_pkg_apis_build_v1alpha1_BuildSpec(ref common.ReferenceCallback) comm
 					},
 					"source": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceConfig"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceConfig"),
 						},
 					},
 					"cacheName": {
@@ -394,8 +383,7 @@ func schema_pkg_apis_build_v1alpha1_BuildSpec(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Binding"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Binding"),
 									},
 								},
 							},
@@ -412,8 +400,7 @@ func schema_pkg_apis_build_v1alpha1_BuildSpec(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/api/core/v1.EnvVar"),
+										Ref: ref("k8s.io/api/core/v1.EnvVar"),
 									},
 								},
 							},
@@ -421,8 +408,7 @@ func schema_pkg_apis_build_v1alpha1_BuildSpec(ref common.ReferenceCallback) comm
 					},
 					"resources": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ResourceRequirements"),
+							Ref: ref("k8s.io/api/core/v1.ResourceRequirements"),
 						},
 					},
 					"lastBuild": {
@@ -494,8 +480,7 @@ func schema_pkg_apis_build_v1alpha1_BuildStatus(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -507,8 +492,7 @@ func schema_pkg_apis_build_v1alpha1_BuildStatus(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackMetadata"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackMetadata"),
 									},
 								},
 							},
@@ -516,8 +500,7 @@ func schema_pkg_apis_build_v1alpha1_BuildStatus(ref common.ReferenceCallback) co
 					},
 					"stack": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildStack"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildStack"),
 						},
 					},
 					"latestImage": {
@@ -543,8 +526,7 @@ func schema_pkg_apis_build_v1alpha1_BuildStatus(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/api/core/v1.ContainerState"),
+										Ref: ref("k8s.io/api/core/v1.ContainerState"),
 									},
 								},
 							},
@@ -561,9 +543,8 @@ func schema_pkg_apis_build_v1alpha1_BuildStatus(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -599,20 +580,17 @@ func schema_pkg_apis_build_v1alpha1_Builder(ref common.ReferenceCallback) common
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.NamespacedBuilderSpec"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.NamespacedBuilderSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuilderStatus"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuilderStatus"),
 						},
 					},
 				},
@@ -646,8 +624,7 @@ func schema_pkg_apis_build_v1alpha1_BuilderList(ref common.ReferenceCallback) co
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -656,8 +633,7 @@ func schema_pkg_apis_build_v1alpha1_BuilderList(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Builder"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Builder"),
 									},
 								},
 							},
@@ -686,14 +662,12 @@ func schema_pkg_apis_build_v1alpha1_BuilderSpec(ref common.ReferenceCallback) co
 					},
 					"stack": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
+							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"store": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
+							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"order": {
@@ -707,8 +681,7 @@ func schema_pkg_apis_build_v1alpha1_BuilderSpec(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
 									},
 								},
 							},
@@ -748,8 +721,7 @@ func schema_pkg_apis_build_v1alpha1_BuilderStatus(ref common.ReferenceCallback) 
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -761,8 +733,7 @@ func schema_pkg_apis_build_v1alpha1_BuilderStatus(ref common.ReferenceCallback) 
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackMetadata"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackMetadata"),
 									},
 								},
 							},
@@ -774,8 +745,7 @@ func schema_pkg_apis_build_v1alpha1_BuilderStatus(ref common.ReferenceCallback) 
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
 									},
 								},
 							},
@@ -783,8 +753,7 @@ func schema_pkg_apis_build_v1alpha1_BuilderStatus(ref common.ReferenceCallback) 
 					},
 					"stack": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildStack"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildStack"),
 						},
 					},
 					"latestImage": {
@@ -827,9 +796,8 @@ func schema_pkg_apis_build_v1alpha1_BuildpackInfo(ref common.ReferenceCallback) 
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"version": {
@@ -853,16 +821,14 @@ func schema_pkg_apis_build_v1alpha1_BuildpackMetadata(ref common.ReferenceCallba
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"homepage": {
@@ -886,9 +852,8 @@ func schema_pkg_apis_build_v1alpha1_BuildpackRef(ref common.ReferenceCallback) c
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"version": {
@@ -918,9 +883,8 @@ func schema_pkg_apis_build_v1alpha1_BuildpackStack(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"mixins": {
@@ -934,9 +898,8 @@ func schema_pkg_apis_build_v1alpha1_BuildpackStack(ref common.ReferenceCallback)
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -1001,20 +964,17 @@ func schema_pkg_apis_build_v1alpha1_ClusterBuilder(ref common.ReferenceCallback)
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterBuilderSpec"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterBuilderSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuilderStatus"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuilderStatus"),
 						},
 					},
 				},
@@ -1048,8 +1008,7 @@ func schema_pkg_apis_build_v1alpha1_ClusterBuilderList(ref common.ReferenceCallb
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -1058,8 +1017,7 @@ func schema_pkg_apis_build_v1alpha1_ClusterBuilderList(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterBuilder"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterBuilder"),
 									},
 								},
 							},
@@ -1088,14 +1046,12 @@ func schema_pkg_apis_build_v1alpha1_ClusterBuilderSpec(ref common.ReferenceCallb
 					},
 					"stack": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
+							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"store": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
+							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"order": {
@@ -1109,8 +1065,7 @@ func schema_pkg_apis_build_v1alpha1_ClusterBuilderSpec(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
 									},
 								},
 							},
@@ -1118,8 +1073,7 @@ func schema_pkg_apis_build_v1alpha1_ClusterBuilderSpec(ref common.ReferenceCallb
 					},
 					"serviceAccountRef": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
+							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 				},
@@ -1152,20 +1106,17 @@ func schema_pkg_apis_build_v1alpha1_ClusterStack(ref common.ReferenceCallback) c
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackSpec"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatus"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatus"),
 						},
 					},
 				},
@@ -1199,8 +1150,7 @@ func schema_pkg_apis_build_v1alpha1_ClusterStackList(ref common.ReferenceCallbac
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -1209,8 +1159,7 @@ func schema_pkg_apis_build_v1alpha1_ClusterStackList(ref common.ReferenceCallbac
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStack"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStack"),
 									},
 								},
 							},
@@ -1239,14 +1188,12 @@ func schema_pkg_apis_build_v1alpha1_ClusterStackSpec(ref common.ReferenceCallbac
 					},
 					"buildImage": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackSpecImage"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackSpecImage"),
 						},
 					},
 					"runImage": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackSpecImage"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackSpecImage"),
 						},
 					},
 				},
@@ -1301,8 +1248,7 @@ func schema_pkg_apis_build_v1alpha1_ClusterStackStatus(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -1316,14 +1262,12 @@ func schema_pkg_apis_build_v1alpha1_ClusterStackStatus(ref common.ReferenceCallb
 					},
 					"buildImage": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatusImage"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatusImage"),
 						},
 					},
 					"runImage": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatusImage"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatusImage"),
 						},
 					},
 					"mixins": {
@@ -1337,9 +1281,8 @@ func schema_pkg_apis_build_v1alpha1_ClusterStackStatus(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -1411,20 +1354,17 @@ func schema_pkg_apis_build_v1alpha1_ClusterStore(ref common.ReferenceCallback) c
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStoreSpec"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStoreSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStoreStatus"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStoreStatus"),
 						},
 					},
 				},
@@ -1458,8 +1398,7 @@ func schema_pkg_apis_build_v1alpha1_ClusterStoreList(ref common.ReferenceCallbac
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -1468,8 +1407,7 @@ func schema_pkg_apis_build_v1alpha1_ClusterStoreList(ref common.ReferenceCallbac
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStore"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStore"),
 									},
 								},
 							},
@@ -1501,8 +1439,7 @@ func schema_pkg_apis_build_v1alpha1_ClusterStoreSpec(ref common.ReferenceCallbac
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.StoreImage"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.StoreImage"),
 									},
 								},
 							},
@@ -1542,8 +1479,7 @@ func schema_pkg_apis_build_v1alpha1_ClusterStoreStatus(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -1560,8 +1496,7 @@ func schema_pkg_apis_build_v1alpha1_ClusterStoreStatus(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.StoreBuildpack"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.StoreBuildpack"),
 									},
 								},
 							},
@@ -1583,16 +1518,14 @@ func schema_pkg_apis_build_v1alpha1_Git(ref common.ReferenceCallback) common.Ope
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"revision": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 				},
@@ -1624,20 +1557,17 @@ func schema_pkg_apis_build_v1alpha1_Image(ref common.ReferenceCallback) common.O
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ImageSpec"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ImageSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ImageStatus"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ImageStatus"),
 						},
 					},
 				},
@@ -1666,8 +1596,7 @@ func schema_pkg_apis_build_v1alpha1_ImageBuild(ref common.ReferenceCallback) com
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Binding"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Binding"),
 									},
 								},
 							},
@@ -1684,8 +1613,7 @@ func schema_pkg_apis_build_v1alpha1_ImageBuild(ref common.ReferenceCallback) com
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/api/core/v1.EnvVar"),
+										Ref: ref("k8s.io/api/core/v1.EnvVar"),
 									},
 								},
 							},
@@ -1693,8 +1621,7 @@ func schema_pkg_apis_build_v1alpha1_ImageBuild(ref common.ReferenceCallback) com
 					},
 					"resources": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ResourceRequirements"),
+							Ref: ref("k8s.io/api/core/v1.ResourceRequirements"),
 						},
 					},
 				},
@@ -1727,9 +1654,8 @@ func schema_pkg_apis_build_v1alpha1_ImageBuilder(ref common.ReferenceCallback) c
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 				},
@@ -1761,8 +1687,7 @@ func schema_pkg_apis_build_v1alpha1_ImageList(ref common.ReferenceCallback) comm
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -1771,8 +1696,7 @@ func schema_pkg_apis_build_v1alpha1_ImageList(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Image"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.Image"),
 									},
 								},
 							},
@@ -1795,15 +1719,13 @@ func schema_pkg_apis_build_v1alpha1_ImageSpec(ref common.ReferenceCallback) comm
 				Properties: map[string]spec.Schema{
 					"tag": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"builder": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
+							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"serviceAccount": {
@@ -1814,8 +1736,7 @@ func schema_pkg_apis_build_v1alpha1_ImageSpec(ref common.ReferenceCallback) comm
 					},
 					"source": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceConfig"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceConfig"),
 						},
 					},
 					"cacheSize": {
@@ -1886,8 +1807,7 @@ func schema_pkg_apis_build_v1alpha1_ImageStatus(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -1981,14 +1901,12 @@ func schema_pkg_apis_build_v1alpha1_NamespacedBuilderSpec(ref common.ReferenceCa
 					},
 					"stack": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
+							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"store": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
+							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"order": {
@@ -2002,8 +1920,7 @@ func schema_pkg_apis_build_v1alpha1_NamespacedBuilderSpec(ref common.ReferenceCa
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
 									},
 								},
 							},
@@ -2050,9 +1967,8 @@ func schema_pkg_apis_build_v1alpha1_NotarySecretRef(ref common.ReferenceCallback
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 				},
@@ -2070,15 +1986,13 @@ func schema_pkg_apis_build_v1alpha1_NotaryV1Config(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"secretRef": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.NotarySecretRef"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.NotarySecretRef"),
 						},
 					},
 				},
@@ -2107,8 +2021,7 @@ func schema_pkg_apis_build_v1alpha1_OrderEntry(ref common.ReferenceCallback) com
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackRef"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackRef"),
 									},
 								},
 							},
@@ -2130,9 +2043,8 @@ func schema_pkg_apis_build_v1alpha1_Registry(ref common.ReferenceCallback) commo
 				Properties: map[string]spec.Schema{
 					"image": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"imagePullSecrets": {
@@ -2148,8 +2060,7 @@ func schema_pkg_apis_build_v1alpha1_Registry(ref common.ReferenceCallback) commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/api/core/v1.LocalObjectReference"),
+										Ref: ref("k8s.io/api/core/v1.LocalObjectReference"),
 									},
 								},
 							},
@@ -2172,9 +2083,8 @@ func schema_pkg_apis_build_v1alpha1_ResolvedBlobSource(ref common.ReferenceCallb
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"subPath": {
@@ -2204,14 +2114,12 @@ func schema_pkg_apis_build_v1alpha1_ResolvedClusterStack(ref common.ReferenceCal
 					},
 					"buildImage": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatusImage"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatusImage"),
 						},
 					},
 					"runImage": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatusImage"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ClusterStackStatusImage"),
 						},
 					},
 					"mixins": {
@@ -2225,9 +2133,8 @@ func schema_pkg_apis_build_v1alpha1_ResolvedClusterStack(ref common.ReferenceCal
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -2261,16 +2168,14 @@ func schema_pkg_apis_build_v1alpha1_ResolvedGitSource(ref common.ReferenceCallba
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"revision": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"subPath": {
@@ -2281,9 +2186,8 @@ func schema_pkg_apis_build_v1alpha1_ResolvedGitSource(ref common.ReferenceCallba
 					},
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 				},
@@ -2301,9 +2205,8 @@ func schema_pkg_apis_build_v1alpha1_ResolvedRegistrySource(ref common.ReferenceC
 				Properties: map[string]spec.Schema{
 					"image": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"subPath": {
@@ -2325,8 +2228,7 @@ func schema_pkg_apis_build_v1alpha1_ResolvedRegistrySource(ref common.ReferenceC
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/api/core/v1.LocalObjectReference"),
+										Ref: ref("k8s.io/api/core/v1.LocalObjectReference"),
 									},
 								},
 							},
@@ -2427,20 +2329,17 @@ func schema_pkg_apis_build_v1alpha1_SourceResolver(ref common.ReferenceCallback)
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceResolverSpec"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceResolverSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceResolverStatus"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceResolverStatus"),
 						},
 					},
 				},
@@ -2474,8 +2373,7 @@ func schema_pkg_apis_build_v1alpha1_SourceResolverList(ref common.ReferenceCallb
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -2484,8 +2382,7 @@ func schema_pkg_apis_build_v1alpha1_SourceResolverList(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceResolver"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceResolver"),
 									},
 								},
 							},
@@ -2514,8 +2411,7 @@ func schema_pkg_apis_build_v1alpha1_SourceResolverSpec(ref common.ReferenceCallb
 					},
 					"source": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceConfig"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.SourceConfig"),
 						},
 					},
 				},
@@ -2553,8 +2449,7 @@ func schema_pkg_apis_build_v1alpha1_SourceResolverStatus(ref common.ReferenceCal
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -2562,8 +2457,7 @@ func schema_pkg_apis_build_v1alpha1_SourceResolverStatus(ref common.ReferenceCal
 					},
 					"source": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ResolvedSourceConfig"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.ResolvedSourceConfig"),
 						},
 					},
 				},
@@ -2582,9 +2476,8 @@ func schema_pkg_apis_build_v1alpha1_StoreBuildpack(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"version": {
@@ -2595,14 +2488,12 @@ func schema_pkg_apis_build_v1alpha1_StoreBuildpack(ref common.ReferenceCallback)
 					},
 					"buildpackage": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackageInfo"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackageInfo"),
 						},
 					},
 					"storeImage": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.StoreImage"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.StoreImage"),
 						},
 					},
 					"diffId": {
@@ -2646,8 +2537,7 @@ func schema_pkg_apis_build_v1alpha1_StoreBuildpack(ref common.ReferenceCallback)
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.OrderEntry"),
 									},
 								},
 							},
@@ -2664,8 +2554,7 @@ func schema_pkg_apis_build_v1alpha1_StoreBuildpack(ref common.ReferenceCallback)
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackStack"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha1.BuildpackStack"),
 									},
 								},
 							},
@@ -2706,9 +2595,8 @@ func schema_pkg_apis_build_v1alpha2_Binding(ref common.ReferenceCallback) common
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"metadataRef": {
@@ -2738,9 +2626,8 @@ func schema_pkg_apis_build_v1alpha2_Blob(ref common.ReferenceCallback) common.Op
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 				},
@@ -2772,20 +2659,17 @@ func schema_pkg_apis_build_v1alpha2_Build(ref common.ReferenceCallback) common.O
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildSpec"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildStatus"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildStatus"),
 						},
 					},
 				},
@@ -2822,8 +2706,7 @@ func schema_pkg_apis_build_v1alpha2_BuildBuilderSpec(ref common.ReferenceCallbac
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/api/core/v1.LocalObjectReference"),
+										Ref: ref("k8s.io/api/core/v1.LocalObjectReference"),
 									},
 								},
 							},
@@ -2859,8 +2742,7 @@ func schema_pkg_apis_build_v1alpha2_BuildList(ref common.ReferenceCallback) comm
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -2869,8 +2751,7 @@ func schema_pkg_apis_build_v1alpha2_BuildList(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.Build"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.Build"),
 									},
 								},
 							},
@@ -2902,9 +2783,8 @@ func schema_pkg_apis_build_v1alpha2_BuildSpec(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -2912,8 +2792,7 @@ func schema_pkg_apis_build_v1alpha2_BuildSpec(ref common.ReferenceCallback) comm
 					},
 					"builder": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildBuilderSpec"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildBuilderSpec"),
 						},
 					},
 					"serviceAccount": {
@@ -2924,8 +2803,7 @@ func schema_pkg_apis_build_v1alpha2_BuildSpec(ref common.ReferenceCallback) comm
 					},
 					"source": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.SourceConfig"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.SourceConfig"),
 						},
 					},
 					"cacheName": {
@@ -2945,8 +2823,7 @@ func schema_pkg_apis_build_v1alpha2_BuildSpec(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.Binding"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.Binding"),
 									},
 								},
 							},
@@ -2963,8 +2840,7 @@ func schema_pkg_apis_build_v1alpha2_BuildSpec(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/api/core/v1.EnvVar"),
+										Ref: ref("k8s.io/api/core/v1.EnvVar"),
 									},
 								},
 							},
@@ -2972,8 +2848,7 @@ func schema_pkg_apis_build_v1alpha2_BuildSpec(ref common.ReferenceCallback) comm
 					},
 					"resources": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ResourceRequirements"),
+							Ref: ref("k8s.io/api/core/v1.ResourceRequirements"),
 						},
 					},
 					"lastBuild": {
@@ -3045,8 +2920,7 @@ func schema_pkg_apis_build_v1alpha2_BuildStatus(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -3058,8 +2932,7 @@ func schema_pkg_apis_build_v1alpha2_BuildStatus(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildpackMetadata"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildpackMetadata"),
 									},
 								},
 							},
@@ -3067,8 +2940,7 @@ func schema_pkg_apis_build_v1alpha2_BuildStatus(ref common.ReferenceCallback) co
 					},
 					"stack": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildStack"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildStack"),
 						},
 					},
 					"latestImage": {
@@ -3094,8 +2966,7 @@ func schema_pkg_apis_build_v1alpha2_BuildStatus(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/api/core/v1.ContainerState"),
+										Ref: ref("k8s.io/api/core/v1.ContainerState"),
 									},
 								},
 							},
@@ -3112,9 +2983,8 @@ func schema_pkg_apis_build_v1alpha2_BuildStatus(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -3150,20 +3020,17 @@ func schema_pkg_apis_build_v1alpha2_Builder(ref common.ReferenceCallback) common
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.NamespacedBuilderSpec"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.NamespacedBuilderSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuilderStatus"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuilderStatus"),
 						},
 					},
 				},
@@ -3197,8 +3064,7 @@ func schema_pkg_apis_build_v1alpha2_BuilderList(ref common.ReferenceCallback) co
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -3207,8 +3073,7 @@ func schema_pkg_apis_build_v1alpha2_BuilderList(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.Builder"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.Builder"),
 									},
 								},
 							},
@@ -3237,14 +3102,12 @@ func schema_pkg_apis_build_v1alpha2_BuilderSpec(ref common.ReferenceCallback) co
 					},
 					"stack": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
+							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"store": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
+							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"order": {
@@ -3258,8 +3121,7 @@ func schema_pkg_apis_build_v1alpha2_BuilderSpec(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.OrderEntry"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.OrderEntry"),
 									},
 								},
 							},
@@ -3299,8 +3161,7 @@ func schema_pkg_apis_build_v1alpha2_BuilderStatus(ref common.ReferenceCallback) 
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -3312,8 +3173,7 @@ func schema_pkg_apis_build_v1alpha2_BuilderStatus(ref common.ReferenceCallback) 
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildpackMetadata"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildpackMetadata"),
 									},
 								},
 							},
@@ -3325,8 +3185,7 @@ func schema_pkg_apis_build_v1alpha2_BuilderStatus(ref common.ReferenceCallback) 
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.OrderEntry"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.OrderEntry"),
 									},
 								},
 							},
@@ -3334,8 +3193,7 @@ func schema_pkg_apis_build_v1alpha2_BuilderStatus(ref common.ReferenceCallback) 
 					},
 					"stack": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildStack"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildStack"),
 						},
 					},
 					"latestImage": {
@@ -3378,9 +3236,8 @@ func schema_pkg_apis_build_v1alpha2_BuildpackInfo(ref common.ReferenceCallback) 
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"version": {
@@ -3404,16 +3261,14 @@ func schema_pkg_apis_build_v1alpha2_BuildpackMetadata(ref common.ReferenceCallba
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"homepage": {
@@ -3437,9 +3292,8 @@ func schema_pkg_apis_build_v1alpha2_BuildpackRef(ref common.ReferenceCallback) c
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"version": {
@@ -3469,9 +3323,8 @@ func schema_pkg_apis_build_v1alpha2_BuildpackStack(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"mixins": {
@@ -3485,9 +3338,8 @@ func schema_pkg_apis_build_v1alpha2_BuildpackStack(ref common.ReferenceCallback)
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -3552,20 +3404,17 @@ func schema_pkg_apis_build_v1alpha2_ClusterBuilder(ref common.ReferenceCallback)
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterBuilderSpec"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterBuilderSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuilderStatus"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuilderStatus"),
 						},
 					},
 				},
@@ -3599,8 +3448,7 @@ func schema_pkg_apis_build_v1alpha2_ClusterBuilderList(ref common.ReferenceCallb
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -3609,8 +3457,7 @@ func schema_pkg_apis_build_v1alpha2_ClusterBuilderList(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterBuilder"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterBuilder"),
 									},
 								},
 							},
@@ -3639,14 +3486,12 @@ func schema_pkg_apis_build_v1alpha2_ClusterBuilderSpec(ref common.ReferenceCallb
 					},
 					"stack": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
+							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"store": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
+							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"order": {
@@ -3660,8 +3505,7 @@ func schema_pkg_apis_build_v1alpha2_ClusterBuilderSpec(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.OrderEntry"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.OrderEntry"),
 									},
 								},
 							},
@@ -3669,8 +3513,7 @@ func schema_pkg_apis_build_v1alpha2_ClusterBuilderSpec(ref common.ReferenceCallb
 					},
 					"serviceAccountRef": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
+							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 				},
@@ -3703,20 +3546,17 @@ func schema_pkg_apis_build_v1alpha2_ClusterStack(ref common.ReferenceCallback) c
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStackSpec"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStackSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStackStatus"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStackStatus"),
 						},
 					},
 				},
@@ -3750,8 +3590,7 @@ func schema_pkg_apis_build_v1alpha2_ClusterStackList(ref common.ReferenceCallbac
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -3760,8 +3599,7 @@ func schema_pkg_apis_build_v1alpha2_ClusterStackList(ref common.ReferenceCallbac
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStack"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStack"),
 									},
 								},
 							},
@@ -3790,14 +3628,12 @@ func schema_pkg_apis_build_v1alpha2_ClusterStackSpec(ref common.ReferenceCallbac
 					},
 					"buildImage": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStackSpecImage"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStackSpecImage"),
 						},
 					},
 					"runImage": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStackSpecImage"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStackSpecImage"),
 						},
 					},
 				},
@@ -3852,8 +3688,7 @@ func schema_pkg_apis_build_v1alpha2_ClusterStackStatus(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -3867,14 +3702,12 @@ func schema_pkg_apis_build_v1alpha2_ClusterStackStatus(ref common.ReferenceCallb
 					},
 					"buildImage": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStackStatusImage"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStackStatusImage"),
 						},
 					},
 					"runImage": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStackStatusImage"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStackStatusImage"),
 						},
 					},
 					"mixins": {
@@ -3888,9 +3721,8 @@ func schema_pkg_apis_build_v1alpha2_ClusterStackStatus(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -3962,20 +3794,17 @@ func schema_pkg_apis_build_v1alpha2_ClusterStore(ref common.ReferenceCallback) c
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStoreSpec"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStoreSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStoreStatus"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStoreStatus"),
 						},
 					},
 				},
@@ -4009,8 +3838,7 @@ func schema_pkg_apis_build_v1alpha2_ClusterStoreList(ref common.ReferenceCallbac
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -4019,8 +3847,7 @@ func schema_pkg_apis_build_v1alpha2_ClusterStoreList(ref common.ReferenceCallbac
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStore"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStore"),
 									},
 								},
 							},
@@ -4052,8 +3879,7 @@ func schema_pkg_apis_build_v1alpha2_ClusterStoreSpec(ref common.ReferenceCallbac
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.StoreImage"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.StoreImage"),
 									},
 								},
 							},
@@ -4093,8 +3919,7 @@ func schema_pkg_apis_build_v1alpha2_ClusterStoreStatus(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -4111,8 +3936,7 @@ func schema_pkg_apis_build_v1alpha2_ClusterStoreStatus(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.StoreBuildpack"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.StoreBuildpack"),
 									},
 								},
 							},
@@ -4134,16 +3958,14 @@ func schema_pkg_apis_build_v1alpha2_Git(ref common.ReferenceCallback) common.Ope
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"revision": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 				},
@@ -4175,20 +3997,17 @@ func schema_pkg_apis_build_v1alpha2_Image(ref common.ReferenceCallback) common.O
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ImageSpec"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ImageSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ImageStatus"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ImageStatus"),
 						},
 					},
 				},
@@ -4217,8 +4036,7 @@ func schema_pkg_apis_build_v1alpha2_ImageBuild(ref common.ReferenceCallback) com
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.Binding"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.Binding"),
 									},
 								},
 							},
@@ -4235,8 +4053,7 @@ func schema_pkg_apis_build_v1alpha2_ImageBuild(ref common.ReferenceCallback) com
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/api/core/v1.EnvVar"),
+										Ref: ref("k8s.io/api/core/v1.EnvVar"),
 									},
 								},
 							},
@@ -4244,8 +4061,7 @@ func schema_pkg_apis_build_v1alpha2_ImageBuild(ref common.ReferenceCallback) com
 					},
 					"resources": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ResourceRequirements"),
+							Ref: ref("k8s.io/api/core/v1.ResourceRequirements"),
 						},
 					},
 				},
@@ -4278,9 +4094,8 @@ func schema_pkg_apis_build_v1alpha2_ImageBuilder(ref common.ReferenceCallback) c
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 				},
@@ -4312,8 +4127,7 @@ func schema_pkg_apis_build_v1alpha2_ImageList(ref common.ReferenceCallback) comm
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -4322,8 +4136,7 @@ func schema_pkg_apis_build_v1alpha2_ImageList(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.Image"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.Image"),
 									},
 								},
 							},
@@ -4346,15 +4159,13 @@ func schema_pkg_apis_build_v1alpha2_ImageSpec(ref common.ReferenceCallback) comm
 				Properties: map[string]spec.Schema{
 					"tag": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"builder": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
+							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"serviceAccount": {
@@ -4365,8 +4176,7 @@ func schema_pkg_apis_build_v1alpha2_ImageSpec(ref common.ReferenceCallback) comm
 					},
 					"source": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.SourceConfig"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.SourceConfig"),
 						},
 					},
 					"cacheSize": {
@@ -4437,8 +4247,7 @@ func schema_pkg_apis_build_v1alpha2_ImageStatus(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -4532,14 +4341,12 @@ func schema_pkg_apis_build_v1alpha2_NamespacedBuilderSpec(ref common.ReferenceCa
 					},
 					"stack": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
+							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"store": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
+							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"order": {
@@ -4553,8 +4360,7 @@ func schema_pkg_apis_build_v1alpha2_NamespacedBuilderSpec(ref common.ReferenceCa
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.OrderEntry"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.OrderEntry"),
 									},
 								},
 							},
@@ -4601,9 +4407,8 @@ func schema_pkg_apis_build_v1alpha2_NotarySecretRef(ref common.ReferenceCallback
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 				},
@@ -4621,15 +4426,13 @@ func schema_pkg_apis_build_v1alpha2_NotaryV1Config(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"secretRef": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.NotarySecretRef"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.NotarySecretRef"),
 						},
 					},
 				},
@@ -4658,8 +4461,7 @@ func schema_pkg_apis_build_v1alpha2_OrderEntry(ref common.ReferenceCallback) com
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildpackRef"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildpackRef"),
 									},
 								},
 							},
@@ -4681,9 +4483,8 @@ func schema_pkg_apis_build_v1alpha2_Registry(ref common.ReferenceCallback) commo
 				Properties: map[string]spec.Schema{
 					"image": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"imagePullSecrets": {
@@ -4699,8 +4500,7 @@ func schema_pkg_apis_build_v1alpha2_Registry(ref common.ReferenceCallback) commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/api/core/v1.LocalObjectReference"),
+										Ref: ref("k8s.io/api/core/v1.LocalObjectReference"),
 									},
 								},
 							},
@@ -4723,9 +4523,8 @@ func schema_pkg_apis_build_v1alpha2_ResolvedBlobSource(ref common.ReferenceCallb
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"subPath": {
@@ -4755,14 +4554,12 @@ func schema_pkg_apis_build_v1alpha2_ResolvedClusterStack(ref common.ReferenceCal
 					},
 					"buildImage": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStackStatusImage"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStackStatusImage"),
 						},
 					},
 					"runImage": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStackStatusImage"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ClusterStackStatusImage"),
 						},
 					},
 					"mixins": {
@@ -4776,9 +4573,8 @@ func schema_pkg_apis_build_v1alpha2_ResolvedClusterStack(ref common.ReferenceCal
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -4812,16 +4608,14 @@ func schema_pkg_apis_build_v1alpha2_ResolvedGitSource(ref common.ReferenceCallba
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"revision": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"subPath": {
@@ -4832,9 +4626,8 @@ func schema_pkg_apis_build_v1alpha2_ResolvedGitSource(ref common.ReferenceCallba
 					},
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 				},
@@ -4852,9 +4645,8 @@ func schema_pkg_apis_build_v1alpha2_ResolvedRegistrySource(ref common.ReferenceC
 				Properties: map[string]spec.Schema{
 					"image": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"subPath": {
@@ -4876,8 +4668,7 @@ func schema_pkg_apis_build_v1alpha2_ResolvedRegistrySource(ref common.ReferenceC
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/api/core/v1.LocalObjectReference"),
+										Ref: ref("k8s.io/api/core/v1.LocalObjectReference"),
 									},
 								},
 							},
@@ -4978,20 +4769,17 @@ func schema_pkg_apis_build_v1alpha2_SourceResolver(ref common.ReferenceCallback)
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.SourceResolverSpec"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.SourceResolverSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.SourceResolverStatus"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.SourceResolverStatus"),
 						},
 					},
 				},
@@ -5025,8 +4813,7 @@ func schema_pkg_apis_build_v1alpha2_SourceResolverList(ref common.ReferenceCallb
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -5035,8 +4822,7 @@ func schema_pkg_apis_build_v1alpha2_SourceResolverList(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.SourceResolver"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.SourceResolver"),
 									},
 								},
 							},
@@ -5065,8 +4851,7 @@ func schema_pkg_apis_build_v1alpha2_SourceResolverSpec(ref common.ReferenceCallb
 					},
 					"source": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.SourceConfig"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.SourceConfig"),
 						},
 					},
 				},
@@ -5104,8 +4889,7 @@ func schema_pkg_apis_build_v1alpha2_SourceResolverStatus(ref common.ReferenceCal
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -5113,8 +4897,7 @@ func schema_pkg_apis_build_v1alpha2_SourceResolverStatus(ref common.ReferenceCal
 					},
 					"source": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ResolvedSourceConfig"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.ResolvedSourceConfig"),
 						},
 					},
 				},
@@ -5133,9 +4916,8 @@ func schema_pkg_apis_build_v1alpha2_StoreBuildpack(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"version": {
@@ -5146,14 +4928,12 @@ func schema_pkg_apis_build_v1alpha2_StoreBuildpack(ref common.ReferenceCallback)
 					},
 					"buildpackage": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildpackageInfo"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildpackageInfo"),
 						},
 					},
 					"storeImage": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.StoreImage"),
+							Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.StoreImage"),
 						},
 					},
 					"diffId": {
@@ -5197,8 +4977,7 @@ func schema_pkg_apis_build_v1alpha2_StoreBuildpack(ref common.ReferenceCallback)
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.OrderEntry"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.OrderEntry"),
 									},
 								},
 							},
@@ -5215,8 +4994,7 @@ func schema_pkg_apis_build_v1alpha2_StoreBuildpack(ref common.ReferenceCallback)
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildpackStack"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/build/v1alpha2.BuildpackStack"),
 									},
 								},
 							},
@@ -5259,7 +5037,6 @@ func schema_pkg_apis_core_v1alpha1_Condition(ref common.ReferenceCallback) commo
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Type of condition.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5267,7 +5044,6 @@ func schema_pkg_apis_core_v1alpha1_Condition(ref common.ReferenceCallback) commo
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status of the condition, one of True, False, Unknown.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5282,7 +5058,6 @@ func schema_pkg_apis_core_v1alpha1_Condition(ref common.ReferenceCallback) commo
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).",
-							Default:     map[string]interface{}{},
 							Type:        []string{"string"}, Format: "",
 						},
 					},
@@ -5336,8 +5111,7 @@ func schema_pkg_apis_core_v1alpha1_Status(ref common.ReferenceCallback) common.O
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
+										Ref: ref("github.com/pivotal/kpack/pkg/apis/core/v1alpha1.Condition"),
 									},
 								},
 							},
@@ -5360,8 +5134,7 @@ func schema_pkg_apis_core_v1alpha1_VolatileTime(ref common.ReferenceCallback) co
 				Properties: map[string]spec.Schema{
 					"inner": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 				},


### PR DESCRIPTION
 - This makes the openapi definition consistent across v1alpha1 and v1alpha2
 - Fix pipeline check that verifies ./hack/openapi-codegen.sh is consistent with committed definition