### PR TITLE
Only Filter Controller by Group/Version

### DIFF
--- a/pkg/reconciler/build/build.go
+++ b/pkg/reconciler/build/build.go
@@ -53,7 +53,7 @@ func NewController(opt reconciler.Options, k8sClient k8sclient.Interface, inform
 	informer.Informer().AddEventHandler(reconciler.Handler(impl.Enqueue))
 
 	podInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterControllerGVK(buildapi.SchemeGroupVersion.WithKind(Kind)),
+		FilterFunc: controller.FilterControllerGK(buildapi.SchemeGroupVersion.WithKind(Kind).GroupKind()),
 		Handler:    reconciler.Handler(impl.EnqueueControllerOf),
 	})
 

--- a/pkg/reconciler/image/image.go
+++ b/pkg/reconciler/image/image.go
@@ -55,17 +55,17 @@ func NewController(
 	imageInformer.Informer().AddEventHandler(reconciler.Handler(impl.Enqueue))
 
 	buildInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterControllerGVK(buildapi.SchemeGroupVersion.WithKind(Kind)),
+		FilterFunc: controller.FilterControllerGK(buildapi.SchemeGroupVersion.WithKind(Kind).GroupKind()),
 		Handler:    reconciler.Handler(impl.EnqueueControllerOf),
 	})
 
 	sourceResolverInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterControllerGVK(buildapi.SchemeGroupVersion.WithKind(Kind)),
+		FilterFunc: controller.FilterControllerGK(buildapi.SchemeGroupVersion.WithKind(Kind).GroupKind()),
 		Handler:    reconciler.Handler(impl.EnqueueControllerOf),
 	})
 
 	pvcInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterControllerGVK(buildapi.SchemeGroupVersion.WithKind(Kind)),
+		FilterFunc: controller.FilterControllerGK(buildapi.SchemeGroupVersion.WithKind(Kind).GroupKind()),
 		Handler:    reconciler.Handler(impl.EnqueueControllerOf),
 	})
 


### PR DESCRIPTION
This prevents an issue where "owned" resources created with an earlier kpack api version were not triggering reconciles of their owning resource.

An example of this was with the Image resource which relies on re-reconciling when a source resolver is updated. However, if the source resolver was created before a kpack controller update it would not rereconcile the image on updates.