### PR TITLE
Update common.sh build script to use proper env vars

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -35,7 +35,7 @@ function compile() {
   completion_image=${IMAGE_PREFIX}completion
   lifecycle_image=${IMAGE_PREFIX}lifecycle
 
-  pack_build ${controller_image} "./cmd/controller" -e BP_BUILD_LIBGIT2=true -e BP_GO_BUILD_FLAGS='-tags="static"'
+  pack_build ${controller_image} "./cmd/controller" -e BP_GIT2GO_ENABLED=true -e BP_GIT2GO_USE_LIBSSL=true
   controller_image=${resolved_image_name}
 
   pack_build ${build_waiter_image} "./cmd/build-waiter"
@@ -44,7 +44,7 @@ function compile() {
   pack_build ${webhook_image} "./cmd/webhook"
   webhook_image=${resolved_image_name}
 
-  pack_build ${build_init_image} "./cmd/build-init" -e BP_BUILD_LIBGIT2=true -e BP_GO_BUILD_FLAGS='-tags="static"'
+  pack_build ${build_init_image} "./cmd/build-init" -e BP_GIT2GO_ENABLED=true -e BP_GIT2GO_USE_LIBSSL=true
   build_init_image=${resolved_image_name}
 
   pack_build ${rebase_image} "./cmd/rebase"


### PR DESCRIPTION
parity of https://github.com/pivotal/build-service-ci/commit/35e96bb8e9c8ffcc3edfbf81550c035f5d8ed261