### PR TITLE
Add builder condition context to image status

### DIFF
--- a/pkg/apis/build/v1alpha2/builder_resource.go
+++ b/pkg/apis/build/v1alpha2/builder_resource.go
@@ -9,4 +9,5 @@ type BuilderResource interface {
 	BuildpackMetadata() corev1alpha1.BuildpackMetadataList
 	RunImage() string
 	GetKind() string
+	ConditionReadyMessage() string
 }

--- a/pkg/apis/build/v1alpha2/image_builds_test.go
+++ b/pkg/apis/build/v1alpha2/image_builds_test.go
@@ -380,6 +380,10 @@ type TestBuilderResource struct {
 	Name             string
 }
 
+func (t TestBuilderResource) ConditionReadyMessage() string {
+	return ""
+}
+
 func (t TestBuilderResource) BuildBuilderSpec() corev1alpha1.BuildBuilderSpec {
 	return corev1alpha1.BuildBuilderSpec{
 		Image:            t.LatestImage,

--- a/pkg/duckbuilder/duck_builder.go
+++ b/pkg/duckbuilder/duck_builder.go
@@ -47,3 +47,12 @@ func (b *DuckBuilder) BuildpackMetadata() corev1alpha1.BuildpackMetadataList {
 func (b *DuckBuilder) RunImage() string {
 	return b.Status.Stack.RunImage
 }
+
+func (b *DuckBuilder) ConditionReadyMessage() string {
+	condition := b.Status.GetCondition(corev1alpha1.ConditionReady)
+	if condition == nil {
+		return ""
+	}
+
+	return condition.Message
+}

--- a/pkg/reconciler/image/build_required_test.go
+++ b/pkg/reconciler/image/build_required_test.go
@@ -833,3 +833,7 @@ func (t TestBuilderResource) GetName() string {
 func (t TestBuilderResource) GetKind() string {
 	return t.Kind
 }
+
+func (t TestBuilderResource) ConditionReadyMessage() string {
+	return ""
+}

--- a/pkg/reconciler/image/reconcile_build.go
+++ b/pkg/reconciler/image/reconcile_build.go
@@ -112,7 +112,7 @@ func builderCondition(builder buildapi.BuilderResource) corev1alpha1.Condition {
 			Type:               buildapi.ConditionBuilderReady,
 			Status:             corev1.ConditionFalse,
 			Reason:             buildapi.BuilderNotReady,
-			Message:            fmt.Sprintf("Builder %s is not ready", builder.GetName()),
+			Message:            builderError(builder),
 			LastTransitionTime: corev1alpha1.VolatileTime{Inner: metav1.Now()},
 		}
 	}
@@ -121,6 +121,16 @@ func builderCondition(builder buildapi.BuilderResource) corev1alpha1.Condition {
 		Status:             corev1.ConditionTrue,
 		LastTransitionTime: corev1alpha1.VolatileTime{Inner: metav1.Now()},
 	}
+}
+
+func builderError(builder buildapi.BuilderResource) string {
+	errorMessage := fmt.Sprintf("Builder %s is not ready", builder.GetName())
+
+	if message := builder.ConditionReadyMessage(); message != "" {
+		errorMessage = fmt.Sprintf("%s: %s", errorMessage, message)
+	}
+
+	return errorMessage
 }
 
 func scheduledBuildCondition(build *buildapi.Build) corev1alpha1.Conditions {


### PR DESCRIPTION
Improve the error message when the cluster stack or cluster store has been deleted or not ready

Co-authored-by: Yael harel <yharel@vmware.com>