### PR TITLE
ignore hack package in arch test

### DIFF
--- a/pkg/arch_test.go
+++ b/pkg/arch_test.go
@@ -9,5 +9,6 @@ import (
 func TestDependencies(t *testing.T) {
 	archtest.Package(t, "github.com/pivotal/kpack/...").
 		IncludeTests().
+		Ignoring("github.com/pivotal/kpack/hack").
 		ShouldNotDependDirectlyOn("gotest.tools/...", "github.com/tj/assert/...")
 }


### PR DESCRIPTION
- This was failing due to go version changes this could derisk the test