### PR TITLE
Provide serviceAccountRef name/namespace on lifecycle-image configmap

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -63,7 +63,6 @@ var (
 	rebaseImage            = flag.String("rebase-image", os.Getenv("REBASE_IMAGE"), "The image used to perform rebases")
 	completionImage        = flag.String("completion-image", os.Getenv("COMPLETION_IMAGE"), "The image used to finish a build")
 	completionWindowsImage = flag.String("completion-windows-image", os.Getenv("COMPLETION_WINDOWS_IMAGE"), "The image used to finish a build on windows")
-	lifecycleImage         = flag.String("lifecycle-image", os.Getenv("LIFECYCLE_IMAGE"), "The image used to provide lifecycle binaries")
 )
 
 func main() {
@@ -161,7 +160,7 @@ func main() {
 		log.Fatalf("could not create empty keychain %s", err)
 	}
 
-	lifecycleProvider := config.NewLifecycleProvider(*lifecycleImage, &registry.Client{}, kpackKeychain)
+	lifecycleProvider := config.NewLifecycleProvider(&registry.Client{}, keychainFactory)
 	configMapWatcher.Watch(config.LifecycleConfigName, lifecycleProvider.UpdateImage)
 
 	builderCreator := &cnb.RemoteBuilderCreator{

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -107,11 +107,6 @@ spec:
             configMapKeyRef:
               name: completion-windows-image
               key: image
-        - name: LIFECYCLE_IMAGE
-          valueFrom:
-            configMapKeyRef:
-              name: lifecycle-image
-              key: image
         resources:
           requests:
             cpu: 20m


### PR DESCRIPTION
- This allows the lifecycle image to live in a registry which requires credentials.
- These credentials can be dynamically updated by updating the credentials directly in k8s api.
- The lifecycle image is no longer immediately read on controller start because the configmap is needed with the full service acocunt references.