### PR TITLE
Improve kpack conditions

### DIFF
--- a/pkg/apis/build/v1alpha2/image_lifecycle.go
+++ b/pkg/apis/build/v1alpha2/image_lifecycle.go
@@ -12,6 +12,7 @@ import (
 const (
 	BuilderNotFound = "BuilderNotFound"
 	BuilderNotReady = "BuilderNotReady"
+	BuilderReady    = "BuilderReady"
 )
 
 func (im *Image) BuilderNotFound() corev1alpha1.Conditions {

--- a/pkg/reconciler/image/image_test.go
+++ b/pkg/reconciler/image/image_test.go
@@ -796,8 +796,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 										ObservedGeneration: originalGeneration,
 										Conditions: corev1alpha1.Conditions{
 											{
-												Type:   corev1alpha1.ConditionReady,
-												Status: corev1.ConditionUnknown,
+												Type:    corev1alpha1.ConditionReady,
+												Status:  corev1.ConditionFalse,
+												Reason:  buildapi.BuilderNotReady,
+												Message: "Builder builder-name is not ready: something went wrong",
 											},
 											{
 												Type:    buildapi.ConditionBuilderReady,
@@ -2106,6 +2108,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 											{
 												Type:   buildapi.ConditionBuilderReady,
 												Status: corev1.ConditionTrue,
+												Reason: buildapi.BuilderReady,
 											},
 										},
 									},
@@ -2168,10 +2171,12 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 										{
 											Type:   corev1alpha1.ConditionSucceeded,
 											Status: corev1.ConditionTrue,
+											Reason: image.UpToDateReason,
 										},
 										{
 											Type:   buildapi.ConditionBuilderReady,
 											Status: corev1.ConditionTrue,
+											Reason: buildapi.BuilderReady,
 										},
 									},
 								},
@@ -2210,10 +2215,12 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 											{
 												Type:   corev1alpha1.ConditionReady,
 												Status: corev1.ConditionTrue,
+												Reason: image.UpToDateReason,
 											},
 											{
 												Type:   buildapi.ConditionBuilderReady,
 												Status: corev1.ConditionTrue,
+												Reason: buildapi.BuilderReady,
 											},
 										},
 									},
@@ -2265,7 +2272,7 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 				})
 			})
 
