### PR TITLE
Add resource conversions between v1alpha1 and v1alpha2

### DIFF
--- a/pkg/apis/build/v1alpha1/builder_types.go
+++ b/pkg/apis/build/v1alpha1/builder_types.go
@@ -73,10 +73,10 @@ func (c *Builder) NamespacedName() types.NamespacedName {
 	return types.NamespacedName{Namespace: c.Namespace, Name: c.Name}
 }
 
-func (i *Builder) ConvertTo(_ context.Context, _ apis.Convertible) error {
+func (c *Builder) ConvertTo(_ context.Context, _ apis.Convertible) error {
 	return errors.New("called convertTo in non-hub apiVersion v1alpha1")
 }
 
-func (i *Builder) ConvertFrom(_ context.Context, _ apis.Convertible) error {
+func (c *Builder) ConvertFrom(_ context.Context, _ apis.Convertible) error {
 	return errors.New("called convertFrom in non-hub apiVersion v1alpha1")
 }

--- a/pkg/apis/build/v1alpha1/builder_types.go
+++ b/pkg/apis/build/v1alpha1/builder_types.go
@@ -69,14 +69,14 @@ func (*Builder) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind(BuilderKind)
 }
 
-func (c *Builder) NamespacedName() types.NamespacedName {
-	return types.NamespacedName{Namespace: c.Namespace, Name: c.Name}
+func (b *Builder) NamespacedName() types.NamespacedName {
+	return types.NamespacedName{Namespace: b.Namespace, Name: b.Name}
 }
 
-func (c *Builder) ConvertTo(_ context.Context, _ apis.Convertible) error {
+func (*Builder) ConvertTo(_ context.Context, _ apis.Convertible) error {
 	return errors.New("called convertTo in non-hub apiVersion v1alpha1")
 }
 
-func (c *Builder) ConvertFrom(_ context.Context, _ apis.Convertible) error {
+func (*Builder) ConvertFrom(_ context.Context, _ apis.Convertible) error {
 	return errors.New("called convertFrom in non-hub apiVersion v1alpha1")
 }

--- a/pkg/apis/build/v1alpha1/cluster_builder_types.go
+++ b/pkg/apis/build/v1alpha1/cluster_builder_types.go
@@ -1,10 +1,14 @@
 package v1alpha1
 
 import (
+	"context"
+
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis"
 )
 
 const ClusterBuilderKind = "ClusterBuilder"
@@ -45,4 +49,12 @@ func (*ClusterBuilder) GetGroupVersionKind() schema.GroupVersionKind {
 
 func (c *ClusterBuilder) NamespacedName() types.NamespacedName {
 	return types.NamespacedName{Namespace: c.Namespace, Name: c.Name}
+}
+
+func (c *ClusterBuilder) ConvertTo(_ context.Context, _ apis.Convertible) error {
+	return errors.New("called convertTo in non-hub apiVersion v1alpha1")
+}
+
+func (c *ClusterBuilder) ConvertFrom(_ context.Context, _ apis.Convertible) error {
+	return errors.New("called convertFrom in non-hub apiVersion v1alpha1")
 }

--- a/pkg/apis/build/v1alpha1/cluster_stack_types.go
+++ b/pkg/apis/build/v1alpha1/cluster_stack_types.go
@@ -1,8 +1,12 @@
 package v1alpha1
 
 import (
+	"context"
+
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/pkg/apis"
 
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 )
@@ -70,4 +74,12 @@ type ClusterStackList struct {
 
 func (*ClusterStack) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind(ClusterStackKind)
+}
+
+func (s *ClusterStack) ConvertTo(_ context.Context, _ apis.Convertible) error {
+	return errors.New("called convertTo in non-hub apiVersion v1alpha1")
+}
+
+func (s *ClusterStack) ConvertFrom(_ context.Context, _ apis.Convertible) error {
+	return errors.New("called convertFrom in non-hub apiVersion v1alpha1")
 }

--- a/pkg/apis/build/v1alpha1/cluster_store_types.go
+++ b/pkg/apis/build/v1alpha1/cluster_store_types.go
@@ -1,8 +1,12 @@
 package v1alpha1
 
 import (
+	"context"
+
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/pkg/apis"
 
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 )
@@ -49,4 +53,12 @@ type ClusterStoreList struct {
 
 func (*ClusterStore) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind(ClusterStoreKind)
+}
+
+func (s *ClusterStore) ConvertTo(_ context.Context, _ apis.Convertible) error {
+	return errors.New("called convertTo in non-hub apiVersion v1alpha1")
+}
+
+func (s *ClusterStore) ConvertFrom(_ context.Context, _ apis.Convertible) error {
+	return errors.New("called convertFrom in non-hub apiVersion v1alpha1")
 }

--- a/pkg/apis/build/v1alpha2/builder_conversion.go
+++ b/pkg/apis/build/v1alpha2/builder_conversion.go
@@ -40,7 +40,7 @@ func (bs *NamespacedBuilderSpec) convertTo(to *v1alpha1.NamespacedBuilderSpec) {
 	to.Stack = bs.Stack
 	to.Store = bs.Store
 	to.Order = bs.Order
-	to.ServiceAccount = bs.ServiceAccountName
+	to.ServiceAccount = bs.ServiceAccount()
 }
 
 func (bs *NamespacedBuilderSpec) convertFrom(from *v1alpha1.NamespacedBuilderSpec) {

--- a/pkg/apis/build/v1alpha2/builder_conversion.go
+++ b/pkg/apis/build/v1alpha2/builder_conversion.go
@@ -52,6 +52,7 @@ func (bs *NamespacedBuilderSpec) convertFrom(from *v1alpha1.NamespacedBuilderSpe
 }
 
 func (bst *BuilderStatus) convertFrom(from *v1alpha1.BuilderStatus) {
+	bst.Status = from.Status
 	bst.BuilderMetadata = from.BuilderMetadata
 	bst.Order = from.Order
 	bst.Stack = from.Stack
@@ -62,6 +63,7 @@ func (bst *BuilderStatus) convertFrom(from *v1alpha1.BuilderStatus) {
 }
 
 func (bst *BuilderStatus) convertTo(to *v1alpha1.BuilderStatus) {
+	to.Status = bst.Status
 	to.BuilderMetadata = bst.BuilderMetadata
 	to.Order = bst.Order
 	to.Stack = bst.Stack

--- a/pkg/apis/build/v1alpha2/builder_conversion.go
+++ b/pkg/apis/build/v1alpha2/builder_conversion.go
@@ -9,24 +9,25 @@ import (
 	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
-func (i *Builder) ConvertTo(_ context.Context, to apis.Convertible) error {
+func (b *Builder) ConvertTo(_ context.Context, to apis.Convertible) error {
 	switch toBuilder := to.(type) {
 	case *v1alpha1.Builder:
-		toBuilder.ObjectMeta = i.ObjectMeta
-		i.Spec.convertTo(&toBuilder.Spec)
-		i.Status.convertTo(&toBuilder.Status)
+		toBuilder.ObjectMeta = b.ObjectMeta
+
+		b.Spec.convertTo(&toBuilder.Spec)
+		b.Status.convertTo(&toBuilder.Status)
 	default:
 		return fmt.Errorf("unknown version, got: %T", toBuilder)
 	}
 	return nil
 }
 
-func (i *Builder) ConvertFrom(_ context.Context, from apis.Convertible) error {
+func (b *Builder) ConvertFrom(_ context.Context, from apis.Convertible) error {
 	switch fromBuilder := from.(type) {
 	case *v1alpha1.Builder:
-		i.ObjectMeta = fromBuilder.ObjectMeta
-		i.Spec.convertFrom(&fromBuilder.Spec)
-		i.Status.convertFrom(&fromBuilder.Status)
+		b.ObjectMeta = fromBuilder.ObjectMeta
+		b.Spec.convertFrom(&fromBuilder.Spec)
+		b.Status.convertFrom(&fromBuilder.Status)
 	default:
 		return fmt.Errorf("unknown version, got: %T", fromBuilder)
 	}
@@ -34,40 +35,38 @@ func (i *Builder) ConvertFrom(_ context.Context, from apis.Convertible) error {
 	return nil
 }
 
-func (is *NamespacedBuilderSpec) convertTo(to *v1alpha1.NamespacedBuilderSpec) {
-	to.Tag = is.Tag
-	to.Stack = is.Stack
-	to.Store = is.Store
-	to.Order = is.Order
-	to.ServiceAccount = is.ServiceAccount()
+func (bs *NamespacedBuilderSpec) convertTo(to *v1alpha1.NamespacedBuilderSpec) {
+	to.Tag = bs.Tag
+	to.Stack = bs.Stack
+	to.Store = bs.Store
+	to.Order = bs.Order
+	to.ServiceAccount = bs.ServiceAccountName
 }
 
-func (is *NamespacedBuilderSpec) convertFrom(from *v1alpha1.NamespacedBuilderSpec) {
-	is.Tag = from.Tag
-	is.Stack = from.Stack
-	is.Store = from.Store
-	is.Order = from.Order
-	is.ServiceAccountName = from.ServiceAccount
+func (bs *NamespacedBuilderSpec) convertFrom(from *v1alpha1.NamespacedBuilderSpec) {
+	bs.Tag = from.Tag
+	bs.Stack = from.Stack
+	bs.Store = from.Store
+	bs.Order = from.Order
+	bs.ServiceAccountName = from.ServiceAccount
 }
 
-func (is *BuilderStatus) convertFrom(from *v1alpha1.BuilderStatus) {
-	is.Status = from.Status
-	is.BuilderMetadata = from.BuilderMetadata
-	is.Order = from.Order
-	is.Stack = from.Stack
-	is.LatestImage = from.LatestImage
-	is.ObservedStackGeneration = from.ObservedStackGeneration
-	is.ObservedStoreGeneration = from.ObservedStoreGeneration
-	is.OS = from.OS
+func (bst *BuilderStatus) convertFrom(from *v1alpha1.BuilderStatus) {
+	bst.BuilderMetadata = from.BuilderMetadata
+	bst.Order = from.Order
+	bst.Stack = from.Stack
+	bst.LatestImage = from.LatestImage
+	bst.ObservedStackGeneration = from.ObservedStackGeneration
+	bst.ObservedStoreGeneration = from.ObservedStoreGeneration
+	bst.OS = from.OS
 }
 
-func (is *BuilderStatus) convertTo(to *v1alpha1.BuilderStatus) {
-	to.Status = is.Status
-	to.BuilderMetadata = is.BuilderMetadata
-	to.Order = is.Order
-	to.Stack = is.Stack
-	to.LatestImage = is.LatestImage
-	to.ObservedStackGeneration = is.ObservedStackGeneration
-	to.ObservedStoreGeneration = is.ObservedStoreGeneration
-	to.OS = is.OS
+func (bst *BuilderStatus) convertTo(to *v1alpha1.BuilderStatus) {
+	to.BuilderMetadata = bst.BuilderMetadata
+	to.Order = bst.Order
+	to.Stack = bst.Stack
+	to.LatestImage = bst.LatestImage
+	to.ObservedStackGeneration = bst.ObservedStackGeneration
+	to.ObservedStoreGeneration = bst.ObservedStoreGeneration
+	to.OS = bst.OS
 }

--- a/pkg/apis/build/v1alpha2/builder_conversion_test.go
+++ b/pkg/apis/build/v1alpha2/builder_conversion_test.go
@@ -1,0 +1,98 @@
+package v1alpha2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
+)
+
+func TestBuilderConversion(t *testing.T) {
+	spec.Run(t, "testBuilderConversion", testBuilderConversion)
+}
+
+func testBuilderConversion(t *testing.T, when spec.G, it spec.S) {
+	when("converting to and from v1alpha1", func() {
+		v1alpha2Builder := &Builder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-builder",
+				Namespace:   "some-namespace",
+				Annotations: map[string]string{"some-key": "some-value"},
+			},
+			Spec: NamespacedBuilderSpec{
+				BuilderSpec: BuilderSpec{
+					Tag: "some-tag",
+					Stack: corev1.ObjectReference{
+						Kind: "ClusterStack",
+						Name: "some-stack",
+					},
+					Store: corev1.ObjectReference{
+						Kind: "ClusterStore",
+						Name: "some-store",
+					},
+					Order: []corev1alpha1.OrderEntry{corev1alpha1.OrderEntry{
+						Group: []corev1alpha1.BuildpackRef{{
+							BuildpackInfo: corev1alpha1.BuildpackInfo{
+								Id: "org.some-buildpack",
+							},
+						}},
+					}},
+				},
+				ServiceAccountName: "some-service-account",
+			},
+			Status: BuilderStatus{
+				Stack: corev1alpha1.BuildStack{},
+			},
+		}
+		v1alpha1Builder := &v1alpha1.Builder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-builder",
+				Namespace:   "some-namespace",
+				Annotations: map[string]string{"some-key": "some-value"},
+			},
+			Spec: v1alpha1.NamespacedBuilderSpec{
+				BuilderSpec: v1alpha1.BuilderSpec{
+					Tag: "some-tag",
+					Stack: corev1.ObjectReference{
+						Kind: "ClusterStack",
+						Name: "some-stack",
+					},
+					Store: corev1.ObjectReference{
+						Kind: "ClusterStore",
+						Name: "some-store",
+					},
+					Order: []corev1alpha1.OrderEntry{corev1alpha1.OrderEntry{
+						Group: []corev1alpha1.BuildpackRef{{
+							BuildpackInfo: corev1alpha1.BuildpackInfo{
+								Id: "org.some-buildpack",
+							},
+						}},
+					}},
+				},
+				ServiceAccount: "some-service-account",
+			},
+			Status: v1alpha1.BuilderStatus{
+				Stack: corev1alpha1.BuildStack{},
+			},
+		}
+
+		it("successfully converts between api versions", func() {
+
+			testV1alpha1Builder := &v1alpha1.Builder{}
+			err := v1alpha2Builder.ConvertTo(context.TODO(), testV1alpha1Builder)
+			require.NoError(t, err)
+			require.Equal(t, v1alpha1Builder, testV1alpha1Builder)
+
+			testV1alpha2Builder := &Builder{}
+			err = testV1alpha2Builder.ConvertFrom(context.TODO(), v1alpha1Builder)
+			require.NoError(t, err)
+			require.Equal(t, testV1alpha2Builder, v1alpha2Builder)
+		})
+	})
+}

--- a/pkg/apis/build/v1alpha2/builder_conversion_test.go
+++ b/pkg/apis/build/v1alpha2/builder_conversion_test.go
@@ -47,7 +47,17 @@ func testBuilderConversion(t *testing.T, when spec.G, it spec.S) {
 				ServiceAccountName: "some-service-account",
 			},
 			Status: BuilderStatus{
-				Stack: corev1alpha1.BuildStack{},
+				Status: corev1alpha1.Status{Conditions: corev1alpha1.Conditions{{Type: "some-type"}}},
+				BuilderMetadata: nil,
+				Order:           nil,
+				Stack: corev1alpha1.BuildStack{
+					RunImage: "",
+					ID:       "",
+				},
+				LatestImage:             "",
+				ObservedStackGeneration: 0,
+				ObservedStoreGeneration: 0,
+				OS:                      "",
 			},
 		}
 		v1alpha1Builder := &v1alpha1.Builder{
@@ -78,6 +88,7 @@ func testBuilderConversion(t *testing.T, when spec.G, it spec.S) {
 				ServiceAccount: "some-service-account",
 			},
 			Status: v1alpha1.BuilderStatus{
+				Status: corev1alpha1.Status{Conditions: corev1alpha1.Conditions{{Type: "some-type"}}},
 				Stack: corev1alpha1.BuildStack{},
 			},
 		}

--- a/pkg/apis/build/v1alpha2/cluster_builder_conversion.go
+++ b/pkg/apis/build/v1alpha2/cluster_builder_conversion.go
@@ -1,0 +1,52 @@
+package v1alpha2
+
+import (
+	"context"
+	"fmt"
+
+	"knative.dev/pkg/apis"
+
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+)
+
+func (b *ClusterBuilder) ConvertTo(_ context.Context, to apis.Convertible) error {
+	switch toClusterBuilder := to.(type) {
+	case *v1alpha1.ClusterBuilder:
+		toClusterBuilder.ObjectMeta = b.ObjectMeta
+
+		b.Spec.convertTo(&toClusterBuilder.Spec)
+		b.Status.convertTo(&toClusterBuilder.Status)
+	default:
+		return fmt.Errorf("unknown version, got: %T", toClusterBuilder)
+	}
+	return nil
+}
+
+func (b *ClusterBuilder) ConvertFrom(_ context.Context, from apis.Convertible) error {
+	switch fromClusterBuilder := from.(type) {
+	case *v1alpha1.ClusterBuilder:
+		b.ObjectMeta = fromClusterBuilder.ObjectMeta
+		b.Spec.convertFrom(&fromClusterBuilder.Spec)
+		b.Status.convertFrom(&fromClusterBuilder.Status)
+	default:
+		return fmt.Errorf("unknown version, got: %T", fromClusterBuilder)
+	}
+
+	return nil
+}
+
+func (cs *ClusterBuilderSpec) convertTo(to *v1alpha1.ClusterBuilderSpec) {
+	to.Tag = cs.Tag
+	to.Stack = cs.Stack
+	to.Store = cs.Store
+	to.Order = cs.Order
+	to.ServiceAccountRef = cs.ServiceAccountRef
+}
+
+func (cs *ClusterBuilderSpec) convertFrom(from *v1alpha1.ClusterBuilderSpec) {
+	cs.Tag = from.Tag
+	cs.Stack = from.Stack
+	cs.Store = from.Store
+	cs.Order = from.Order
+	cs.ServiceAccountRef = from.ServiceAccountRef
+}

--- a/pkg/apis/build/v1alpha2/cluster_builder_conversion_test.go
+++ b/pkg/apis/build/v1alpha2/cluster_builder_conversion_test.go
@@ -1,0 +1,105 @@
+package v1alpha2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
+)
+
+func TestClusterBuilderConversion(t *testing.T) {
+	spec.Run(t, "testClusterBuilderConversion", testClusterBuilderConversion)
+}
+
+func testClusterBuilderConversion(t *testing.T, when spec.G, it spec.S) {
+	when("converting to and from v1alpha1", func() {
+		v1alpha2ClusterBuilder := &ClusterBuilder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-builder",
+				Namespace:   "some-namespace",
+				Annotations: map[string]string{"some-key": "some-value"},
+			},
+			Spec: ClusterBuilderSpec{
+				BuilderSpec: BuilderSpec{
+					Tag: "some-tag",
+					Stack: corev1.ObjectReference{
+						Kind: "ClusterStack",
+						Name: "some-stack",
+					},
+					Store: corev1.ObjectReference{
+						Kind: "ClusterStore",
+						Name: "some-store",
+					},
+					Order: []corev1alpha1.OrderEntry{corev1alpha1.OrderEntry{
+						Group: []corev1alpha1.BuildpackRef{{
+							BuildpackInfo: corev1alpha1.BuildpackInfo{
+								Id: "org.some-buildpack",
+							},
+						}},
+					}},
+				},
+				ServiceAccountRef: corev1.ObjectReference{
+					Namespace: "some-namespace",
+					Name:      "some-service-account",
+				},
+			},
+			Status: BuilderStatus{
+				Stack: corev1alpha1.BuildStack{},
+			},
+		}
+
+		v1alpha1ClusterBuilder := &v1alpha1.ClusterBuilder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-builder",
+				Namespace:   "some-namespace",
+				Annotations: map[string]string{"some-key": "some-value"},
+			},
+			Spec: v1alpha1.ClusterBuilderSpec{
+				BuilderSpec: v1alpha1.BuilderSpec{
+					Tag: "some-tag",
+					Stack: corev1.ObjectReference{
+						Kind: "ClusterStack",
+						Name: "some-stack",
+					},
+					Store: corev1.ObjectReference{
+						Kind: "ClusterStore",
+						Name: "some-store",
+					},
+					Order: []corev1alpha1.OrderEntry{corev1alpha1.OrderEntry{
+						Group: []corev1alpha1.BuildpackRef{{
+							BuildpackInfo: corev1alpha1.BuildpackInfo{
+								Id: "org.some-buildpack",
+							},
+						}},
+					}},
+				},
+				ServiceAccountRef: corev1.ObjectReference{
+					Namespace: "some-namespace",
+					Name:      "some-service-account",
+				},
+			},
+			Status: v1alpha1.BuilderStatus{
+				Stack: corev1alpha1.BuildStack{},
+			},
+		}
+
+		it("successfully converts between api versions", func() {
+
+			testV1alpha1ClusterBuilder := &v1alpha1.ClusterBuilder{}
+			err := v1alpha2ClusterBuilder.ConvertTo(context.TODO(), testV1alpha1ClusterBuilder)
+			require.NoError(t, err)
+			require.Equal(t, v1alpha1ClusterBuilder, testV1alpha1ClusterBuilder)
+
+			testV1alpha2ClusterBuilder := &ClusterBuilder{}
+			err = testV1alpha2ClusterBuilder.ConvertFrom(context.TODO(), v1alpha1ClusterBuilder)
+			require.NoError(t, err)
+			require.Equal(t, testV1alpha2ClusterBuilder, v1alpha2ClusterBuilder)
+		})
+	})
+}

--- a/pkg/apis/build/v1alpha2/cluster_stack_conversion.go
+++ b/pkg/apis/build/v1alpha2/cluster_stack_conversion.go
@@ -1,0 +1,80 @@
+package v1alpha2
+
+import (
+	"context"
+	"fmt"
+
+	"knative.dev/pkg/apis"
+
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+)
+
+func (s *ClusterStack) ConvertTo(_ context.Context, to apis.Convertible) error {
+	switch toClusterStack := to.(type) {
+	case *v1alpha1.ClusterStack:
+		toClusterStack.ObjectMeta = s.ObjectMeta
+
+		s.Spec.convertTo(&toClusterStack.Spec)
+		s.Status.convertTo(&toClusterStack.Status)
+	default:
+		return fmt.Errorf("unknown version, got: %T", toClusterStack)
+	}
+	return nil
+}
+
+func (s *ClusterStack) ConvertFrom(_ context.Context, from apis.Convertible) error {
+	switch fromClusterStack := from.(type) {
+	case *v1alpha1.ClusterStack:
+		s.ObjectMeta = fromClusterStack.ObjectMeta
+		s.Spec.convertFrom(&fromClusterStack.Spec)
+		s.Status.convertFrom(&fromClusterStack.Status)
+	default:
+		return fmt.Errorf("unknown version, got: %T", fromClusterStack)
+	}
+
+	return nil
+}
+
+func (cs *ClusterStackSpec) convertTo(to *v1alpha1.ClusterStackSpec) {
+	to.Id = cs.Id
+	to.BuildImage.Image = cs.BuildImage.Image
+	to.RunImage.Image = cs.RunImage.Image
+}
+
+func (cs *ClusterStackSpec) convertFrom(from *v1alpha1.ClusterStackSpec) {
+	cs.Id = from.Id
+	cs.BuildImage.Image = from.BuildImage.Image
+	cs.RunImage.Image = from.RunImage.Image
+}
+
+func (ct *ClusterStackStatus) convertTo(to *v1alpha1.ClusterStackStatus) {
+	to.Status = ct.Status
+	to.Id = ct.Id
+	to.BuildImage = v1alpha1.ClusterStackStatusImage{
+		LatestImage: ct.BuildImage.LatestImage,
+		Image:       ct.BuildImage.Image,
+	}
+	to.RunImage = v1alpha1.ClusterStackStatusImage{
+		LatestImage: ct.RunImage.LatestImage,
+		Image:       ct.RunImage.Image,
+	}
+	to.Mixins = ct.Mixins
+	to.UserID = ct.UserID
+	to.GroupID = ct.GroupID
+}
+
+func (ct *ClusterStackStatus) convertFrom(from *v1alpha1.ClusterStackStatus) {
+	ct.Status = from.Status
+	ct.Id = from.Id
+	ct.BuildImage = ClusterStackStatusImage{
+		LatestImage: from.BuildImage.LatestImage,
+		Image:       from.BuildImage.Image,
+	}
+	ct.RunImage = ClusterStackStatusImage{
+		LatestImage: from.RunImage.LatestImage,
+		Image:       from.RunImage.Image,
+	}
+	ct.Mixins = from.Mixins
+	ct.UserID = from.UserID
+	ct.GroupID = from.GroupID
+}

--- a/pkg/apis/build/v1alpha2/cluster_stack_conversion_test.go
+++ b/pkg/apis/build/v1alpha2/cluster_stack_conversion_test.go
@@ -1,0 +1,100 @@
+package v1alpha2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+)
+
+func TestClusterStackConversion(t *testing.T) {
+	spec.Run(t, "testClusterStackConversion", testClusterStackConversion)
+}
+
+func testClusterStackConversion(t *testing.T, when spec.G, it spec.S) {
+	when("converting to and from v1alpha1", func() {
+		v1alpha2ClusterStack := &ClusterStack{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-clusterstack",
+			},
+			Spec: ClusterStackSpec{
+				BuildImage: ClusterStackSpecImage{
+					Image: "some-build-image",
+				},
+				RunImage: ClusterStackSpecImage{
+					Image: "some-run-image",
+				},
+				ServiceAccountRef: &corev1.ObjectReference{
+					Kind:      "service-account",
+					Namespace: "some-namespace",
+					Name:      "some-service-account",
+				},
+			},
+			Status: ClusterStackStatus{
+				ResolvedClusterStack: ResolvedClusterStack{
+					Id: "some-id",
+					BuildImage: ClusterStackStatusImage{
+						LatestImage: "some-latest-build-image",
+						Image:       "some-build-image",
+					},
+					RunImage: ClusterStackStatusImage{
+						LatestImage: "some-latest-run-image",
+						Image:       "some-run-image",
+					},
+					Mixins:  []string{"cowsay", "ionCannon2.4", "forkbomb"},
+					UserID:  0,
+					GroupID: 0,
+				},
+			},
+		}
+
+		v1alpha1ClusterStack := &v1alpha1.ClusterStack{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-clusterstack",
+			},
+			Spec: v1alpha1.ClusterStackSpec{
+				BuildImage: v1alpha1.ClusterStackSpecImage{
+					Image: "some-build-image",
+				},
+				RunImage: v1alpha1.ClusterStackSpecImage{
+					Image: "some-run-image",
+				},
+			},
+			Status: v1alpha1.ClusterStackStatus{
+				ResolvedClusterStack: v1alpha1.ResolvedClusterStack{
+					Id: "some-id",
+					BuildImage: v1alpha1.ClusterStackStatusImage{
+						LatestImage: "some-latest-build-image",
+						Image:       "some-build-image",
+					},
+					RunImage: v1alpha1.ClusterStackStatusImage{
+						LatestImage: "some-latest-run-image",
+						Image:       "some-run-image",
+					},
+					Mixins:  []string{"cowsay", "ionCannon2.4", "forkbomb"},
+					UserID:  0,
+					GroupID: 0,
+				},
+			},
+		}
+
+		it("successfully converts between api versions", func() {
+
+			testV1alpha1ClusterStack := &v1alpha1.ClusterStack{}
+			err := v1alpha2ClusterStack.ConvertTo(context.TODO(), testV1alpha1ClusterStack)
+			require.NoError(t, err)
+			require.Equal(t, v1alpha1ClusterStack, testV1alpha1ClusterStack)
+
+			testV1alpha2ClusterStack := &ClusterStack{}
+			err = testV1alpha2ClusterStack.ConvertFrom(context.TODO(), v1alpha1ClusterStack)
+			v1alpha2ClusterStack.Spec.ServiceAccountRef = nil
+			require.NoError(t, err)
+			require.Equal(t, testV1alpha2ClusterStack, v1alpha2ClusterStack)
+		})
+	})
+}

--- a/pkg/apis/build/v1alpha2/cluster_store_conversion.go
+++ b/pkg/apis/build/v1alpha2/cluster_store_conversion.go
@@ -1,0 +1,54 @@
+package v1alpha2
+
+import (
+	"context"
+	"fmt"
+
+	"knative.dev/pkg/apis"
+
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+)
+
+func (s *ClusterStore) ConvertTo(_ context.Context, to apis.Convertible) error {
+	switch toClusterStore := to.(type) {
+	case *v1alpha1.ClusterStore:
+		toClusterStore.ObjectMeta = s.ObjectMeta
+
+		s.Spec.convertTo(&toClusterStore.Spec)
+		s.Status.convertTo(&toClusterStore.Status)
+	default:
+		return fmt.Errorf("unknown version, got: %T", toClusterStore)
+	}
+	return nil
+}
+
+func (s *ClusterStore) ConvertFrom(_ context.Context, from apis.Convertible) error {
+	switch fromClusterStore := from.(type) {
+	case *v1alpha1.ClusterStore:
+		s.ObjectMeta = fromClusterStore.ObjectMeta
+		s.Spec.convertFrom(&fromClusterStore.Spec)
+		s.Status.convertFrom(&fromClusterStore.Status)
+	default:
+		return fmt.Errorf("unknown version, got: %T", fromClusterStore)
+	}
+
+	return nil
+}
+
+func (cs *ClusterStoreSpec) convertTo(to *v1alpha1.ClusterStoreSpec) {
+	to.Sources = cs.Sources
+}
+
+func (cs *ClusterStoreSpec) convertFrom(from *v1alpha1.ClusterStoreSpec) {
+	cs.Sources = from.Sources
+}
+
+func (ct *ClusterStoreStatus) convertTo(to *v1alpha1.ClusterStoreStatus) {
+	to.Status = ct.Status
+	to.Buildpacks = ct.Buildpacks
+}
+
+func (ct *ClusterStoreStatus) convertFrom(from *v1alpha1.ClusterStoreStatus) {
+	ct.Status = from.Status
+	ct.Buildpacks = from.Buildpacks
+}

--- a/pkg/apis/build/v1alpha2/cluster_store_conversion_test.go
+++ b/pkg/apis/build/v1alpha2/cluster_store_conversion_test.go
@@ -1,0 +1,107 @@
+package v1alpha2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestClusterStoreConversion(t *testing.T) {
+	spec.Run(t, "testClusterStackConversion", testClusterStoreConversion)
+}
+
+func testClusterStoreConversion(t *testing.T, when spec.G, it spec.S) {
+	when("converting to and from v1alpha1", func() {
+		v1alpha2ClusterStore := &ClusterStore{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-cluster-store",
+				Annotations: map[string]string{"some-key": "some-value"},
+			},
+			Spec: ClusterStoreSpec{
+				Sources: []corev1alpha1.StoreImage{{"some-image"}, {"another-image"}},
+				ServiceAccountRef: &corev1.ObjectReference{
+					Namespace: "some-namespace",
+					Name:      "some-service-account",
+				},
+			},
+			Status: ClusterStoreStatus{
+				Status: corev1alpha1.Status{},
+				Buildpacks: []corev1alpha1.StoreBuildpack{{
+					BuildpackInfo: corev1alpha1.BuildpackInfo{
+						Id:      "cool-buildpack-id",
+						Version: "1.23",
+					},
+					Buildpackage: corev1alpha1.BuildpackageInfo{
+						Id:       "cool-buildpackage-id",
+						Version:  "4.56",
+						Homepage: "wow-what-a-site.com",
+					},
+					StoreImage: corev1alpha1.StoreImage{
+						Image: "some-image",
+					},
+					DiffId:   "12345",
+					Digest:   "some-digest",
+					Size:     0,
+					API:      "some-api-version",
+					Homepage: "neopets.com",
+					Order:    nil,
+					Stacks:   nil,
+				}},
+			},
+		}
+
+		v1alpha1ClusterStore := &v1alpha1.ClusterStore{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-cluster-store",
+				Annotations: map[string]string{"some-key": "some-value"},
+			},
+			Spec: v1alpha1.ClusterStoreSpec{
+				Sources: []corev1alpha1.StoreImage{{"some-image"}, {"another-image"}},
+			},
+			Status: v1alpha1.ClusterStoreStatus{
+				Status: corev1alpha1.Status{},
+				Buildpacks: []corev1alpha1.StoreBuildpack{{
+					BuildpackInfo: corev1alpha1.BuildpackInfo{
+						Id:      "cool-buildpack-id",
+						Version: "1.23",
+					},
+					Buildpackage: corev1alpha1.BuildpackageInfo{
+						Id:       "cool-buildpackage-id",
+						Version:  "4.56",
+						Homepage: "wow-what-a-site.com",
+					},
+					StoreImage: corev1alpha1.StoreImage{
+						Image: "some-image",
+					},
+					DiffId:   "12345",
+					Digest:   "some-digest",
+					Size:     0,
+					API:      "some-api-version",
+					Homepage: "neopets.com",
+					Order:    nil,
+					Stacks:   nil,
+				}},
+			},
+		}
+
+		it("successfully converts between api versions", func() {
+
+			testV1alpha1ClusterStore := &v1alpha1.ClusterStore{}
+			err := v1alpha2ClusterStore.ConvertTo(context.TODO(), testV1alpha1ClusterStore)
+			require.NoError(t, err)
+			require.Equal(t, v1alpha1ClusterStore, testV1alpha1ClusterStore)
+
+			testV1alpha2ClusterStore := &ClusterStore{}
+			err = testV1alpha2ClusterStore.ConvertFrom(context.TODO(), v1alpha1ClusterStore)
+			v1alpha2ClusterStore.Spec.ServiceAccountRef = nil
+			require.NoError(t, err)
+			require.Equal(t, testV1alpha2ClusterStore, v1alpha2ClusterStore)
+		})
+	})
+}

