### PR TITLE
Retry logic for builders on network failures

### DIFF
--- a/pkg/reconciler/builder/builder.go
+++ b/pkg/reconciler/builder/builder.go
@@ -55,7 +55,9 @@ func NewController(opt reconciler.Options,
 		zap.String(logkey.Kind, buildapi.BuilderCRName),
 	)
 
-	impl := controller.NewImpl(c, logger, ReconcilerName)
+	impl := controller.NewImpl(&reconciler.NetworkErrorReconciler{
+		Reconciler: c,
+	}, logger, ReconcilerName)
 	builderInformer.Informer().AddEventHandler(reconciler.Handler(impl.Enqueue))
 
 	c.Tracker = tracker.New(impl.EnqueueKey, opt.TrackerResyncPeriod())
@@ -100,8 +102,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		if err != nil {
 			return err
 		}
-
-		return controller.NewPermanentError(creationError)
+		return creationError
 	}
 
 	builder.Status.BuilderRecord(builderRecord)

--- a/pkg/reconciler/builder/builder_test.go
+++ b/pkg/reconciler/builder/builder_test.go
@@ -18,6 +18,7 @@ import (
 	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 	"github.com/pivotal/kpack/pkg/client/clientset/versioned/fake"
+	kreconciler "github.com/pivotal/kpack/pkg/reconciler"
 	"github.com/pivotal/kpack/pkg/reconciler/builder"
 	"github.com/pivotal/kpack/pkg/reconciler/testhelpers"
 	"github.com/pivotal/kpack/pkg/registry"
@@ -57,7 +58,7 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 				ClusterStoreLister: listers.GetClusterStoreLister(),
 				ClusterStackLister: listers.GetClusterStackLister(),
 			}
-			return r, rtesting.ActionRecorderList{fakeClient}, rtesting.EventList{Recorder: record.NewFakeRecorder(10)}
+			return &kreconciler.NetworkErrorReconciler{Reconciler: r}, rtesting.ActionRecorderList{fakeClient}, rtesting.EventList{Recorder: record.NewFakeRecorder(10)}
 		})
 
 	clusterStore := &buildapi.ClusterStore{

--- a/pkg/reconciler/clusterbuilder/clusterbuilder.go
+++ b/pkg/reconciler/clusterbuilder/clusterbuilder.go
@@ -53,7 +53,9 @@ func NewController(
 		zap.String(logkey.Kind, buildapi.ClusterBuilderCRName),
 	)
 
-	impl := controller.NewImpl(c, logger, ReconcilerName)
+	impl := controller.NewImpl(&reconciler.NetworkErrorReconciler{
+		Reconciler: c,
+	}, logger, ReconcilerName)
 	clusterBuilderInformer.Informer().AddEventHandler(reconciler.Handler(impl.Enqueue))
 
 	c.Tracker = tracker.New(impl.EnqueueKey, opt.TrackerResyncPeriod())
@@ -99,7 +101,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 			return err
 		}
 
-		return controller.NewPermanentError(creationError)
+		return creationError
 	}
 
 	builder.Status.BuilderRecord(builderRecord)

--- a/pkg/reconciler/clusterbuilder/clusterbuilder_test.go
+++ b/pkg/reconciler/clusterbuilder/clusterbuilder_test.go
@@ -18,6 +18,7 @@ import (
 	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 	"github.com/pivotal/kpack/pkg/client/clientset/versioned/fake"
+	kreconciler "github.com/pivotal/kpack/pkg/reconciler"
 	clusterBuilder "github.com/pivotal/kpack/pkg/reconciler/clusterbuilder"
 	"github.com/pivotal/kpack/pkg/reconciler/testhelpers"
 	"github.com/pivotal/kpack/pkg/registry"
@@ -56,7 +57,7 @@ func testClusterBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 				ClusterStoreLister:   listers.GetClusterStoreLister(),
 				ClusterStackLister:   listers.GetClusterStackLister(),
 			}
