### PR TITLE
Support registry cache in a private registry 

### DIFF
--- a/pkg/apis/build/v1alpha2/build_pod.go
+++ b/pkg/apis/build/v1alpha2/build_pod.go
@@ -384,6 +384,7 @@ func (b *Build) BuildPod(images BuildPodImages, buildContext BuildContext) (*cor
 							homeVolume,
 						}, cacheVolumes),
 						Env: []corev1.EnvVar{
+							homeEnv,
 							{
 								Name:  platformAPIEnvVar,
 								Value: platformAPI.Original(),
@@ -391,7 +392,11 @@ func (b *Build) BuildPod(images BuildPodImages, buildContext BuildContext) (*cor
 						},
 						ImagePullPolicy: corev1.PullIfNotPresent,
 					},
-					ifWindows(buildContext.os(), addNetworkWaitLauncherVolume(), useNetworkWaitLauncher(dnsProbeHost))...,
+					ifWindows(buildContext.os(),
+						addNetworkWaitLauncherVolume(),
+						useNetworkWaitLauncher(dnsProbeHost),
+						userprofileHomeEnv(),
+					)...,
 				)
 				step(
 					corev1.Container{

--- a/pkg/apis/build/v1alpha2/build_pod_test.go
+++ b/pkg/apis/build/v1alpha2/build_pod_test.go
@@ -742,6 +742,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 
 			assert.Equal(t, pod.Spec.InitContainers[3].Name, "restore")
 			assert.Contains(t, pod.Spec.InitContainers[3].Env, corev1.EnvVar{Name: "CNB_PLATFORM_API", Value: "0.6"})
+			assert.Contains(t, pod.Spec.InitContainers[3].Env, corev1.EnvVar{Name: "HOME", Value: "/builder/home"})
 			assert.Equal(t, pod.Spec.InitContainers[3].Image, builderImage)
 			assert.Equal(t, []string{
 				"layers-dir",
@@ -2017,6 +2018,12 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 					{
 						Name:      "network-wait-launcher-dir",
 						MountPath: "/networkWait",
+					},
+				})
+				assert.Subset(t, restoreContainer.Env, []corev1.EnvVar{
+					{
+						Name:  "USERPROFILE",
+						Value: "/builder/home",
 					},
 				})
 				assert.Equal(t, []string{"/networkWait/network-wait-launcher"}, restoreContainer.Command)


### PR DESCRIPTION
Without HOME the restore step can not correctly load the docker credentials.
This prevents layers from properly being restored from a cache image in a private registry.

Without this change 
```
Restoring metadata for "paketo-buildpacks/ca-certificates:helper" from app image
Restoring metadata for "paketo-buildpacks/bellsoft-liberica:helper" from app image
Restoring metadata for "paketo-buildpacks/bellsoft-liberica:java-security-properties" from app image
Restoring metadata for "paketo-buildpacks/bellsoft-liberica:jre" from app image
Restoring metadata for "paketo-buildpacks/bellsoft-liberica:jdk" from cache
Restoring metadata for "paketo-buildpacks/maven:application" from cache
Restoring metadata for "paketo-buildpacks/maven:cache" from cache
Restoring metadata for "paketo-buildpacks/spring-boot:helper" from app image
Restoring metadata for "paketo-buildpacks/spring-boot:spring-cloud-bindings" from app image
Restoring metadata for "paketo-buildpacks/spring-boot:web-application-type" from app image
Layer cache not found
```