-			it("reports unknown when last build was successful and builder is not ready", func() {
+			it("reports false when last build was successful and builder is not ready", func() {
 				imageWithBuilder.Status.BuildCounter = 1
 				imageWithBuilder.Status.LatestBuildRef = "image-name-build-1"
 				imageWithBuilder.Status.LatestImage = "some/image@some-old-sha"
@@ -2291,8 +2298,10 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 										ObservedGeneration: originalGeneration,
 										Conditions: corev1alpha1.Conditions{
 											{
-												Type:   corev1alpha1.ConditionReady,
-												Status: corev1.ConditionUnknown,
+												Type:    corev1alpha1.ConditionReady,
+												Status:  corev1.ConditionFalse,
+												Reason:  buildapi.BuilderNotReady,
+												Message: "Builder builder-name is not ready",
 											},
 											{
 												Type:    buildapi.ConditionBuilderReady,
@@ -2377,11 +2386,13 @@ func testImageReconciler(t *testing.T, when spec.G, it spec.S) {
 											{
 												Type:    corev1alpha1.ConditionReady,
 												Status:  corev1.ConditionFalse,
+												Reason:  image.BuildFailedReason,
 												Message: failureMessage,
 											},
 											{
 												Type:   buildapi.ConditionBuilderReady,
 												Status: corev1.ConditionTrue,
+												Reason: buildapi.BuilderReady,
 											},
 										},
 									},
@@ -2594,11 +2605,13 @@ func conditionReadyUnknown() corev1alpha1.Conditions {
 		{
 			Type:    corev1alpha1.ConditionReady,
 			Status:  corev1.ConditionUnknown,
+			Reason:  image.ResolverNotReadyReason,
 			Message: "SourceResolver image-name-source is not ready",
 		},
 		{
 			Type:   buildapi.ConditionBuilderReady,
 			Status: corev1.ConditionTrue,
+			Reason: buildapi.BuilderReady,
 		},
 	}
 }
@@ -2608,11 +2621,13 @@ func conditionBuildExecuting(buildName string) corev1alpha1.Conditions {
 		{
 			Type:    corev1alpha1.ConditionReady,
 			Status:  corev1.ConditionUnknown,
+			Reason:  image.BuildRunningReason,
 			Message: fmt.Sprintf("%s is executing", buildName),
 		},
 		{
 			Type:   buildapi.ConditionBuilderReady,
 			Status: corev1.ConditionTrue,
+			Reason: buildapi.BuilderReady,
 		},
 	}
 }
@@ -2622,10 +2637,12 @@ func conditionReady() corev1alpha1.Conditions {
 		{
 			Type:   corev1alpha1.ConditionReady,
 			Status: corev1.ConditionTrue,
+			Reason: image.UpToDateReason,
 		},
 		{
 			Type:   buildapi.ConditionBuilderReady,
 			Status: corev1.ConditionTrue,
+			Reason: buildapi.BuilderReady,
 		},
 	}
 }
@@ -2635,10 +2652,12 @@ func conditionNotReady() corev1alpha1.Conditions {
 		{
 			Type:   corev1alpha1.ConditionReady,
 			Status: corev1.ConditionFalse,
+			Reason: image.BuildFailedReason,
 		},
 		{
 			Type:   buildapi.ConditionBuilderReady,
 			Status: corev1.ConditionTrue,
+			Reason: buildapi.BuilderReady,
 		},
 	}
 }

--- a/pkg/reconciler/image/reconcile_build.go
+++ b/pkg/reconciler/image/reconcile_build.go
@@ -13,7 +13,12 @@ import (
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 )
 
-const BuildRunningReason = "BuildRunning"
+const (
+	BuildRunningReason     = "BuildRunning"
+	ResolverNotReadyReason = "ResolverNotReady"
+	BuildFailedReason      = "BuildFailed"
+	UpToDateReason         = "UpToDate"
+)
 
 func (c *Reconciler) reconcileBuild(ctx context.Context, image *buildapi.Image, latestBuild *buildapi.Build, sourceResolver *buildapi.SourceResolver, builder buildapi.BuilderResource, buildCacheName string) (buildapi.ImageStatus, error) {
 	currentBuildNumber, err := buildCounter(latestBuild)
@@ -55,7 +60,7 @@ func (c *Reconciler) reconcileBuild(ctx context.Context, image *buildapi.Image, 
 	case corev1.ConditionFalse:
 		return buildapi.ImageStatus{
 			Status: corev1alpha1.Status{
-				Conditions: noScheduledBuild(result.ConditionStatus, builder, latestBuild, sourceResolver),
+				Conditions: noScheduledBuild(result, builder, latestBuild, sourceResolver),
 			},
 			LatestBuildRef:             latestBuild.BuildRef(),
 			LatestBuildReason:          latestBuild.BuildReason(),
@@ -70,9 +75,21 @@ func (c *Reconciler) reconcileBuild(ctx context.Context, image *buildapi.Image, 
 	}
 }
 
-func noScheduledBuild(buildNeeded corev1.ConditionStatus, builder buildapi.BuilderResource, build *buildapi.Build, sourceResolver *buildapi.SourceResolver) corev1alpha1.Conditions {
-	if buildNeeded == corev1.ConditionUnknown {
-		message := ""
+func noScheduledBuild(buildNeeded buildRequiredResult, builder buildapi.BuilderResource, build *buildapi.Build, sourceResolver *buildapi.SourceResolver) corev1alpha1.Conditions {
+	if !builder.Ready() {
+		return corev1alpha1.Conditions{
+			{
+				Type:               corev1alpha1.ConditionReady,
+				Status:             corev1.ConditionFalse,
+				Reason:             buildapi.BuilderNotReady,
+				Message:            builderError(builder),
+				LastTransitionTime: corev1alpha1.VolatileTime{Inner: metav1.Now()},
+			},
+			builderCondition(builder),
+		}
+	}
+	if buildNeeded.ConditionStatus == corev1.ConditionUnknown {
+		message := "Build status unknown"
 		if !sourceResolver.Ready() {
 			message = fmt.Sprintf("SourceResolver %s is not ready", sourceResolver.GetName())
 		}
@@ -80,6 +97,7 @@ func noScheduledBuild(buildNeeded corev1.ConditionStatus, builder buildapi.Build
 			{
 				Type:               corev1alpha1.ConditionReady,
 				Status:             corev1.ConditionUnknown,
+				Reason:             ResolverNotReadyReason,
 				Message:            message,
 				LastTransitionTime: corev1alpha1.VolatileTime{Inner: metav1.Now()},
 			},
@@ -87,11 +105,20 @@ func noScheduledBuild(buildNeeded corev1.ConditionStatus, builder buildapi.Build
 		}
 	}
 
+	buildReason := UpToDateReason
+	buildMessage := "Last build succeeded"
+
+	if !build.Status.GetCondition(corev1alpha1.ConditionSucceeded).IsTrue() {
+		buildReason = BuildFailedReason
+		buildMessage = "Last build did not succeed"
+	}
+
 	return corev1alpha1.Conditions{
 		{
 			Type:               corev1alpha1.ConditionReady,
 			Status:             unknownStatusIfNil(build.Status.GetCondition(corev1alpha1.ConditionSucceeded)),
-			Message:            emptyMessageIfNil(build.Status.GetCondition(corev1alpha1.ConditionSucceeded)),
+			Reason:             buildReason,
+			Message:            defaultMessageIfNil(build.Status.GetCondition(corev1alpha1.ConditionSucceeded), buildMessage),
 			LastTransitionTime: corev1alpha1.VolatileTime{Inner: metav1.Now()},
 		},
 		builderCondition(builder),
@@ -106,9 +133,12 @@ func unknownStatusIfNil(condition *corev1alpha1.Condition) corev1.ConditionStatu
 	return condition.Status
 }
 
-func emptyMessageIfNil(condition *corev1alpha1.Condition) string {
+// Copies the message from the specified condition, or fills in a default message if nil.
+// We should always have a message for non-successful conditions, as that conveys
+// information to the user about what is expected.
+func defaultMessageIfNil(condition *corev1alpha1.Condition, defaultMessage string) string {
 	if condition == nil {
-		return ""
+		return defaultMessage
 	}
 	return condition.Message
 }
@@ -126,6 +156,7 @@ func builderCondition(builder buildapi.BuilderResource) corev1alpha1.Condition {
 	return corev1alpha1.Condition{
 		Type:               buildapi.ConditionBuilderReady,
 		Status:             corev1.ConditionTrue,
+		Reason:             buildapi.BuilderReady,
 		LastTransitionTime: corev1alpha1.VolatileTime{Inner: metav1.Now()},
 	}
 }
@@ -145,12 +176,14 @@ func scheduledBuildCondition(build *buildapi.Build) corev1alpha1.Conditions {
 		{
 			Type:               corev1alpha1.ConditionReady,
 			Status:             corev1.ConditionUnknown,
-			LastTransitionTime: corev1alpha1.VolatileTime{Inner: metav1.Now()},
+			Reason:             BuildRunningReason,
 			Message:            fmt.Sprintf("%s is executing", build.Name),
+			LastTransitionTime: corev1alpha1.VolatileTime{Inner: metav1.Now()},
 		},
 		{
 			Type:               buildapi.ConditionBuilderReady,
 			Status:             corev1.ConditionTrue,
+			Reason:             buildapi.BuilderReady,
 			LastTransitionTime: corev1alpha1.VolatileTime{Inner: metav1.Now()},
 		},
 	}
@@ -168,10 +201,11 @@ func buildCounter(build *buildapi.Build) (int64, error) {
 func buildRunningCondition(build *buildapi.Build, builder buildapi.BuilderResource) corev1alpha1.Conditions {
 	return corev1alpha1.Conditions{
 		{
-			Type:               corev1alpha1.ConditionReady,
-			Status:             corev1.ConditionUnknown,
-			Reason:             BuildRunningReason,
-			Message:            emptyMessageIfNil(build.Status.GetCondition(corev1alpha1.ConditionSucceeded)),
+			Type:   corev1alpha1.ConditionReady,
+			Status: corev1.ConditionUnknown,
+			Reason: BuildRunningReason,
+			Message: defaultMessageIfNil(build.Status.GetCondition(corev1alpha1.ConditionSucceeded),
+				fmt.Sprintf("%s is executing", build.Name)),
 			LastTransitionTime: corev1alpha1.VolatileTime{Inner: metav1.Now()},
 		},
 		builderCondition(builder),


### PR DESCRIPTION
Improve condition fields for kpack Images, particularly for use with [Cartographer health rules](https://cartographer.sh/docs/development/health-rules/#multi-match):

> When a matcher set is satisfied, the message field of the first condition will be replicated on the owner object.
(etc for single-condition matchers)

I also did a little cleanup, following the [Kubernetes API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties):

Conditions should always have 'reason' filled ("This field may not be empty").

Additionally, 'message' should be filled in for Unknown or Error conditions so that users know how to resolve the issue.  (Inspired by a question on how to represent "build in progress" status from the `tanzu apps` CLI.)

