### PR TITLE
use v1alpha1 in image waiter

### DIFF
--- a/pkg/logs/watch_build.go
+++ b/pkg/logs/watch_build.go
@@ -21,11 +21,11 @@ type watchOneBuild struct {
 func (l *watchOneBuild) Watch(options v1.ListOptions) (watch.Interface, error) {
 	options.FieldSelector = fmt.Sprintf("metadata.name=%s", l.buildName)
 
-	return l.kpackClient.KpackV1alpha2().Builds(l.namespace).Watch(l.context, options)
+	return l.kpackClient.KpackV1alpha1().Builds(l.namespace).Watch(l.context, options)
 }
 
 func (l *watchOneBuild) List(options v1.ListOptions) (runtime.Object, error) {
 	options.FieldSelector = fmt.Sprintf("metadata.name=%s", l.buildName)
 
-	return l.kpackClient.KpackV1alpha2().Builds(l.namespace).List(l.context, options)
+	return l.kpackClient.KpackV1alpha1().Builds(l.namespace).List(l.context, options)
 }

--- a/pkg/logs/watch_image.go
+++ b/pkg/logs/watch_image.go
@@ -7,13 +7,13 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 
-	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pivotal/kpack/pkg/client/clientset/versioned"
 )
 
 type watchOneImage struct {
 	kpackClient versioned.Interface
-	image       *buildapi.Image
+	image       *v1alpha1.Image
 	ctx         context.Context
 }
 


### PR DESCRIPTION
this is needed to for [kp](https://github.com/vmware-tanzu/kpack-cli) and other consumers of the logs package to maintain backwards compatibility with earlier versions of kpack. This can be bumped to the next lowest supported version once v1alpha1 is no longer supported.