### PR TITLE
Update docs to refer to the Jammy stack

### DIFF
--- a/docs/stack.md
+++ b/docs/stack.md
@@ -16,11 +16,11 @@ kind: ClusterStack
 metadata:
   name: base
 spec:
-  id: "io.buildpacks.stacks.bionic"
+  id: "io.buildpacks.stacks.jammy"
   buildImage:
-    image: "paketobuildpacks/build:base-cnb"
+    image: "paketobuildpacks/build-jammy-base"
   runImage:
-    image: "paketobuildpacks/run:base-cnb"
+    image: "paketobuildpacks/run-jammy-base"
 ```
 
 * `id`:  The 'id' of the stack
@@ -46,4 +46,4 @@ The stack resource will not poll for updates. A CI/CD tool is needed to update t
 
 ### Suggested stacks
 
-The [pack CLI](https://github.com/buildpacks/pack) command: `pack stack suggest` will display a list of recommended stacks that can be used. We recommend starting with the `io.buildpacks.stacks.bionic` base stack.
+The [pack CLI](https://github.com/buildpacks/pack) command: `pack stack suggest` will display a list of recommended stacks that can be used. We recommend starting with the `io.buildpacks.stacks.jammy` base stack.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -96,11 +96,11 @@ This tutorial will walk through creating a kpack [builder](builders.md) resource
     metadata:
       name: base
     spec:
-      id: "io.buildpacks.stacks.bionic"
+      id: "io.buildpacks.stacks.jammy"
       buildImage:
-        image: "paketobuildpacks/build:base-cnb"
+        image: "paketobuildpacks/build-jammy-base"
       runImage:
-        image: "paketobuildpacks/run:base-cnb"
+        image: "paketobuildpacks/run-jammy-base"
     ```
 
     Apply this stack to the cluster 


### PR DESCRIPTION
Updates the Stack and Tutorial docs to refer to the Jammy stack since the Bionic stack is going out of support. I think a lot of folks copy paste from these examples, so this will be helpful in nudging them onto a more supported base OS.

The `pack stack suggest` command was updated in [this commit](https://github.com/buildpacks/pack/commit/efbc2b85f7186748c63a3ceb52bcd544755f0675), but I'm not sure that's been released, so the change I made here in reference to that might be a bit optimistic.