### PR TITLE
Set logrus log level to fatal

### DIFF
--- a/cmd/build-init/main.go
+++ b/cmd/build-init/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
 	"github.com/pkg/errors"
 
+	_ "github.com/pivotal/kpack/internal/logrus/fatal"
 	"github.com/pivotal/kpack/pkg/blob"
 	"github.com/pivotal/kpack/pkg/buildchange"
 	"github.com/pivotal/kpack/pkg/cnb"
@@ -40,9 +41,9 @@ var (
 	buildChanges   = flag.String("build-changes", os.Getenv("BUILD_CHANGES"), "JSON string of build changes and their reason")
 	descriptorPath = flag.String("project-descriptor-path", os.Getenv("PROJECT_DESCRIPTOR_PATH"), "path to project descriptor file")
 
-	builderImage= flag.String("builder-image", os.Getenv("BUILDER_IMAGE"), "The builder image used to build the application")
-	builderName = flag.String("builder-name", os.Getenv("BUILDER_NAME"), "The builder name provided during creation")
-	builderKind = flag.String("builder-kind", os.Getenv("BUILDER_KIND"), "The builder kind")
+	builderImage = flag.String("builder-image", os.Getenv("BUILDER_IMAGE"), "The builder image used to build the application")
+	builderName  = flag.String("builder-name", os.Getenv("BUILDER_NAME"), "The builder name provided during creation")
+	builderKind  = flag.String("builder-kind", os.Getenv("BUILDER_KIND"), "The builder kind")
 
 	basicGitCredentials     flaghelpers.CredentialsFlags
 	sshGitCredentials       flaghelpers.CredentialsFlags

--- a/cmd/completion/main.go
+++ b/cmd/completion/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sigstore/cosign/cmd/cosign/cli/sign"
 
+	_ "github.com/pivotal/kpack/internal/logrus/fatal"
 	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
 	"github.com/pivotal/kpack/pkg/cnb"
 	"github.com/pivotal/kpack/pkg/cosign"

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -29,6 +29,7 @@ import (
 	"knative.dev/pkg/signals"
 
 	"github.com/pivotal/kpack/cmd"
+	_ "github.com/pivotal/kpack/internal/logrus/fatal"
 	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
 	"github.com/pivotal/kpack/pkg/blob"
 	"github.com/pivotal/kpack/pkg/buildpod"

--- a/cmd/rebase/main.go
+++ b/cmd/rebase/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
 	"github.com/pkg/errors"
 
+	_ "github.com/pivotal/kpack/internal/logrus/fatal"
 	"github.com/pivotal/kpack/pkg/buildchange"
 	"github.com/pivotal/kpack/pkg/dockercreds"
 	"github.com/pivotal/kpack/pkg/flaghelpers"

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/sclevine/spec v1.4.0
 	github.com/sigstore/cosign v1.5.2
+	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.1
 	github.com/theupdateframework/notary v0.6.2-0.20200804143915-84287fd8df4f
@@ -240,7 +241,6 @@ require (
 	github.com/sigstore/fulcio v0.1.2-0.20220114150912-86a2036f9bc7 // indirect
 	github.com/sigstore/rekor v0.4.1-0.20220114213500-23f583409af3 // indirect
 	github.com/sigstore/sigstore v1.1.1-0.20220130134424-bae9b66b8442 // indirect
-	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/afero v1.8.0 // indirect

--- a/internal/logrus/fatal/fatal_level.go
+++ b/internal/logrus/fatal/fatal_level.go
@@ -1,0 +1,9 @@
+package fatal
+
+import "github.com/sirupsen/logrus"
+
+// package can be imported to set the log level to fatal
+
+func init() {
+	logrus.SetLevel(logrus.FatalLevel)
+}


### PR DESCRIPTION
- This is done in all binaries that might interact with a registry
- The goal is to reduce the noisiness of the github.com/awslabs/amazon-ecr-credential-helper package

The ecr helper has not yet released a configurable logger: https://github.com/awslabs/amazon-ecr-credential-helper/releases/tag/v0.6.0

The implementation idea is to set the global logrus log level to `Fatal` so only fatal or panic errors are logged from the ecr cred helper package

The risk is that this would configure all unconfigured logrus loggers to also be set to the Fatal log level. I think this is acceptable because it is not used in our code. It is only notably used in the notary package which does have configurable logger which we set.