### PR TITLE
Add support for known_hosts file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -356,7 +356,7 @@ jobs:
         password: ${{ env.REGISTRY_PASS }}
 
     - name: Run tests
-      run: |        
+      run: |
         # make the registry container accessible by name from inside the cluster
         docker network connect kind registry.local
 
@@ -365,6 +365,11 @@ jobs:
         export IMAGE_REGISTRY=${{ env.REGISTRY_URL }}
         export IMAGE_REGISTRY_USERNAME=${{ env.REGISTRY_USER }}
         export IMAGE_REGISTRY_PASSWORD=${{ env.REGISTRY_PASS }}
+
+        export GIT_PRIVATE_REPO=${{ env.E2E_PRIVATE_REPO }}
+        export GIT_BASIC_USERNAME=${{ secrets.E2E_PRIVATE_REPO_USERNAME }}
+        export GIT_BASIC_PASSWORD=${{ secrets.E2E_PRIVATE_REPO_PASSWORD }}
+        export GIT_SSH_PRIVATE_KEY=${{ secrets.E2E_PRIVATE_REPO_PRIVATE_KEY }}
 
         make e2e
         kapp delete -a kpack -y
@@ -375,8 +380,8 @@ jobs:
         helm repo update
         kubectl create namespace istio-system
         helm install istio-base istio/base -n istio-system --wait
-        helm install istiod istio/istiod -n istio-system --wait    
-        
+        helm install istiod istio/istiod -n istio-system --wait
+
         cat <<EOF > overlay.yaml
         #@ load("@ytt:overlay", "overlay")
         #@overlay/match by=overlay.subset({"metadata":{"name":"kpack-controller"}, "kind": "Deployment"})
@@ -394,7 +399,7 @@ jobs:
                 - name: INJECTED_SIDECAR_SUPPORT
                   value: "true"
         EOF
-        
+
         ytt -f prerelease.yaml -f overlay.yaml | kapp deploy -a kpack -y -f-
 
         export IMAGE_REGISTRY=${{ env.REGISTRY_URL }}

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ unit-ci:
 	$(GOCMD) test ./pkg/... -coverprofile=coverage.txt -covermode=atomic
 
 e2e:
-	$(GOCMD) test -v ./test/...
+	$(GOCMD) test --timeout=15m -v ./test/...
 
 .PHONY: unit unit-ci e2e

