### PR TITLE
fix webhook validation

### DIFF
--- a/pkg/apis/build/v1alpha2/build_validation.go
+++ b/pkg/apis/build/v1alpha2/build_validation.go
@@ -33,27 +33,9 @@ func (bs *BuildSpec) Validate(ctx context.Context) *apis.FieldError {
 		Also(bs.Services.Validate(ctx).ViaField("services")).
 		Also(bs.LastBuild.Validate(ctx).ViaField("lastBuild")).
 		Also(bs.validateImmutableFields(ctx)).
-		Also(bs.validateCnbBindings(ctx).ViaField("cnbBindings")).
+		Also(validateCnbBindings(ctx, bs.CNBBindings).ViaField("cnbBindings")).
 		Also(bs.validateNodeSelector(ctx)).
-		Also(bs.validateNotary(ctx).ViaField("notary"))
-}
-
-func (bs *BuildSpec) validateCnbBindings(ctx context.Context) *apis.FieldError {
-	//only allow the kpack controller to create resources with cnb bindings
-	if !resourceCreatedByKpackController(apis.GetUserInfo(ctx)) && len(bs.CNBBindings) > 0 {
-		return apis.ErrGeneric("use of this field has been deprecated and cannot be set", "")
-	}
-
-	return bs.CNBBindings.Validate(ctx)
-}
-
-func (bs *BuildSpec) validateNotary(ctx context.Context) *apis.FieldError {
-	//only allow the kpack controller to create resources with notary
-	if !resourceCreatedByKpackController(apis.GetUserInfo(ctx)) && bs.Notary != nil {
-		return apis.ErrGeneric("use of this field has been deprecated and cannot be set", "")
-	}
-
-	return bs.Notary.Validate(ctx)
+		Also(validateNotary(ctx, bs.Notary).ViaField("notary"))
 }
 
 func resourceCreatedByKpackController(info *authv1.UserInfo) bool {

--- a/pkg/apis/build/v1alpha2/build_validation_test.go
+++ b/pkg/apis/build/v1alpha2/build_validation_test.go
@@ -204,7 +204,7 @@ func testBuildValidation(t *testing.T, when spec.G, it spec.S) {
 				{MetadataRef: &corev1.LocalObjectReference{Name: "metadata"}},
 			}
 
-			assertValidationError(build, context.TODO(), apis.ErrGeneric("use of this field has been deprecated and cannot be set", "spec.cnbBindings"))
+			assertValidationError(build, context.TODO(), apis.ErrGeneric("use of this field has been deprecated in v1alpha2, please use v1alpha1 for CNB bindings", "spec.cnbBindings"))
 
 		})
 
@@ -284,7 +284,7 @@ func testBuildValidation(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			}
-			assertValidationError(build, context.TODO(), apis.ErrGeneric("use of this field has been deprecated and cannot be set", "spec.notary"))
+			assertValidationError(build, context.TODO(), apis.ErrGeneric("use of this field has been deprecated in v1alpha2, please use v1alpha1 for notary image signing", "spec.notary"))
 
 		})
 


### PR DESCRIPTION
allow cnb bindings and notary to be added to v1alpha2 images if they are created by the kpack controller