### PR TITLE
Inline the `image` field for ClusterBuildpack

### DIFF
--- a/pkg/apis/build/v1alpha2/cluster_buildpack_types.go
+++ b/pkg/apis/build/v1alpha2/cluster_buildpack_types.go
@@ -29,7 +29,7 @@ type ClusterBuildpack struct {
 // +k8s:openapi-gen=true
 type ClusterBuildpackSpec struct {
 	// +listType
-	corev1alpha1.ImageSource `json:"source,omitempty"`
+	corev1alpha1.ImageSource `json:",inline"`
 	ServiceAccountRef        *corev1.ObjectReference `json:"serviceAccountRef,omitempty"`
 }
 

--- a/pkg/apis/build/v1alpha2/cluster_buildpack_validation.go
+++ b/pkg/apis/build/v1alpha2/cluster_buildpack_validation.go
@@ -24,5 +24,5 @@ func (s *ClusterBuildpackSpec) Validate(ctx context.Context) *apis.FieldError {
 		}
 	}
 
-	return validate.Image(s.Image).ViaField()
+	return validate.Image(s.Image)
 }


### PR DESCRIPTION
This is what the Buildpack resource do and what the docs and rfc both say.