### PR TITLE
Disable Istio Injection on build pods

### DIFF
--- a/pkg/apis/build/v1alpha2/build_pod.go
+++ b/pkg/apis/build/v1alpha2/build_pod.go
@@ -41,6 +41,7 @@ const (
 	cosignRespositoryAnnotationPrefix      = "kpack.io/cosign.repository"
 	DOCKERSecretAnnotationPrefix           = "kpack.io/docker"
 	GITSecretAnnotationPrefix              = "kpack.io/git"
+	IstioInject                            = "sidecar.istio.io/inject"
 
 	cosignSecretDataCosignKey = "cosign.key"
 
@@ -332,7 +333,9 @@ func (b *Build) BuildPod(images BuildPodImages, buildContext BuildContext) (*cor
 			Labels: combine(b.Labels, map[string]string{
 				BuildLabel: b.Name,
 			}),
-			Annotations: b.Annotations,
+			Annotations: combine(b.Annotations, map[string]string{
+				IstioInject: "false",
+			}),
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(b),
 			},
@@ -740,7 +743,9 @@ func (b *Build) rebasePod(buildContext BuildContext, images BuildPodImages) (*co
 			Labels: combine(b.Labels, map[string]string{
 				BuildLabel: b.Name,
 			}),
-			Annotations: b.Annotations,
+			Annotations: combine(b.Annotations, map[string]string{
+				IstioInject: "false",
+			}),
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(b),
 			},

--- a/pkg/apis/build/v1alpha2/build_pod_test.go
+++ b/pkg/apis/build/v1alpha2/build_pod_test.go
@@ -320,7 +320,8 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 					"image.kpack.io/buildNumber": "12",
 				},
 				Annotations: map[string]string{
-					"some/annotation": "to-pass-through",
+					"some/annotation":         "to-pass-through",
+					"sidecar.istio.io/inject": "false",
 				},
 				OwnerReferences: []metav1.OwnerReference{
 					*kmeta.NewControllerRef(build),
@@ -1369,6 +1370,7 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 					},
 					Annotations: map[string]string{
 						"some/annotation":               "to-pass-through",
+						"sidecar.istio.io/inject":       "false",
 						buildapi.BuildReasonAnnotation:  buildapi.BuildReasonStack,
 						buildapi.BuildChangesAnnotation: "some-stack-change",
 					},


### PR DESCRIPTION
 - This will prevent istio from injecting in and build pods allowing the builds to succeed on clusters that don't require istio