### PR TITLE
Use parsed ssh username if git2go does not provide one

### DIFF
--- a/pkg/git/git_keychain.go
+++ b/pkg/git/git_keychain.go
@@ -161,6 +161,10 @@ func (k *secretGitKeychain) Resolve(url string, username string, allowedTypes gi
 		return nil, err
 	}
 
+	if username == "" {
+		username = u.User.Username()
+	}
+
 	sort.Slice(k.creds, func(i, j int) bool { return k.creds[i].name() < k.creds[j].name() })
 
 	for _, cred := range k.creds {

--- a/pkg/git/git_keychain_test.go
+++ b/pkg/git/git_keychain_test.go
@@ -32,6 +32,7 @@ func testGitFileKeychain(t *testing.T, when spec.G, it spec.S) {
 		require.NoError(t, os.MkdirAll(path.Join(testDir, "basic-bitbucket-creds"), 0777))
 		require.NoError(t, os.MkdirAll(path.Join(testDir, "zzz-ssh-bitbucket-creds"), 0777))
 		require.NoError(t, os.MkdirAll(path.Join(testDir, "noscheme-creds"), 0777))
+		require.NoError(t, os.MkdirAll(path.Join(testDir, "git-ssh-creds"), 0777))
 
 		require.NoError(t, ioutil.WriteFile(path.Join(testDir, "github-creds", corev1.BasicAuthUsernameKey), []byte("saved-username"), 0600))
 		require.NoError(t, ioutil.WriteFile(path.Join(testDir, "github-creds", corev1.BasicAuthPasswordKey), []byte("saved-password"), 0600))
@@ -41,6 +42,7 @@ func testGitFileKeychain(t *testing.T, when spec.G, it spec.S) {
 
 		require.NoError(t, ioutil.WriteFile(path.Join(testDir, "bitbucket-creds", corev1.SSHAuthPrivateKey), []byte("private key 1"), 0600))
 		require.NoError(t, ioutil.WriteFile(path.Join(testDir, "zzz-ssh-bitbucket-creds", corev1.SSHAuthPrivateKey), []byte("private key 2"), 0600))
+		require.NoError(t, ioutil.WriteFile(path.Join(testDir, "git-ssh-creds", corev1.SSHAuthPrivateKey), []byte("private key 3"), 0600))
 		require.NoError(t, ioutil.WriteFile(path.Join(testDir, "basic-bitbucket-creds", corev1.BasicAuthUsernameKey), []byte("saved-username"), 0600))
 		require.NoError(t, ioutil.WriteFile(path.Join(testDir, "basic-bitbucket-creds", corev1.BasicAuthPasswordKey), []byte("saved-password"), 0600))
 
@@ -100,6 +102,18 @@ func testGitFileKeychain(t *testing.T, when spec.G, it spec.S) {
 		it("returns an error if no credentials found", func() {
 			_, err := keychain.Resolve("https://no-creds-github.com/org/repo", "git", git2go.CredentialTypeUserpassPlaintext)
 			require.EqualError(t, err, "no credentials found for https://no-creds-github.com/org/repo")
+		})
+
+		when("ssh usernameFromUrl is empty during credential callback", func() {
+			it("determines correct username", func() {
+				gitKeychain, err := NewMountedSecretGitKeychain(testDir, []string{}, []string{
+					"git-ssh-creds=git@my-git-server.com",
+				})
+				cred, err := gitKeychain.Resolve("ssh://git@my-git-server.com/my-org/my-repo.git", "", git2go.CredentialTypeSSHKey)
+				require.NoError(t, err)
+
+				require.Equal(t, SSHGit2GoAuth{Username: "git", PrivateKey: "private key 3"}, cred)
+			})
 		})
 	})
 }


### PR DESCRIPTION
This is required because git2go is unable to parse the username when calling `remote.Fetch` with the go ssh transport