### PR TITLE
Add workaround to fix regression

### DIFF
--- a/pkg/dockercreds/k8sdockercreds/azurecredentialhelperfix/keychain.go
+++ b/pkg/dockercreds/k8sdockercreds/azurecredentialhelperfix/keychain.go
@@ -1,0 +1,68 @@
+package azurecredentialhelperfix
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	credentialprovider "github.com/vdemeester/k8s-pkg-credentialprovider"
+)
+
+var (
+	once    sync.Once
+	keyring credentialprovider.DockerKeyring
+)
+
+func AzureFileKeychain() authn.Keychain {
+	once.Do(func() {
+		keyring = credentialprovider.NewDockerKeyring()
+	})
+
+	return &keychain{keyring: keyring}
+}
+
+// Copied from https://github.com/google/go-containerregistry/blob/d9bfbcb99e526b2a9417160e209b816e1b1fb6bd/pkg/authn/k8schain/k8schain.go#L141
+type lazyProvider struct {
+	kc    *keychain
+	image string
+}
+
+// Authorization implements Authenticator.
+func (lp lazyProvider) Authorization() (*authn.AuthConfig, error) {
+	creds, found := lp.kc.keyring.Lookup(lp.image)
+	if !found || len(creds) < 1 {
+		return nil, fmt.Errorf("keychain returned no credentials for %q", lp.image)
+	}
+	authConfig := creds[0]
+	return &authn.AuthConfig{
+		Username:      authConfig.Username,
+		Password:      authConfig.Password,
+		Auth:          authConfig.Auth,
+		IdentityToken: authConfig.IdentityToken,
+		RegistryToken: authConfig.RegistryToken,
+	}, nil
+}
+
+type keychain struct {
+	keyring credentialprovider.DockerKeyring
+}
+
+// Resolve implements authn.Keychain
+func (kc *keychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	var image string
+	if repo, ok := target.(name.Repository); ok {
+		image = repo.String()
+	} else {
+		// Lookup expects an image reference and we only have a registry.
+		image = target.RegistryStr() + "/foo/bar"
+	}
+
+	if creds, found := kc.keyring.Lookup(image); !found || len(creds) < 1 {
+		return authn.Anonymous, nil
+	}
+	return lazyProvider{
+		kc:    kc,
+		image: image,
+	}, nil
+}

--- a/pkg/dockercreds/k8sdockercreds/azurecredentialhelperfix/setup.go
+++ b/pkg/dockercreds/k8sdockercreds/azurecredentialhelperfix/setup.go
@@ -1,4 +1,4 @@
-package setup
+package azurecredentialhelperfix
 
 import (
 	_ "github.com/vdemeester/k8s-pkg-credentialprovider/azure"

--- a/pkg/dockercreds/k8sdockercreds/k8s_keychain.go
+++ b/pkg/dockercreds/k8sdockercreds/k8s_keychain.go
@@ -34,7 +34,7 @@ func NewSecretKeychainFactory(client k8sclient.Interface) (*k8sSecretKeychainFac
 
 func (f *k8sSecretKeychainFactory) KeychainForSecretRef(ctx context.Context, ref registry.SecretRef) (authn.Keychain, error) {
 	if !ref.IsNamespaced() {
-		k8sKeychain, err := k8schain.NewNoClient(context.Background())
+		k8sKeychain, err := NewNoClient(context.Background())
 		if err != nil {
 			return nil, err
 		}
@@ -46,7 +46,7 @@ func (f *k8sSecretKeychainFactory) KeychainForSecretRef(ctx context.Context, ref
 		return nil, err
 	}
 
-	k8sKeychain, err := k8schain.New(ctx, f.client, k8schain.Options{
+	k8sKeychain, err := New(ctx, f.client, k8schain.Options{
 		Namespace:          ref.Namespace,
 		ServiceAccountName: ref.ServiceAccount,
 		ImagePullSecrets:   toStringPullSecrets(ref.ImagePullSecrets),

--- a/pkg/dockercreds/k8sdockercreds/k8s_keychain_test.go
+++ b/pkg/dockercreds/k8sdockercreds/k8s_keychain_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/google/go-containerregistry/pkg/authn/k8schain"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/sclevine/spec"
 	"github.com/stretchr/testify/assert"
@@ -270,7 +269,7 @@ func testK8sSecretKeychainFactory(t *testing.T, when spec.G, it spec.S) {
 			})
 			require.NoError(t, err)
 
-			k8sKeychain, err := k8schain.NewNoClient(context.Background())
+			k8sKeychain, err := NewNoClient(context.Background())
 			require.NoError(t, err)
 			volumeKeyChain := dockercreds.DockerCreds{}
 			expected := authn.NewMultiKeychain(volumeKeyChain, k8sKeychain)

--- a/pkg/dockercreds/k8sdockercreds/keychain.go
+++ b/pkg/dockercreds/k8sdockercreds/keychain.go
@@ -1,0 +1,74 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sdockercreds
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+
+	ecr "github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
+	"github.com/chrismellard/docker-credential-acr-env/pkg/credhelper"
+	"github.com/google/go-containerregistry/pkg/authn"
+	kauth "github.com/google/go-containerregistry/pkg/authn/kubernetes"
+	"github.com/google/go-containerregistry/pkg/v1/google"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/pivotal/kpack/pkg/dockercreds/k8sdockercreds/azurecredentialhelperfix"
+)
+
+// Copied from https://github.com/google/go-containerregistry/blob/main/pkg/authn/k8schain/k8schain.go
+// This allows us to support AZURE_CONTAINER_REGISTRY_CONFIG
+
+var (
+	amazonKeychain authn.Keychain = authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithLogger(ioutil.Discard)))
+	azureKeychain  authn.Keychain = authn.NewKeychainFromHelper(credhelper.NewACRCredentialsHelper())
+)
+
+// Options holds configuration data for guiding credential resolution.
+type Options = kauth.Options
+
+// New returns a new authn.Keychain suitable for resolving image references as
+// scoped by the provided Options.  It speaks to Kubernetes through the provided
+// client interface.
+func New(ctx context.Context, client kubernetes.Interface, opt Options) (authn.Keychain, error) {
+	if os.Getenv("AZURE_CONTAINER_REGISTRY_CONFIG") != "" {
+		azureKeychain = authn.NewMultiKeychain(azurecredentialhelperfix.AzureFileKeychain(), azureKeychain)
+	}
+	k8s, err := kauth.New(ctx, client, kauth.Options(opt))
+	if err != nil {
+		return nil, err
+	}
+
+	return authn.NewMultiKeychain(
+		k8s,
+		authn.DefaultKeychain,
+		google.Keychain,
+		amazonKeychain,
+		azureKeychain,
+	), nil
+}
+
+func NewNoClient(ctx context.Context) (authn.Keychain, error) {
+	if os.Getenv("AZURE_CONTAINER_REGISTRY_CONFIG") != "" {
+		azureKeychain = authn.NewMultiKeychain(azurecredentialhelperfix.AzureFileKeychain(), azureKeychain)
+	}
+	return authn.NewMultiKeychain(
+		authn.DefaultKeychain,
+		google.Keychain,
+		amazonKeychain,
+		azureKeychain,
+	), nil
+}


### PR DESCRIPTION
- Bring back support for AZURE_CONTAINER_REGISTRY_CONFIG auth with acr

POC for supporting `AZURE_CONTAINER_REGISTRY_CONFIG`