### PR TITLE
fix: remove ClusterStore from sample ClusterBuilder

### DIFF
--- a/docs/builders.md
+++ b/docs/builders.md
@@ -98,9 +98,7 @@ spec:
     - name: sample-cluster-buildpack
       kind: ClusterBuildpack
       id: paketo-buildpacks/nodejs
-    - name: sample-cluster-store
-      kind: ClusterStore
-      id: paketo-buildpacks/nodejs
+    - id: paketo-buildpacks/nodejs # can obtain buildpacks from a Store/ClusterStore
       version: 1.2.3
 ```
 


### PR DESCRIPTION
### Changes
* Removed both name and kind from the ClusterStore reference in the `order` section of the sample ClusterBuilder, as those fields are unsupported when referencing a ClusterStore from which buildpacks should be obtained.

### Motivation
While following the docs on kpack, I noticed that with the latest `main` code I was not able to apply a ClusterBuilder that had a ClusterStore in the `order` section of the YAML:
```console
Error from server (BadRequest): error when creating "clusterbuilder.yaml": admission webhook "validation.webhook.kpack.io" denied the request: validation failed: invalid value: ClusterStore: order[2].group[1].kind
must be one of Buildpack, ClusterBuildpack
```

Upon removing the kind and name fields from the ClusterStore item, I was able to apply it correctly to the cluster.