### PR TITLE
Fix compilation error in ./test/

### DIFF
--- a/test/execute_build_test.go
+++ b/test/execute_build_test.go
@@ -215,7 +215,7 @@ func testCreateImage(t *testing.T, when spec.G, it spec.S) {
 						},
 					},
 				},
-				ServiceAccount: serviceAccountName,
+				ServiceAccountName: serviceAccountName,
 			},
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)


### PR DESCRIPTION
We noticed that `go test ./test/` failed with a compilation error:

```                                                                                                                                                      
# github.com/pivotal/kpack/test [github.com/pivotal/kpack/test.test]                                                                                                                           
test/execute_build_test.go:218:5: unknown field 'ServiceAccount' in struct literal of type "github.com/pivotal/kpack/pkg/apis/build/v1alpha2".NamespacedBuilderSpec                            
```

**Note:**
Maybe you should consider at least compiling the e2e tests in the CI.
This can be done with:

```bash
go test -c -o /tmp/test-bin ./test/
```