### PR TITLE
go.mod updates to allow using in other modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	k8s.io/api v0.24.1
 	k8s.io/apimachinery v0.24.1
-	k8s.io/client-go v1.5.2
+	k8s.io/client-go v0.24.1
 	k8s.io/code-generator v0.23.6
 	k8s.io/kube-openapi v0.0.0-20220413171646-5e7f5fdc6da6
 	knative.dev/pkg v0.0.0-20220325200448-1f7514acd0c2


### PR DESCRIPTION
The k8s.io/client-go version in go.mod was accidentally bumped to 1.5.2 which is marked as retracted. The correct versions are current in the 0.24.x range. For some reason, the replace on client-go stops go issuing a warning about this.

This change allows kpack to be included in other go projects without causing problems with the client-go dependency

cc @georgethebeatle