--- a/cmd/build-init/main.go
+++ b/cmd/build-init/main.go
@@ -202,7 +202,7 @@ func fetchSource(logger *log.Logger, keychain authn.Keychain) error {
 	case *gitURL != "":
 		logLoadingSecrets(logger, basicGitCredentials, sshGitCredentials)
 
-		gitKeychain, err := git.NewMountedSecretGitKeychain(buildSecretsDir, basicGitCredentials, sshGitCredentials)
+		gitKeychain, err := git.NewMountedSecretGitKeychain(buildSecretsDir, basicGitCredentials, sshGitCredentials, *sshTrustUnknownHosts)
 		if err != nil {
 			return err
 		}

--- a/cmd/build-init/main.go
+++ b/cmd/build-init/main.go
@@ -52,6 +52,8 @@ var (
 	dockerCfgCredentials    flaghelpers.CredentialsFlags
 	dockerConfigCredentials flaghelpers.CredentialsFlags
 	imagePullSecrets        flaghelpers.CredentialsFlags
+
+	sshTrustUnknownHosts = flag.Bool("insecure-ssh-trust-unknown-hosts", flaghelpers.GetEnvBool("INSECURE_SSH_TRUST_UNKNOWN_HOSTS", true), "Trust unknown hosts when using SSH authentication")
 )
 
 func init() {

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strconv"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -42,6 +41,7 @@ import (
 	"github.com/pivotal/kpack/pkg/config"
 	"github.com/pivotal/kpack/pkg/dockercreds/k8sdockercreds"
 	"github.com/pivotal/kpack/pkg/duckbuilder"
+	"github.com/pivotal/kpack/pkg/flaghelpers"
 	"github.com/pivotal/kpack/pkg/git"
 	"github.com/pivotal/kpack/pkg/reconciler"
 	"github.com/pivotal/kpack/pkg/reconciler/build"
@@ -62,15 +62,6 @@ const (
 	component             = "controller"
 )
 
-func getEnvBool(key string, defaultValue bool) bool {
-	s := os.Getenv(key)
-	v, err := strconv.ParseBool(s)
-	if err != nil {
-		return defaultValue
-	}
-	return v
-}
-
 var (
 	kubeconfig = flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	masterURL  = flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
@@ -80,10 +71,11 @@ var (
 	rebaseImage               = flag.String("rebase-image", os.Getenv("REBASE_IMAGE"), "The image used to perform rebases")
 	completionImage           = flag.String("completion-image", os.Getenv("COMPLETION_IMAGE"), "The image used to finish a build")
 	completionWindowsImage    = flag.String("completion-windows-image", os.Getenv("COMPLETION_WINDOWS_IMAGE"), "The image used to finish a build on windows")
-	enablePriorityClasses     = flag.Bool("enable-priority-classes", getEnvBool("ENABLE_PRIORITY_CLASSES", false), "if set to true, enables different pod priority classes for normal builds and automated builds")
+	enablePriorityClasses     = flag.Bool("enable-priority-classes", flaghelpers.GetEnvBool("ENABLE_PRIORITY_CLASSES", false), "if set to true, enables different pod priority classes for normal builds and automated builds")
 	maximumPlatformApiVersion = flag.String("maximum-platform-api-version", os.Getenv("MAXIMUM_PLATFORM_API_VERSION"), "The maximum allowed platform api version a build can utilize")
 	buildWaiterImage          = flag.String("build-waiter-image", os.Getenv("BUILD_WAITER_IMAGE"), "The image used to initialize a build")
-	injectedSidecarSupport    = flag.Bool("injected-sidecar-support", getEnvBool("INJECTED_SIDECAR_SUPPORT", false), "if set to true, all builds will execute in standard containers instead of init containers to support injected sidecars")
+	injectedSidecarSupport    = flag.Bool("injected-sidecar-support", flaghelpers.GetEnvBool("INJECTED_SIDECAR_SUPPORT", false), "if set to true, all builds will execute in standard containers instead of init containers to support injected sidecars")
+	sshTrustUnknownHosts      = flag.Bool("insecure-ssh-trust-unknown-hosts", flaghelpers.GetEnvBool("INSECURE_SSH_TRUST_UNKNOWN_HOSTS", true), "if set to true, automatically trust unknown hosts when using git ssh source")
 )
 
 func main() {
@@ -179,6 +171,7 @@ func main() {
 		DynamicClient:             dynamicClient,
 		MaximumPlatformApiVersion: maxPlatformApi,
 		InjectedSidecarSupport:    *injectedSidecarSupport,
+		SSHTrustUnknownHost:       *sshTrustUnknownHosts,
 	}
 
 	gitResolver := git.NewResolver(k8sClient)

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -174,7 +174,7 @@ func main() {
 		SSHTrustUnknownHost:       *sshTrustUnknownHosts,
 	}
 
-	gitResolver := git.NewResolver(k8sClient)
+	gitResolver := git.NewResolver(k8sClient, *sshTrustUnknownHosts)
 	blobResolver := &blob.Resolver{}
 	registryResolver := &registry.Resolver{}
 

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -98,6 +98,8 @@ spec:
           value: "false"
         - name: INJECTED_SIDECAR_SUPPORT
           value: "false"
+        - name: INSECURE_SSH_TRUST_UNKNOWN_HOSTS
+          value: "true"
         - name: CONFIG_LOGGING_NAME
           value: config-logging
         - name: CONFIG_OBSERVABILITY_NAME

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -94,6 +94,22 @@ stringData:
   ssh-privatekey: <x509-private-key>
 ```
 
+Host key checking is disabled by default, it can be enabled by setting the `INSECURE_SSH_TRUST_UNKNOWN_HOSTS` environment variable on the controller to `false`.
+
+When host key checking is enabled, you can use the optional `known_hosts` field on the ssh auth secret. If it is not specified, the build will use the `SSH_KNOWN_HOSTS` environment variable before checking `~/.ssh/known_hosts` and `/etc/ssh/ssh_known_hosts`.
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: git-ssh-auth
+  annotations:
+    kpack.io/git: git@github.com
+type: kubernetes.io/ssh-auth
+stringData:
+  known_hosts: <ssh-keyscan output>
+  ssh-privatekey: <x509-private-key>
+```
+
 If your github account has 2 factor auth configured, create a personal access token using [this procedure](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line).
 
 Configure your secret for github like this:

--- a/pkg/apis/build/v1alpha2/build_pod.go
+++ b/pkg/apis/build/v1alpha2/build_pod.go
@@ -117,6 +117,7 @@ type BuildContext struct {
 	ImagePullSecrets          []corev1.LocalObjectReference
 	MaximumPlatformApiVersion *semver.Version
 	InjectedSidecarSupport    bool
+	SSHTrustUnknownHost       bool
 }
 
 func (c BuildContext) os() string {
@@ -461,6 +462,10 @@ func (b *Build) BuildPod(images BuildPodImages, buildContext BuildContext) (*cor
 							corev1.EnvVar{
 								Name:  buildChangesEnvVar,
 								Value: b.BuildChanges(),
+							},
+							corev1.EnvVar{
+								Name:  "INSECURE_SSH_TRUST_UNKNOWN_HOSTS",
+								Value: strconv.FormatBool(buildContext.SSHTrustUnknownHost),
 							},
 						),
 						ImagePullPolicy: corev1.PullIfNotPresent,

--- a/pkg/flaghelpers/credential_flags.go
+++ b/pkg/flaghelpers/credential_flags.go
@@ -1,6 +1,10 @@
 package flaghelpers
 
-import "strings"
+import (
+	"os"
+	"strconv"
+	"strings"
+)
 
 type CredentialsFlags []string
 
@@ -15,4 +19,13 @@ func (i *CredentialsFlags) String() string {
 func (i *CredentialsFlags) Set(value string) error {
 	*i = append(*i, value)
 	return nil
+}
+
+func GetEnvBool(key string, defaultValue bool) bool {
+	s := os.Getenv(key)
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		return defaultValue
+	}
+	return v
 }

--- a/pkg/git/k8s_git_keychain_test.go
+++ b/pkg/git/k8s_git_keychain_test.go
@@ -5,7 +5,9 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
+	"fmt"
 	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
@@ -231,4 +233,12 @@ func generateRandomPrivateKey(t *testing.T) []byte {
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
 	}
 	return pem.EncodeToMemory(pemBlock)
+}
+
+func generateSSHKeyscan(t *testing.T, hostname string, privateKey []byte) []byte {
+	key, err := ssh2.ParsePrivateKey(privateKey)
+	require.NoError(t, err)
+
+	base64EncodedKey := base64.StdEncoding.EncodeToString(key.PublicKey().Marshal())
+	return []byte(fmt.Sprintf("%v %v %v", hostname, key.PublicKey().Type(), base64EncodedKey))
 }

--- a/pkg/git/resolver.go
+++ b/pkg/git/resolver.go
@@ -14,10 +14,10 @@ type Resolver struct {
 	gitKeychain       *k8sGitKeychain
 }
 
-func NewResolver(k8sClient k8sclient.Interface) *Resolver {
+func NewResolver(k8sClient k8sclient.Interface, sshTrustUnknownHosts bool) *Resolver {
 	return &Resolver{
 		remoteGitResolver: remoteGitResolver{},
-		gitKeychain:       newK8sGitKeychain(k8sClient),
+		gitKeychain:       newK8sGitKeychain(k8sClient, sshTrustUnknownHosts),
 	}
 }
 

--- a/pkg/secret/secret_types.go
+++ b/pkg/secret/secret_types.go
@@ -10,6 +10,6 @@ type BasicAuth struct {
 }
 
 type SSH struct {
-	PrivateKey     string
-	KnownHostsFile []string
+	PrivateKey string
+	KnownHosts string
 }

--- a/pkg/secret/secret_types.go
+++ b/pkg/secret/secret_types.go
@@ -1,10 +1,15 @@
 package secret
 
+const (
+	SSHAuthKnownHostsKey = "known_hosts"
+)
+
 type BasicAuth struct {
 	Username string
 	Password string
 }
 
 type SSH struct {
-	PrivateKey string
+	PrivateKey     string
+	KnownHostsFile []string
 }

--- a/pkg/secret/volume_secret_reader.go
+++ b/pkg/secret/volume_secret_reader.go
@@ -36,15 +36,18 @@ func ReadSshSecret(secretVolume, secretName string) (SSH, error) {
 		return SSH{}, err
 	}
 
-	var knownHosts []string = nil
+	var knownHosts []byte = nil
 	knownHostsPath := filepath.Join(secretPath, SSHAuthKnownHostsKey)
 	if _, err := os.Stat(knownHostsPath); !os.IsNotExist(err) {
-		knownHosts = []string{knownHostsPath}
+		knownHosts, err = ioutil.ReadFile(knownHostsPath)
+		if err != nil {
+			return SSH{}, err
+		}
 	}
 
 	return SSH{
-		PrivateKey:     string(privateKey),
-		KnownHostsFile: knownHosts,
+		PrivateKey: string(privateKey),
+		KnownHosts: string(knownHosts),
 	}, nil
 }
 

--- a/pkg/secret/volume_secret_reader.go
+++ b/pkg/secret/volume_secret_reader.go
@@ -3,6 +3,7 @@ package secret
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	corev1 "k8s.io/api/core/v1"
@@ -35,8 +36,15 @@ func ReadSshSecret(secretVolume, secretName string) (SSH, error) {
 		return SSH{}, err
 	}
 
+	var knownHosts []string = nil
+	knownHostsPath := filepath.Join(secretPath, SSHAuthKnownHostsKey)
+	if _, err := os.Stat(knownHostsPath); !os.IsNotExist(err) {
+		knownHosts = []string{knownHostsPath}
+	}
+
 	return SSH{
-		PrivateKey: string(privateKey),
+		PrivateKey:     string(privateKey),
+		KnownHostsFile: knownHosts,
 	}, nil
 }
 

--- a/pkg/secret/volume_secret_reader_test.go
+++ b/pkg/secret/volume_secret_reader_test.go
@@ -44,7 +44,7 @@ func testVolumeSecretReader(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("#readSshSecret", func() {
-		it("returns the private key from the secret", func() {
+		it("returns the private key and known hosts from the secret", func() {
 			testDir, err := ioutil.TempDir("", "secret-volume")
 			require.NoError(t, err)
 
@@ -55,12 +55,14 @@ func testVolumeSecretReader(t *testing.T, when spec.G, it spec.S) {
 			require.NoError(t, os.MkdirAll(path.Join(testDir, "creds"), 0777))
 
 			require.NoError(t, ioutil.WriteFile(path.Join(testDir, "creds", corev1.SSHAuthPrivateKey), []byte("foobar"), 0600))
+			require.NoError(t, ioutil.WriteFile(path.Join(testDir, "creds", secret.SSHAuthKnownHostsKey), []byte("ssh-keyscan"), 0600))
 
 			auth, err := secret.ReadSshSecret(testDir, "creds")
 			require.NoError(t, err)
 
 			assert.Equal(t, auth, secret.SSH{
-				PrivateKey: "foobar",
+				PrivateKey:     "foobar",
+				KnownHostsFile: []string{path.Join(testDir, "creds", "known_hosts")},
 			})
 		})
 	})

--- a/pkg/secret/volume_secret_reader_test.go
+++ b/pkg/secret/volume_secret_reader_test.go
@@ -61,8 +61,8 @@ func testVolumeSecretReader(t *testing.T, when spec.G, it spec.S) {
 			require.NoError(t, err)
 
 			assert.Equal(t, auth, secret.SSH{
-				PrivateKey:     "foobar",
-				KnownHostsFile: []string{path.Join(testDir, "creds", "known_hosts")},
+				PrivateKey: "foobar",
+				KnownHosts: "ssh-keyscan",
 			})
 		})
 	})


### PR DESCRIPTION
fixes #1230 

For more details see the docs change

- Introduce a flag `INSECURE_SSH_TRUST_UNKNOWN_HOSTS` to automatically trust unknown hosts (default value is `true` to keep backwards compatibilty
- If the flag is disabled, a `known_hosts` field can be specified on the ssh auth secret to configure it
- Add e2e tests for authenticated git sources (basic auth + ssh auth)