### PR TITLE
Git: parse short scp-like syntax into proper SSH URLs

### DIFF
--- a/pkg/git/fetch.go
+++ b/pkg/git/fetch.go
@@ -24,7 +24,7 @@ func (f Fetcher) Fetch(dir, gitURL, gitRevision, metadataDir string) error {
 	}
 	defer repository.Free()
 
-	remote, err := repository.Remotes.CreateWithOptions(gitURL, &git2go.RemoteCreateOptions{
+	remote, err := repository.Remotes.CreateWithOptions(parseURL(gitURL), &git2go.RemoteCreateOptions{
 		Name:  "origin",
 		Flags: git2go.RemoteCreateSkipInsteadof,
 	})

--- a/pkg/git/remote_git_resolver.go
+++ b/pkg/git/remote_git_resolver.go
@@ -33,7 +33,7 @@ func (*remoteGitResolver) Resolve(keychain GitKeychain, sourceConfig corev1alpha
 	}
 	defer repository.Free()
 
-	remote, err := repository.Remotes.CreateWithOptions(sourceConfig.Git.URL, &git2go.RemoteCreateOptions{
+	remote, err := repository.Remotes.CreateWithOptions(parseURL(sourceConfig.Git.URL), &git2go.RemoteCreateOptions{
 		Name:  defaultRemote,
 		Flags: git2go.RemoteCreateSkipInsteadof,
 	})

--- a/pkg/git/url_parser.go
+++ b/pkg/git/url_parser.go
@@ -1,0 +1,26 @@
+package git
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var shortScpRegex = regexp.MustCompile(`^(ssh://)?(.*)@([[:alnum:]\.-]+):(.*)$`)
+
+// ParseURL converts a short scp-like SSH syntax to a proper SSH URL.
+// Git's ssh protocol supports a url like user@hostname:path syntax, which is
+// not a valid ssh url but is inherited from scp. Because the library we
+// use for git relies on the Golang SSH support, we need to convert it to a
+// proper SSH URL.
+// See https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols
+func parseURL(url string) string {
+	parts := shortScpRegex.FindStringSubmatch(url)
+	if len(parts) == 0 {
+		return url
+	}
+	if parts[1] == "ssh://" {
+		return url
+	}
+
+	return fmt.Sprintf("ssh://%v@%v/%v", parts[2], parts[3], parts[4])
+}

--- a/pkg/git/url_parser_test.go
+++ b/pkg/git/url_parser_test.go
@@ -1,0 +1,59 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseURL(t *testing.T) {
+	spec.Focus(t, "Test Parse Git URL", testParseURL)
+}
+
+func testParseURL(t *testing.T, when spec.G, it spec.S) {
+	type entry struct {
+		url      string
+		expected string
+	}
+
+	testURLs := func(table []entry) {
+		for _, e := range table {
+			assert.Equal(t, e.expected, parseURL(e.url))
+		}
+	}
+
+	// https: //stackoverflow.com/questions/31801271/what-are-the-supported-git-url-formats
+	when("using the local protcol", func() {
+		it("parses the url correctly", func() {
+			testURLs([]entry{
+				{url: "/path/to/repo.git", expected: "/path/to/repo.git"},
+				{url: "file:///path/to/repo.git", expected: "file:///path/to/repo.git"},
+			})
+		})
+	})
+	when("using the https protcol", func() {
+		it("parses the url correctly", func() {
+			testURLs([]entry{
+				{url: "http://host.xz/path/to/repo.git", expected: "http://host.xz/path/to/repo.git"},
+				{url: "https://host.xz/path/to/repo.git", expected: "https://host.xz/path/to/repo.git"},
+			})
+		})
+	})
+	when("using the ssh protcol", func() {
+		it("parses the url correctly", func() {
+			testURLs([]entry{
+				{url: "ssh://user@host.xz:port/path/to/repo.git/", expected: "ssh://user@host.xz:port/path/to/repo.git/"},
+				{url: "ssh://user@host.xz/path/to/repo.git/", expected: "ssh://user@host.xz/path/to/repo.git/"},
+				{url: "user@host.xz:path/to/repo.git", expected: "ssh://user@host.xz/path/to/repo.git"},
+			})
+		})
+	})
+	when("using the git protcol", func() {
+		it("parses the url correctly", func() {
+			testURLs([]entry{
+				{url: "git://host.xz/path/to/repo.git", expected: "git://host.xz/path/to/repo.git"},
+			})
+		})
+	})
+}


### PR DESCRIPTION
fixes #1066

Parse all git URLs before passing to git2go. The parser will convert any short scp-like syntax to proper SSH style ones and leave all other URLs the same.