-			return r, rtesting.ActionRecorderList{fakeClient}, rtesting.EventList{Recorder: record.NewFakeRecorder(10)}
+			return &kreconciler.NetworkErrorReconciler{Reconciler: r}, rtesting.ActionRecorderList{fakeClient}, rtesting.EventList{Recorder: record.NewFakeRecorder(10)}
 		})
 
 	clusterStore := &buildapi.ClusterStore{

--- a/pkg/reconciler/clusterstack/clusterstack.go
+++ b/pkg/reconciler/clusterstack/clusterstack.go
@@ -47,7 +47,9 @@ func NewController(
 		zap.String(logkey.Kind, buildapi.ClusterStackCRName),
 	)
 
-	impl := controller.NewImpl(c, logger, ReconcilerName)
+	impl := controller.NewImpl(&reconciler.NetworkErrorReconciler{
+		Reconciler: c,
+	}, logger, ReconcilerName)
 	clusterStackInformer.Informer().AddEventHandler(reconciler.Handler(impl.Enqueue))
 	return impl
 }
@@ -82,7 +84,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	}
 
 	if err != nil {
-		return controller.NewPermanentError(err)
+		return err
 	}
 	return nil
 }

--- a/pkg/reconciler/clusterstack/clusterstack_test.go
+++ b/pkg/reconciler/clusterstack/clusterstack_test.go
@@ -18,6 +18,7 @@ import (
 	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 	"github.com/pivotal/kpack/pkg/client/clientset/versioned/fake"
+	kreconciler "github.com/pivotal/kpack/pkg/reconciler"
 	"github.com/pivotal/kpack/pkg/reconciler/clusterstack"
 	"github.com/pivotal/kpack/pkg/reconciler/clusterstack/clusterstackfakes"
 	"github.com/pivotal/kpack/pkg/reconciler/testhelpers"
@@ -68,7 +69,7 @@ func testClusterStackReconciler(t *testing.T, when spec.G, it spec.S) {
 				ClusterStackReader: fakeClusterStackReader,
 				KeychainFactory:    fakeKeyChainFactory,
 			}
-			return r, rtesting.ActionRecorderList{fakeClient}, rtesting.EventList{Recorder: record.NewFakeRecorder(10)}
+			return &kreconciler.NetworkErrorReconciler{Reconciler: r}, rtesting.ActionRecorderList{fakeClient}, rtesting.EventList{Recorder: record.NewFakeRecorder(10)}
 		})
 
 	when("#Reconcile", func() {

--- a/pkg/reconciler/clusterstore/clusterstore.go
+++ b/pkg/reconciler/clusterstore/clusterstore.go
@@ -47,7 +47,9 @@ func NewController(
 		zap.String(logkey.Kind, buildapi.ClusterStoreCRName),
 	)
 
-	impl := controller.NewImpl(c, logger, ReconcilerName)
+	impl := controller.NewImpl(&reconciler.NetworkErrorReconciler{
+		Reconciler: c,
+	}, logger, ReconcilerName)
 	clusterStoreInformer.Informer().AddEventHandler(reconciler.Handler(impl.Enqueue))
 	return impl
 }
@@ -82,7 +84,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	}
 
 	if err != nil {
-		return controller.NewPermanentError(err)
+		return err
 	}
 	return nil
 }

