### PR TITLE
Use keychain from clusterstack to pull build image in CreateBuild

### DIFF
--- a/pkg/cnb/create_builder.go
+++ b/pkg/cnb/create_builder.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
+
 	buildapi "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 	"github.com/pivotal/kpack/pkg/registry"
@@ -26,13 +27,8 @@ type RemoteBuilderCreator struct {
 	KeychainFactory   registry.KeychainFactory
 }
 
-func (r *RemoteBuilderCreator) CreateBuilder(
-	ctx context.Context,
-	builderKeychain authn.Keychain,
-	fetcher RemoteBuildpackFetcher,
-	clusterStack *buildapi.ClusterStack, spec buildapi.BuilderSpec,
-) (buildapi.BuilderRecord, error) {
-	buildImage, _, err := r.RegistryClient.Fetch(builderKeychain, clusterStack.Status.BuildImage.LatestImage)
+func (r *RemoteBuilderCreator) CreateBuilder(ctx context.Context, builderKeychain authn.Keychain, stackKeychain authn.Keychain, fetcher RemoteBuildpackFetcher, clusterStack *buildapi.ClusterStack, spec buildapi.BuilderSpec) (buildapi.BuilderRecord, error) {
+	buildImage, _, err := r.RegistryClient.Fetch(stackKeychain, clusterStack.Status.BuildImage.LatestImage)
 	if err != nil {
 		return buildapi.BuilderRecord{}, err
 	}

--- a/pkg/reconciler/builder/builder_test.go
+++ b/pkg/reconciler/builder/builder_test.go
@@ -85,6 +85,12 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 			Kind:       "ClusterStack",
 			APIVersion: "kpack.io/v1alpha2",
 		},
+		Spec: buildapi.ClusterStackSpec{
+			ServiceAccountRef: &corev1.ObjectReference{
+				Name:      "some-service-account",
+				Namespace: testNamespace,
+			},
+		},
 		Status: buildapi.ClusterStackStatus{
 			Status: corev1alpha1.Status{
 				ObservedGeneration: 0,
@@ -247,11 +253,12 @@ func testBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			assert.Equal(t, []testhelpers.CreateBuilderArgs{{
-				Context:      context.Background(),
-				Keychain:     &registryfakes.FakeKeychain{},
-				Fetcher:      expectedFetcher,
-				ClusterStack: clusterStack,
-				BuilderSpec:  builder.Spec.BuilderSpec,
+				Context:         context.Background(),
+				BuilderKeychain: &registryfakes.FakeKeychain{},
+				StackKeychain:   &registryfakes.FakeKeychain{},
+				Fetcher:         expectedFetcher,
+				ClusterStack:    clusterStack,
+				BuilderSpec:     builder.Spec.BuilderSpec,
 			}}, builderCreator.CreateBuilderCalls)
 		})
 

--- a/pkg/reconciler/clusterbuilder/clusterbuilder.go
+++ b/pkg/reconciler/clusterbuilder/clusterbuilder.go
@@ -34,7 +34,7 @@ const (
 )
 
 type BuilderCreator interface {
-	CreateBuilder(ctx context.Context, keychain authn.Keychain, fetcher cnb.RemoteBuildpackFetcher, clusterStack *buildapi.ClusterStack, spec buildapi.BuilderSpec) (buildapi.BuilderRecord, error)
+	CreateBuilder(ctx context.Context, builderKeychain authn.Keychain, stackKeychain authn.Keychain, fetcher cnb.RemoteBuildpackFetcher, clusterStack *buildapi.ClusterStack, spec buildapi.BuilderSpec) (buildapi.BuilderRecord, error)
 }
 
 func NewController(
@@ -188,7 +188,7 @@ func (c *Reconciler) reconcileBuilder(ctx context.Context, builder *buildapi.Clu
 		return buildapi.BuilderRecord{}, errors.Errorf("stack %s is not ready", clusterStack.Name)
 	}
 
-	keychain, err := c.KeychainFactory.KeychainForSecretRef(ctx, registry.SecretRef{
+	builderKeychain, err := c.KeychainFactory.KeychainForSecretRef(ctx, registry.SecretRef{
 		ServiceAccount: builder.Spec.ServiceAccountRef.Name,
 		Namespace:      builder.Spec.ServiceAccountRef.Namespace,
 	})
@@ -196,9 +196,20 @@ func (c *Reconciler) reconcileBuilder(ctx context.Context, builder *buildapi.Clu
 		return buildapi.BuilderRecord{}, err
 	}
 
+	stackKeychain := builderKeychain
+	if clusterStack.Spec.ServiceAccountRef != nil {
+		stackKeychain, err = c.KeychainFactory.KeychainForSecretRef(ctx, registry.SecretRef{
+			ServiceAccount: clusterStack.Spec.ServiceAccountRef.Name,
+			Namespace:      clusterStack.Spec.ServiceAccountRef.Namespace,
+		})
+		if err != nil {
+			return buildapi.BuilderRecord{}, err
+		}
+	}
+
 	fetcher := cnb.NewRemoteBuildpackFetcher(c.KeychainFactory, clusterStore, nil, clusterBuildpacks)
 
-	buildRecord, err := c.BuilderCreator.CreateBuilder(ctx, keychain, fetcher, clusterStack, builder.Spec.BuilderSpec)
+	buildRecord, err := c.BuilderCreator.CreateBuilder(ctx, builderKeychain, stackKeychain, fetcher, clusterStack, builder.Spec.BuilderSpec)
 	if err != nil {
 		return buildapi.BuilderRecord{}, err
 	}

--- a/pkg/reconciler/clusterbuilder/clusterbuilder_test.go
+++ b/pkg/reconciler/clusterbuilder/clusterbuilder_test.go
@@ -83,6 +83,12 @@ func testClusterBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 			Kind:       "ClusterStack",
 			APIVersion: "kpack.io/v1alpha2",
 		},
+		Spec: buildapi.ClusterStackSpec{
+			ServiceAccountRef: &corev1.ObjectReference{
+				Namespace: "some-sa-namespace",
+				Name:      "some-sa-name",
+			},
+		},
 		Status: buildapi.ClusterStackStatus{
 			Status: corev1alpha1.Status{
 				ObservedGeneration: 0,
@@ -243,11 +249,12 @@ func testClusterBuilderReconciler(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			assert.Equal(t, []testhelpers.CreateBuilderArgs{{
-				Context:      context.Background(),
-				Keychain:     &registryfakes.FakeKeychain{},
-				Fetcher:      expectedFetcher,
-				ClusterStack: clusterStack,
-				BuilderSpec:  builder.Spec.BuilderSpec,
+				Context:         context.Background(),
+				BuilderKeychain: &registryfakes.FakeKeychain{},
+				StackKeychain:   &registryfakes.FakeKeychain{},
+				Fetcher:         expectedFetcher,
+				ClusterStack:    clusterStack,
+				BuilderSpec:     builder.Spec.BuilderSpec,
 			}}, builderCreator.CreateBuilderCalls)
 		})
 

--- a/pkg/reconciler/testhelpers/fake_builder_creator.go
+++ b/pkg/reconciler/testhelpers/fake_builder_creator.go
@@ -19,20 +19,22 @@ type FakeBuilderCreator struct {
 }
 
 type CreateBuilderArgs struct {
-	Context      context.Context
-	Keychain     authn.Keychain
-	Fetcher      cnb.RemoteBuildpackFetcher
-	ClusterStack *buildapi.ClusterStack
-	BuilderSpec  buildapi.BuilderSpec
+	Context         context.Context
+	BuilderKeychain authn.Keychain
+	StackKeychain   authn.Keychain
+	Fetcher         cnb.RemoteBuildpackFetcher
+	ClusterStack    *buildapi.ClusterStack
+	BuilderSpec     buildapi.BuilderSpec
 }
 
-func (f *FakeBuilderCreator) CreateBuilder(ctx context.Context, keychain authn.Keychain, fetcher cnb.RemoteBuildpackFetcher, clusterStack *buildapi.ClusterStack, builder buildapi.BuilderSpec) (buildapi.BuilderRecord, error) {
+func (f *FakeBuilderCreator) CreateBuilder(ctx context.Context, builderKeychain authn.Keychain, stackKeychain authn.Keychain, fetcher cnb.RemoteBuildpackFetcher, clusterStack *buildapi.ClusterStack, spec buildapi.BuilderSpec) (buildapi.BuilderRecord, error) {
 	f.CreateBuilderCalls = append(f.CreateBuilderCalls, CreateBuilderArgs{
-		Context:      ctx,
-		Keychain:     keychain,
-		Fetcher:      fetcher,
-		ClusterStack: clusterStack,
-		BuilderSpec:  builder,
+		Context:         ctx,
+		BuilderKeychain: builderKeychain,
+		StackKeychain:   stackKeychain,
+		Fetcher:         fetcher,
+		ClusterStack:    clusterStack,
+		BuilderSpec:     spec,
 	})
 
 	return f.Record, f.CreateErr


### PR DESCRIPTION
- fallback to builder keychain if there is no service account on the clusterstack to mimic existing behavior