### PR TITLE
Utilize lifecycle 0.14.3

### DIFF
--- a/hack/lifecycle/main.go
+++ b/hack/lifecycle/main.go
@@ -33,7 +33,7 @@ import (
 const (
 	lifecycleMetadataLabel = "io.buildpacks.lifecycle.metadata"
 	lifecycleLocation      = "/cnb/lifecycle/"
-	lifecycleVersion       = "0.14.2"
+	lifecycleVersion       = "0.14.3"
 )
 
 var (
@@ -256,7 +256,7 @@ func download(filepath string, url string) error {
 	return err
 }
 
-//copied from github.com/docker/docker/pkg/ioutils
+// copied from github.com/docker/docker/pkg/ioutils
 type ReadCloserWrapper struct {
 	io.Reader
 	closer func() error


### PR DESCRIPTION
- https://github.com/buildpacks/lifecycle/releases/tag/v0.14.3
- Lifecycle is built with go@1.18.7