--- a/pkg/reconciler/clusterstore/clusterstore_test.go
+++ b/pkg/reconciler/clusterstore/clusterstore_test.go
@@ -17,6 +17,7 @@ import (
 	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 	"github.com/pivotal/kpack/pkg/client/clientset/versioned/fake"
+	kreconciler "github.com/pivotal/kpack/pkg/reconciler"
 	"github.com/pivotal/kpack/pkg/reconciler/clusterstore"
 	"github.com/pivotal/kpack/pkg/reconciler/clusterstore/clusterstorefakes"
 	"github.com/pivotal/kpack/pkg/reconciler/testhelpers"
@@ -51,7 +52,7 @@ func testClusterStoreReconciler(t *testing.T, when spec.G, it spec.S) {
 				ClusterStoreLister: listers.GetClusterStoreLister(),
 				KeychainFactory:    fakeKeyChainFactory,
 			}
-			return r, rtesting.ActionRecorderList{fakeClient}, rtesting.EventList{Recorder: record.NewFakeRecorder(10)}
+			return &kreconciler.NetworkErrorReconciler{Reconciler: r}, rtesting.ActionRecorderList{fakeClient}, rtesting.EventList{Recorder: record.NewFakeRecorder(10)}
 		})
 
 	store := &buildapi.ClusterStore{

--- a/pkg/reconciler/network_error_reconciler.go
+++ b/pkg/reconciler/network_error_reconciler.go
@@ -1,0 +1,31 @@
+package reconciler
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	"knative.dev/pkg/controller"
+)
+
+type NetworkErrorReconciler struct {
+	Reconciler controller.Reconciler
+}
+
+func (r *NetworkErrorReconciler) Reconcile(ctx context.Context, key string) error {
+	if err := r.Reconciler.Reconcile(ctx, key); err != nil {
+		var networkError *NetworkError
+		if errors.As(err, &networkError) {
+			// Re-queue the key if it's a network error.
+			return err
+		}
+		return controller.NewPermanentError(err)
+	}
+	return nil
+}
+
+type NetworkError struct {
+	Err error
+}
+
+func (e *NetworkError) Error() string {
+	return e.Err.Error()
+}

--- a/pkg/reconciler/network_error_reconciler_test.go
+++ b/pkg/reconciler/network_error_reconciler_test.go
@@ -1,0 +1,62 @@
+package reconciler
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+const (
+	networkErrorMsg = "some network problem"
+	otherErrorMsg = "some other error"
+)
+
+func TestNetworkErrorReconciler(t *testing.T) {
+	spec.Run(t, "Network Error Reconciler", testNetworkErrorReconciler)
+}
+
+func testNetworkErrorReconciler(t *testing.T, when spec.G, it spec.S) {
+
+	when("#Reconcile", func() {
+		when("network error", func() {
+			subject := &NetworkErrorReconciler{Reconciler: &fakeErrorReconciler{retry: true}}
+			it("re-throw the error", func() {
+				err := subject.Reconcile(context.Background(), "whatever")
+
+				require.Error(t, err)
+
+				var networkError *NetworkError
+				require.True(t, errors.As(err, &networkError))
+				require.Equal(t, networkErrorMsg, err.Error())
+			})
+		})
+
+		when("other error", func() {
+			subject := &NetworkErrorReconciler{Reconciler: &fakeErrorReconciler{retry: false}}
+			it("wraps it as permanent error", func() {
+				err := subject.Reconcile(context.Background(), "whatever")
+
+				require.Error(t, err)
+
+				var networkError *NetworkError
+				require.False(t, errors.As(err, &networkError))
+				require.Equal(t, otherErrorMsg, err.Error())
+			})
+		})
+	})
+}
+
+type fakeErrorReconciler struct {
+	retry bool
+}
+
+func (r *fakeErrorReconciler) Reconcile(ctx context.Context, key string) error {
+	if r.retry {
+		err := errors.New(networkErrorMsg)
+		return &NetworkError{Err: err}
+	}
+	err := errors.New(otherErrorMsg)
+	return err
+}

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -10,10 +10,12 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/pkg/errors"
 	"github.com/sclevine/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pivotal/kpack/pkg/reconciler"
 	"github.com/pivotal/kpack/pkg/registry"
 )
 
