### PR TITLE
Improved error handling so that binding to a ProvisionedService object no longer swallows errors

### DIFF
--- a/pkg/buildpod/generator.go
+++ b/pkg/buildpod/generator.go
@@ -141,11 +141,11 @@ func (g *Generator) readProvisionedServiceDuckType(ctx context.Context, build Bu
 	gvr, _ := meta.UnsafeGuessKindToResource(s.GroupVersionKind())
 	unstructured, err := g.DynamicClient.Resource(gvr).Namespace(build.GetNamespace()).Get(ctx, s.Name, metav1.GetOptions{})
 	if err != nil {
-		return duckprovisionedserviceable.ProvisionedServicable{}, nil
+		return duckprovisionedserviceable.ProvisionedServicable{}, err
 	}
 	ps := duckprovisionedserviceable.ProvisionedServicable{}
 	if err := duck.FromUnstructured(unstructured, &ps); err != nil {
-		return duckprovisionedserviceable.ProvisionedServicable{}, nil
+		return duckprovisionedserviceable.ProvisionedServicable{}, err
 	}
 	return ps, nil
 }

--- a/pkg/duckprovisionedserviceable/fake/fakeprovisionedservice.go
+++ b/pkg/duckprovisionedserviceable/fake/fakeprovisionedservice.go
@@ -4,6 +4,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type FakeProvisionedService struct {
@@ -21,6 +22,10 @@ func (ps *FakeProvisionedService) DeepCopyObject() runtime.Object {
 		Spec:       ps.Spec,
 		Status:     ps.Status,
 	}
+}
+
+func (ps *FakeProvisionedService) GetGroupVersionKind() schema.GroupVersionKind {
+	return ps.GroupVersionKind()
 }
 
 type ProvisionedServiceSpec struct {


### PR DESCRIPTION
Fixed error handling on readProvisionedServiceDuckType. Added additional test coverage.