### PR TITLE
Bump kpack controller memory requests and limits

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -141,7 +141,6 @@ spec:
         resources:
           requests:
             cpu: 20m
-            memory: 100Mi
+            memory: 1Gi
           limits:
-            cpu: 100m
-            memory: 500Mi
+            memory: 1Gi


### PR DESCRIPTION
- This will allow kpack to handle larger amounts of images and other resources
- Also remove the cpu limit because it is a compressible resource