@@ -35,8 +37,10 @@ func testClient(t *testing.T, when spec.G, it spec.S) {
 	)
 
 	when("Fetch", func() {
-		const digest = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-		const sampleManifest = `{
+
+		when("no error", func() {
+			const digest = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+			const sampleManifest = `{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
   "config": {
@@ -54,125 +58,218 @@ func testClient(t *testing.T, when spec.G, it spec.S) {
 }
 `
 
-		it.Before(func() {
-			handler.HandleFunc("/v2/some/image/manifests", func(writer http.ResponseWriter, request *http.Request) {
-				if request.Method != "GET" {
-					t.Errorf("unexpected %s to %s", request.Method, request.URL)
-					writer.WriteHeader(500)
-					return
-				}
-				writer.WriteHeader(200)
+			it.Before(func() {
+				handler.HandleFunc("/v2/some/image/manifests", func(writer http.ResponseWriter, request *http.Request) {
+					if request.Method != "GET" {
+						t.Errorf("unexpected %s to %s", request.Method, request.URL)
+						writer.WriteHeader(500)
+						return
+					}
+					writer.WriteHeader(200)
 
-				writer.Write([]byte(sampleManifest))
+					writer.Write([]byte(sampleManifest))
+				})
+
+				handler.HandleFunc("/v2/", func(writer http.ResponseWriter, request *http.Request) {
+					if request.Method != "GET" {
+						t.Errorf("unexpected %s to %s", request.Method, request.URL)
+						writer.WriteHeader(404)
+						return
+					}
+
+					writer.WriteHeader(200)
+				})
+
 			})
 
-			handler.HandleFunc("/v2/", func(writer http.ResponseWriter, request *http.Request) {
-				if request.Method != "GET" {
-					t.Errorf("unexpected %s to %s", request.Method, request.URL)
-					writer.WriteHeader(404)
-					return
-				}
+			when("#Identifer", func() {
+				var fullyQualifedImageRef = fmt.Sprintf("%s/some/image@%s", server.URL[7:], digest)
+				it("includes digest if repoName does not have a digest", func() {
+					_, imageId, err := subject.Fetch(keychain, tagName)
+					require.NoError(t, err)
 
-				writer.WriteHeader(200)
+					require.Equal(t, imageId, fullyQualifedImageRef)
+				})
+
+				it("includes digest if repoName already has a digest", func() {
+					_, imageId, err := subject.Fetch(keychain, fullyQualifedImageRef)
+					require.NoError(t, err)
+
+					require.Equal(t, imageId, fullyQualifedImageRef)
+				})
 			})
-
 		})
 
-		when("#Identifer", func() {
-			var fullyQualifedImageRef = fmt.Sprintf("%s/some/image@%s", server.URL[7:], digest)
-			it("includes digest if repoName does not have a digest", func() {
-				_, imageId, err := subject.Fetch(keychain, tagName)
-				require.NoError(t, err)
-
-				require.Equal(t, imageId, fullyQualifedImageRef)
+		when("error", func() {
+			when("network", func() {
+				it.Before(func() {
+					handler.HandleFunc("/v2/", func(writer http.ResponseWriter, request *http.Request) {
+						writer.WriteHeader(404)
+					})
+				})
+				it("wraps it to NetworkError", func() {
+					assertNetworkErrorOn(t, true, func() error {
+						_, _, err := subject.Fetch(keychain, tagName)
+						return err
+					})
+				})
 			})
 
-			it("includes digest if repoName already has a digest", func() {
-				_, imageId, err := subject.Fetch(keychain, fullyQualifedImageRef)
-				require.NoError(t, err)
+			when("unauthorized", func() {
+				it.Before(func() {
+					handler.HandleFunc("/v2/", func(writer http.ResponseWriter, request *http.Request) {
+						writer.WriteHeader(http.StatusUnauthorized)
+					})
+				})
+				it("doesn't wrap it to NetworkError", func() {
+					assertNetworkErrorOn(t, false, func() error {
+						_, _, err := subject.Fetch(keychain, tagName)
+						return err
+					})
+				})
+			})
 
-				require.Equal(t, imageId, fullyQualifedImageRef)
+			when("forbidden", func() {
+				it.Before(func() {
+					handler.HandleFunc("/v2/", func(writer http.ResponseWriter, request *http.Request) {
+						writer.WriteHeader(http.StatusForbidden)
+					})
+				})
+				it("doesn't wrap it to NetworkError", func() {
+					assertNetworkErrorOn(t, false, func() error {
+						_, _, err := subject.Fetch(keychain, tagName)
+						return err
+					})
+				})
 			})
 		})
 	})
 
 	when("Save", func() {
+		when("no error", func() {
+			it("should save", func() {
+				image := randomImage(t, layerCount)
+				var (
+					numberOfLayerUploads       = 0
+					numberOfManifestsSaves     = 0
+					numberOfAdditionalTagSaves = 0
+				)
 
-		it("should save", func() {
-			image := randomImage(t, layerCount)
-			var (
-				numberOfLayerUploads       = 0
-				numberOfManifestsSaves     = 0
-				numberOfAdditionalTagSaves = 0
-			)
+				handler.HandleFunc("/v2/some/image/blobs/", func(writer http.ResponseWriter, request *http.Request) {
+					writer.WriteHeader(200)
+					numberOfLayerUploads++
+				})
 
-			handler.HandleFunc("/v2/some/image/blobs/", func(writer http.ResponseWriter, request *http.Request) {
-				writer.WriteHeader(200)
-				numberOfLayerUploads++
-			})
+				handler.HandleFunc("/v2/some/image/manifests/tag", func(writer http.ResponseWriter, request *http.Request) {
+					if request.Method == "GET" {
+						writer.WriteHeader(404)
+						return
+					}
 
-			handler.HandleFunc("/v2/some/image/manifests/tag", func(writer http.ResponseWriter, request *http.Request) {
-				if request.Method == "GET" {
-					writer.WriteHeader(404)
-					return
-				}
+					numberOfManifestsSaves++
+					writer.WriteHeader(201)
+				})
 
-				numberOfManifestsSaves++
-				writer.WriteHeader(201)
-			})
+				handler.HandleFunc("/v2/some/image/manifests/", func(writer http.ResponseWriter, request *http.Request) {
+					if request.Method == "GET" {
+						t.Errorf("unexpected %s to %s", request.Method, request.URL)
+						writer.WriteHeader(404)
+						return
+					}
+					assert.Regexp(t, regexp.MustCompile("/v2/some/image/manifests/\\d{14}"), request.RequestURI)
+					numberOfAdditionalTagSaves++
 
-			handler.HandleFunc("/v2/some/image/manifests/", func(writer http.ResponseWriter, request *http.Request) {
-				if request.Method == "GET" {
-					t.Errorf("unexpected %s to %s", request.Method, request.URL)
-					writer.WriteHeader(404)
-					return
-				}
-				assert.Regexp(t, regexp.MustCompile("/v2/some/image/manifests/\\d{14}"), request.RequestURI)
-				numberOfAdditionalTagSaves++
+					writer.WriteHeader(200)
+				})
 
-				writer.WriteHeader(200)
-			})
+				handler.HandleFunc("/v2/", func(writer http.ResponseWriter, request *http.Request) {
+					if request.Method != "GET" {
+						t.Errorf("unexpected %s to %s", request.Method, request.URL)
+						writer.WriteHeader(404)
+						return
+					}
 
-			handler.HandleFunc("/v2/", func(writer http.ResponseWriter, request *http.Request) {
-				if request.Method != "GET" {
-					t.Errorf("unexpected %s to %s", request.Method, request.URL)
-					writer.WriteHeader(404)
-					return
-				}
+					writer.WriteHeader(200)
+				})
 
-				writer.WriteHeader(200)
-			})
-
-			_, err := subject.Save(keychain, tagName, image)
-			require.NoError(t, err)
-
-			const configLayer = 1
-			assert.Equal(t, numberOfLayerUploads, layerCount+configLayer)
-			assert.Equal(t, numberOfManifestsSaves, 1)
-			assert.Equal(t, numberOfAdditionalTagSaves, 1)
-		})
-
-		it("does not save images if exisiting image already exisits", func() {
-			image := randomImage(t, layerCount)
-
-			handler.HandleFunc("/v2/some/image/manifests/tag", func(writer http.ResponseWriter, request *http.Request) {
-				configFile, err := image.RawManifest()
+				_, err := subject.Save(keychain, tagName, image)
 				require.NoError(t, err)
 
-				writer.Write(configFile)
-				writer.WriteHeader(200)
+				const configLayer = 1
+				assert.Equal(t, numberOfLayerUploads, layerCount+configLayer)
+				assert.Equal(t, numberOfManifestsSaves, 1)
+				assert.Equal(t, numberOfAdditionalTagSaves, 1)
 			})
 
-			handler.HandleFunc("/v2/", func(writer http.ResponseWriter, request *http.Request) {
-				if request.Method != "GET" {
-					t.Fatalf("unexpected %s to %s", request.Method, request.URL)
-				}
+			it("does not save images if exisiting image already exisits", func() {
+				image := randomImage(t, layerCount)
 
-				writer.WriteHeader(200)
+				handler.HandleFunc("/v2/some/image/manifests/tag", func(writer http.ResponseWriter, request *http.Request) {
+					configFile, err := image.RawManifest()
+					require.NoError(t, err)
+
+					writer.Write(configFile)
+					writer.WriteHeader(200)
+				})
+
+				handler.HandleFunc("/v2/", func(writer http.ResponseWriter, request *http.Request) {
+					if request.Method != "GET" {
+						t.Fatalf("unexpected %s to %s", request.Method, request.URL)
+					}
+
+					writer.WriteHeader(200)
+				})
+
+				_, err := subject.Save(keychain, tagName, image)
+				require.NoError(t, err)
+			})
+		})
+
+		when("error", func() {
+			when("network", func() {
+				it.Before(func() {
+					handler.HandleFunc("/v2/", func(writer http.ResponseWriter, request *http.Request) {
+						writer.WriteHeader(http.StatusNotFound)
+					})
+				})
+				it("wraps it to NetworkError", func() {
+					assertNetworkErrorOn(t, true, func() error {
+						image := randomImage(t, 0)
+						_, err := subject.Save(keychain, tagName, image)
+						return err
+					})
+				})
 			})
 
-			_, err := subject.Save(keychain, tagName, image)
-			require.NoError(t, err)
+			when("unauthorized", func() {
+				it.Before(func() {
+					handler.HandleFunc("/v2/", func(writer http.ResponseWriter, request *http.Request) {
+						writer.WriteHeader(http.StatusUnauthorized)
+					})
+				})
+				it("doesn't wrap it to NetworkError", func() {
+					assertNetworkErrorOn(t, false, func() error {
+						image := randomImage(t, 0)
+						_, err := subject.Save(keychain, tagName, image)
+						return err
+					})
+				})
+			})
+
+			when("forbidden", func() {
+				it.Before(func() {
+					handler.HandleFunc("/v2/", func(writer http.ResponseWriter, request *http.Request) {
+						writer.WriteHeader(http.StatusForbidden)
+					})
+				})
+				it("doesn't wrap it to NetworkError", func() {
+					assertNetworkErrorOn(t, false, func() error {
+						image := randomImage(t, 0)
+						_, err := subject.Save(keychain, tagName, image)
+						return err
+					})
+				})
+			})
 		})
 	})
 }
@@ -181,4 +278,15 @@ func randomImage(t *testing.T, layers int64) v1.Image {
 	image, err := random.Image(5, layers)
 	require.NoError(t, err)
 	return image
+}
+
+func assertNetworkErrorOn(t *testing.T, expected bool, fn func() error) {
+	err := fn()
+	require.Error(t, err)
+	var networkError *reconciler.NetworkError
+	if expected {
+		require.True(t, errors.As(err, &networkError))
+	} else {
+		require.False(t, errors.As(err, &networkError))
+	}
 }


### PR DESCRIPTION
### Solution

A new *NetworkErrorReconciler* struct was created to wrapped the existing Reconciler for:
 - BuilderReconciler
 - ClusterBuilderReconciler
 - ClusterStackReconciler
 - ClusterStoreReconciler

The client library that is accessing the Registries (currently using GGCR library) wraps any network error with a new error type.
The *NetworkErrorReconciler* verifies if the error thrown by its wrapping Reconcilers is a network error, in such as case, it will re-queue the task otherwise it will behave as it is right now

Fixes #550 

Signed-off-by: Juan Bustamante <jbustamante@vmware.com>