### PR TITLE
Use /cnb/process/completion as start command for completion container

### DIFF
--- a/pkg/apis/build/v1alpha2/build_pod.go
+++ b/pkg/apis/build/v1alpha2/build_pod.go
@@ -321,7 +321,7 @@ func (b *Build) BuildPod(images BuildPodImages, buildContext BuildContext) (*cor
 				step(corev1.Container{
 					Name:    "completion",
 					Image:   images.completion(buildContext.os()),
-					Command: []string{"/cnb/process/web"},
+					Command: []string{"/cnb/process/completion"},
 					Env: []corev1.EnvVar{
 						homeEnv,
 					},
@@ -739,7 +739,7 @@ func (b *Build) rebasePod(buildContext BuildContext, images BuildPodImages) (*co
 				{
 					Name:    "completion",
 					Image:   images.completion(buildContext.os()),
-					Command: []string{"/cnb/process/web"},
+					Command: []string{"/cnb/process/completion"},
 					Args: args(
 						b.notaryArgs(),
 						secretArgs,

--- a/pkg/apis/build/v1alpha2/build_pod_test.go
+++ b/pkg/apis/build/v1alpha2/build_pod_test.go
@@ -1492,7 +1492,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 
 					assert.NotNil(t, pod.Spec.Containers[0])
 					assert.NotNil(t, pod.Spec.Containers[0].Command[0])
-					assert.Equal(t, "/cnb/process/web", pod.Spec.Containers[0].Command[0])
+					assert.Equal(t, "/cnb/process/completion", pod.Spec.Containers[0].Command[0])
 
 					invalidSecretName := "invalid-cosign-secret"
 					assertSecretNotPresent(t, pod, invalidSecretName)
@@ -1635,7 +1635,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 					pod, err := build.BuildPod(config, buildContext)
 					require.NoError(t, err)
 
-					assert.Equal(t, "/cnb/process/web", pod.Spec.Containers[0].Command[0])
+					assert.Equal(t, "/cnb/process/completion", pod.Spec.Containers[0].Command[0])
 
 					require.Subset(t,
 						pod.Spec.Containers[0].Args,
@@ -1684,7 +1684,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 					pod, err := build.BuildPod(config, buildContext)
 					require.NoError(t, err)
 
-					assert.Equal(t, "/cnb/process/web", pod.Spec.Containers[0].Command[0])
+					assert.Equal(t, "/cnb/process/completion", pod.Spec.Containers[0].Command[0])
 
 					invalidSecretName := "invalid-cosign-secret"
 					assertSecretNotPresent(t, pod, invalidSecretName)
@@ -1700,7 +1700,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 					pod, err := build.BuildPod(config, buildContext)
 					require.NoError(t, err)
 
-					assert.Equal(t, "/cnb/process/web", pod.Spec.Containers[0].Command[0])
+					assert.Equal(t, "/cnb/process/completion", pod.Spec.Containers[0].Command[0])
 
 					validSecrets := []string{
 						"cosign-secret-1",
@@ -1799,7 +1799,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 
 				assert.NotNil(t, pod.Spec.Containers[0])
 				assert.NotNil(t, pod.Spec.Containers[0].Command[0])
-				assert.Equal(t, "/cnb/process/web", pod.Spec.Containers[0].Command[0])
+				assert.Equal(t, "/cnb/process/completion", pod.Spec.Containers[0].Command[0])
 
 				invalidSecretName := "invalid-cosign-secret"
 				assertSecretNotPresent(t, pod, invalidSecretName)
@@ -1899,7 +1899,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 				pod, err := build.BuildPod(config, buildContext)
 				require.NoError(t, err)
 
-				assert.Equal(t, "/cnb/process/web", pod.Spec.Containers[0].Command[0])
+				assert.Equal(t, "/cnb/process/completion", pod.Spec.Containers[0].Command[0])
 
 				require.Subset(t,
 					pod.Spec.Containers[0].Args,
@@ -1956,7 +1956,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 				pod, err := build.BuildPod(config, buildContext)
 				require.NoError(t, err)
 
-				assert.Equal(t, "/cnb/process/web", pod.Spec.Containers[0].Command[0])
+				assert.Equal(t, "/cnb/process/completion", pod.Spec.Containers[0].Command[0])
 
 				invalidSecretName := "invalid-cosign-secret"
 				assertSecretNotPresent(t, pod, invalidSecretName)
@@ -1972,7 +1972,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 				pod, err := build.BuildPod(config, buildContext)
 				require.NoError(t, err)
 
-				assert.Equal(t, "/cnb/process/web", pod.Spec.Containers[0].Command[0])
+				assert.Equal(t, "/cnb/process/completion", pod.Spec.Containers[0].Command[0])
 
 				validSecrets := []string{
 					"cosign-secret-1",
@@ -2373,7 +2373,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 				assert.Equal(t, []string{
 					dnsProbeHost,
 					"--",
-					"/cnb/process/web",
+					"/cnb/process/completion",
 					"-notary-v1-url=some-notary-server",
 					"-basic-git=git-secret-1=https://github.com",
 					"-ssh-git=git-secret-2=https://bitbucket.com",
@@ -2417,7 +2417,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 				assert.Equal(t, []string{
 					dnsProbeHost,
 					"--",
-					"/cnb/process/web",
+					"/cnb/process/completion",
 					"-basic-git=git-secret-1=https://github.com",
 					"-ssh-git=git-secret-2=https://bitbucket.com",
 					"-basic-docker=docker-secret-1=acr.io",


### PR DESCRIPTION
- The web process type has been removed from the go buildpack