### PR TITLE
Update duckbuilder informer to have seperate builder event handlers

### DIFF
--- a/pkg/duckbuilder/informer.go
+++ b/pkg/duckbuilder/informer.go
@@ -15,8 +15,11 @@ type DuckBuilderInformer struct {
 	ClusterBuilderInformer buildinformers.ClusterBuilderInformer
 }
 
-func (di *DuckBuilderInformer) AddEventHandler(handler cache.ResourceEventHandler) {
+func (di *DuckBuilderInformer) AddBuilderEventHandler(handler cache.ResourceEventHandler) {
 	di.BuilderInformer.Informer().AddEventHandler(handler)
+}
+
+func (di *DuckBuilderInformer) AddClusterBuilderEventHandler(handler cache.ResourceEventHandler) {
 	di.ClusterBuilderInformer.Informer().AddEventHandler(handler)
 }
 

--- a/pkg/duckbuilder/informer_test.go
+++ b/pkg/duckbuilder/informer_test.go
@@ -137,17 +137,29 @@ func testDuckBuilderInformer(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
-	when("#AddEventHandler", func() {
-		it("adds the event handler to each builder's informer", func() {
+	when("#AddClusterBuilderEventHandler", func() {
+		it("adds the event handler to cluster builder's informer", func() {
 			testHandler := &testHandler{}
-			subject.AddEventHandler(testHandler)
+			subject.AddClusterBuilderEventHandler(testHandler)
 
 			assert.Eventually(t, func() bool {
-				return len(testHandler.added) == 2
+				return len(testHandler.added) == 1
+			}, 5*time.Second, time.Millisecond)
+
+			assert.Contains(t, testHandler.added, clusterBuilder)
+		})
+	})
+
+	when("#AddBuilderEventHandler", func() {
+		it("adds the event handler to  builder's informer", func() {
+			testHandler := &testHandler{}
+			subject.AddBuilderEventHandler(testHandler)
+
+			assert.Eventually(t, func() bool {
+				return len(testHandler.added) == 1
 			}, 5*time.Second, time.Millisecond)
 
 			assert.Contains(t, testHandler.added, builder)
-			assert.Contains(t, testHandler.added, clusterBuilder)
 		})
 	})
 }


### PR DESCRIPTION
- Needed to ensure Type metadata is included
- Also fix bug in tracker namespace when builder is clusterbuilder