### PR TITLE
Accept all types of corev1.EnvVar as build env vars

### DIFF
--- a/cmd/build-init/main.go
+++ b/cmd/build-init/main.go
@@ -29,9 +29,8 @@ import (
 )
 
 var (
-	platformEnvVars = flag.String("platformEnvVars", os.Getenv("PLATFORM_ENV_VARS"), "a JSON string of build time environment variables formatted as key/value pairs")
-	imageTag        = flag.String("imageTag", os.Getenv("IMAGE_TAG"), "tag of image that will get created by the lifecycle")
-	runImage        = flag.String("runImage", os.Getenv("RUN_IMAGE"), "The base image from which application images are built.")
+	imageTag = flag.String("imageTag", os.Getenv("IMAGE_TAG"), "tag of image that will get created by the lifecycle")
+	runImage = flag.String("runImage", os.Getenv("RUN_IMAGE"), "The base image from which application images are built.")
 
 	gitURL          = flag.String("git-url", os.Getenv("GIT_URL"), "The url of the Git repository to initialize.")
 	gitRevision     = flag.String("git-revision", os.Getenv("GIT_REVISION"), "The Git revision to make the repository HEAD.")
@@ -159,7 +158,7 @@ func main() {
 			*builderName, *builderKind)
 	}
 
-	err = cnb.SetupPlatformEnvVars(platformDir, *platformEnvVars)
+	err = cnb.SetupPlatformEnvVars(platformDir)
 	if err != nil {
 		logger.Fatalf("error setting up platform env vars %s", err)
 	}

--- a/pkg/apis/build/v1alpha2/build_pod.go
+++ b/pkg/apis/build/v1alpha2/build_pod.go
@@ -1,7 +1,6 @@
 package v1alpha2
 
 import (
-	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -60,6 +59,8 @@ const (
 	platformAPIEnvVar            = "CNB_PLATFORM_API"
 	serviceBindingRootEnvVar     = "SERVICE_BINDING_ROOT"
 	TerminationMessagePathEnvVar = "TERMINATION_MESSAGE_PATH"
+
+	PlatformEnvVarPrefix = "PLATFORM_ENV_"
 )
 
 type ServiceBinding interface {
@@ -195,9 +196,10 @@ func (b *Build) BuildPod(images BuildPodImages, buildContext BuildContext) (*cor
 	}
 	dnsProbeHost := ref.Context().RegistryStr()
 
-	envVars, err := json.Marshal(b.Spec.Env)
-	if err != nil {
-		return nil, err
+	buildEnv := b.Spec.Source.Source().BuildEnvVars()
+	for _, envVar := range b.Spec.Env {
+		envVar.Name = PlatformEnvVarPrefix + envVar.Name
+		buildEnv = append(buildEnv, envVar)
 	}
 
 	secretVolumes, secretVolumeMounts, secretArgs := b.setupSecretVolumesAndArgs(buildContext.Secrets, gitAndDockerSecrets)
@@ -397,7 +399,7 @@ func (b *Build) BuildPod(images BuildPodImages, buildContext BuildContext) (*cor
 						Args:      append(secretArgs, imagePullArgs...),
 						Resources: b.Spec.Resources,
 						Env: append(
-							b.Spec.Source.Source().BuildEnvVars(),
+							buildEnv,
 							corev1.EnvVar{
 								Name:  "SOURCE_SUB_PATH",
 								Value: b.Spec.Source.SubPath,
@@ -405,10 +407,6 @@ func (b *Build) BuildPod(images BuildPodImages, buildContext BuildContext) (*cor
 							corev1.EnvVar{
 								Name:  "PROJECT_DESCRIPTOR_PATH",
 								Value: b.Spec.ProjectDescriptorPath,
-							},
-							corev1.EnvVar{
-								Name:  "PLATFORM_ENV_VARS",
-								Value: string(envVars),
 							},
 							corev1.EnvVar{
 								Name:  "IMAGE_TAG",

--- a/pkg/apis/build/v1alpha2/build_pod_test.go
+++ b/pkg/apis/build/v1alpha2/build_pod_test.go
@@ -296,6 +296,14 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 				Env: []corev1.EnvVar{
 					{Name: "keyA", Value: "valueA"},
 					{Name: "keyB", Value: "valueB"},
+					{Name: "keyC", ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "my-secret",
+							},
+							Key: "keyC",
+						},
+					}},
 				},
 				Resources: resources,
 				LastBuild: &buildapi.LastBuild{
@@ -677,8 +685,25 @@ func testBuildPod(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal(t, pod.Spec.InitContainers[0].Image, config.BuildInitImage)
 			assert.Contains(t, pod.Spec.InitContainers[0].Env,
 				corev1.EnvVar{
-					Name:  "PLATFORM_ENV_VARS",
-					Value: `[{"name":"keyA","value":"valueA"},{"name":"keyB","value":"valueB"}]`,
+					Name:  "PLATFORM_ENV_keyA",
+					Value: "valueA",
+				})
+			assert.Contains(t, pod.Spec.InitContainers[0].Env,
+				corev1.EnvVar{
+					Name:  "PLATFORM_ENV_keyB",
+					Value: "valueB",
+				})
+			assert.Contains(t, pod.Spec.InitContainers[0].Env,
+				corev1.EnvVar{
+					Name: "PLATFORM_ENV_keyC",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "my-secret",
+							},
+							Key: "keyC",
+						},
+					},
 				})
 			assert.Contains(t, pod.Spec.InitContainers[0].Env,
 				corev1.EnvVar{

--- a/pkg/cnb/platform_env_vars_setup.go
+++ b/pkg/cnb/platform_env_vars_setup.go
@@ -1,14 +1,32 @@
 package cnb
 
 import (
-	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
 )
 
-func SetupPlatformEnvVars(dir, envVarsJSON string) error {
+func SetupPlatformEnvVars(dir string) error {
 	var envVars []envVariable
-	err := json.Unmarshal([]byte(envVarsJSON), &envVars)
-	if err != nil {
-		return err
+
+	for _, envVar := range os.Environ() {
+		eqPos := strings.Index(envVar, "=")
+		if eqPos < 0 {
+			continue
+		}
+
+		key := envVar[:eqPos]
+		if !strings.HasPrefix(key, v1alpha2.PlatformEnvVarPrefix) {
+			continue
+		}
+
+		val := envVar[eqPos+1:]
+		envVars = append(envVars, envVariable{
+			Name:  key[len(v1alpha2.PlatformEnvVarPrefix):],
+			Value: val,
+		})
 	}
+
 	return serializeEnvVars(envVars, dir)
 }


### PR DESCRIPTION
This allows consumers of the kpack Image resource to specify environment variables to pass to the build process in all formats supported by kubernetes. Previously, only literal string values were accepted.

To do this, we set the supplied env vars on the prepare init container, using a prefix to identify them. Kubernetes transparently fetches values from secrets or however else the env vars are defined, and provides the literal values in the container's environment.

Finally, the prepare init container code fetches those env vars with the given prefix, and serializes them to the env directory as before.

It fixes this issue: https://github.com/pivotal/kpack/issues/554