--- a/pkg/apis/build/v1alpha2/source_resolver_conversion_test.go
+++ b/pkg/apis/build/v1alpha2/source_resolver_conversion_test.go
@@ -1,0 +1,89 @@
+package v1alpha2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSourceResolverConverstion(t *testing.T) {
+	spec.Run(t, "testClusterStackConversion", testSourceResolverConverstion)
+}
+
+func testSourceResolverConverstion(t *testing.T, when spec.G, it spec.S) {
+	when("converting to and from v1alpha1", func() {
+		v1alpha2SourceResolver := &SourceResolver{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-source-resolver",
+				Namespace:  "some-namespace",
+				Generation: 0,
+			},
+			Spec: SourceResolverSpec{
+				ServiceAccountName: "some-service-account",
+				Source: corev1alpha1.SourceConfig{
+					Git: &corev1alpha1.Git{
+						URL:      "github.com/my-awesome-project-by-me",
+						Revision: "some-revision",
+					},
+				},
+			},
+			Status: SourceResolverStatus{
+				Status: corev1alpha1.Status{},
+				Source: corev1alpha1.ResolvedSourceConfig{
+					Git: &corev1alpha1.ResolvedGitSource{
+						URL:      "github.com/my-awesome-project-by-me",
+						Revision: "some-revision",
+						SubPath:  "some-subpath",
+						Type:     "some-type",
+					},
+				},
+			},
+		}
+
+		v1alpha1SourceResolver := &v1alpha1.SourceResolver{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-source-resolver",
+				Namespace:  "some-namespace",
+				Generation: 0,
+			},
+			Spec: v1alpha1.SourceResolverSpec{
+				ServiceAccount: "some-service-account",
+				Source: corev1alpha1.SourceConfig{
+					Git: &corev1alpha1.Git{
+						URL:      "github.com/my-awesome-project-by-me",
+						Revision: "some-revision",
+					},
+				},
+			},
+			Status: v1alpha1.SourceResolverStatus{
+				Status: corev1alpha1.Status{},
+				Source: corev1alpha1.ResolvedSourceConfig{
+					Git: &corev1alpha1.ResolvedGitSource{
+						URL:      "github.com/my-awesome-project-by-me",
+						Revision: "some-revision",
+						SubPath:  "some-subpath",
+						Type:     "some-type",
+					},
+				},
+			},
+		}
+
+		it("successfully converts between api versions", func() {
+
+			testV1alpha1SourceResolver := &v1alpha1.SourceResolver{}
+			err := v1alpha2SourceResolver.ConvertTo(context.TODO(), testV1alpha1SourceResolver)
+			require.NoError(t, err)
+			require.Equal(t, v1alpha1SourceResolver, testV1alpha1SourceResolver)
+
+			testV1alpha2SourceResolver := &SourceResolver{}
+			err = testV1alpha2SourceResolver.ConvertFrom(context.TODO(), v1alpha1SourceResolver)
+			require.NoError(t, err)
+			require.Equal(t, testV1alpha2SourceResolver, v1alpha2SourceResolver)
+		})
+	})
+}


### PR DESCRIPTION
Adding capability to convert between different api-typed resources will allow us to introduce support for v1alpha2 in the kpack-cli while still maintaining backwards compatibility.